### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 dist: trusty
 sudo: required
-addons:
-  chrome: stable
 cache: bundler
 language: ruby
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ else
   gem "rails_test_params_backport", group: :test
 end
 
-gem 'chromedriver-helper' if ENV['CI']
-
 gem 'pg', '~> 0.21'
 gem 'sqlite3'
 gem 'mysql2', '~> 0.4.10'


### PR DESCRIPTION
Removing unused `chromedriver-helper` gem fix the build. Aside, is not necessary install chrome in travis too.