### PR TITLE
Fix deprecation warning for #has_rdoc

### DIFF
--- a/solidus_i18n.gemspec
+++ b/solidus_i18n.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.has_rdoc = false
-
   s.add_runtime_dependency 'solidus_core', ['>= 1.1', '< 3']
 
   s.add_development_dependency 'pry-rails', '>= 0.3.0'


### PR DESCRIPTION
`NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.`