### PR TITLE
Add it translations

### DIFF
--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,23 +1,59 @@
+---
 it:
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        cancel: Annulla
+        quantity: Quantità
+        shipment: Spedizione
+        state: Stato
+    errors:
+      models:
+        spree/fulfilment_changer:
+          attributes:
+            current_shipment:
+              can_not_have_backordered_inventory_units: 
+              has_already_been_shipped: 
+            desired_shipment:
+              can_not_transfer_within_same_shipment: 
+              not_enough_stock_at_desired_location: 
   activerecord:
     attributes:
       spree/address:
         address1: Indirizzo
         address2: Indirizzo (agg.)
         city: Città
+        company: Azienda
         country: Nazione
         firstname: Nome
         lastname: Cognome
         phone: Telefono
         state: Provincia
         zipcode: CAP
-        company: Azienda
+      spree/adjustment:
+        adjustable: Variabile
+        adjustment_reason_id: Motivazione
+        amount: Quantità
+        label: Descrizione
+        name: Nome
+        state: Stato
+      spree/adjustment_reason:
+        active: Attivo
+        code: Codice
+        name: Nome
+        state: Stato
+      spree/calculator/flat_rate:
+        preferred_amount: 
       spree/calculator/tiered_flat_rate:
         preferred_base_amount: Importo Base
+        preferred_currency: 
         preferred_tiers: Livelli
       spree/calculator/tiered_percent:
         preferred_base_percent: Percentuale Base
+        preferred_currency: 
         preferred_tiers: Livelli
+      spree/carton:
+        tracking: Tracciamento
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -27,47 +63,66 @@ it:
         states_required: Province o Stati Necessari
       spree/credit_card:
         base: ''
+        card_code: Codice Carta
         cc_type: Tipologia
+        expiration: Scadenza
         month: Mese
         name: Nome
         number: Numero
         verification_value: Codice di Verifica
         year: Anno
-        card_code: Codice Carta
-        expiration: Scadenza
+      spree/customer_return:
+        created_at: 
+        name: Nome
+        number: Numero Reso
+        pre_tax_total: Totale al lordo delle tasse
+        reimbursement_status: Stato Rimborso
+        total: Totale
+        total_excluding_vat: 
+      spree/image:
+        alt: Testo Alternativo
+        attachment: Nome del file
       spree/inventory_unit:
         state: Stato
+      spree/legacy_user:
+        email: Email
+        password: Password
+        password_confirmation: Conferma Password
+        spree_roles: 
       spree/line_item:
-        price: Prezzo
-        quantity: Quantità
         description: Descrizione dell'articolo
         name: Nome
+        price: Prezzo
+        quantity: Quantità
         total: Prezzo totale
       spree/option_type:
         name: Nome
         presentation: Presentazione
+      spree/option_value:
+        name: Nome
+        presentation: Presentazione
       spree/order:
+        additional_tax_total: Tassazione
+        approved_at: Approvato il
+        approver_id: Approvatore
+        canceled_at: Annullato il
+        canceler_id: Annullatore
         checkout_complete: Checkout Completato
         completed_at: Completato il
         considered_risky: A rischio
         coupon_code: Codice Coupon
         created_at: Data Ordine
         email: E-Mail Cliente
+        included_tax_total: Tasse (incl.)
         ip_address: Indirizzo IP
         item_total: Totale Articoli
         number: Numero
         payment_state: Stato Pagamento
         shipment_state: Stato Spedizione
+        shipment_total: Totale Spedizione
         special_instructions: Istruzioni Aggiuntive
         state: Stato
         total: Totale
-        additional_tax_total: Tassazione
-        approved_at: Approvato il
-        approver_id: Approvatore
-        canceled_at: Annullato il
-        canceler_id: Annullatore
-        included_tax_total: Tasse (incl.)
-        shipment_total: Totale Spedizione
       spree/order/bill_address:
         address1: Indirizzo di fatturazione
         city: Città di fatturazione
@@ -86,46 +141,95 @@ it:
         zipcode: CAP indirizzo di spedizione
       spree/payment:
         amount: Quantità
+        created_at: 
+        number: 
         response_code: ID transazione
         state: Stato Pagamento
       spree/payment_method:
-        name: Nome
         active: Attivo
         auto_capture: Riscossione Automatica
         description: Descrizione
         display_on: Mostra
+        name: Nome
+        preference_source: 
         type: Fornitore
+      spree/price:
+        amount: 
+        currency: 
+        is_default: 
       spree/product:
         available_on: Disponibile dal
         cost_currency: Valuta Costo
         cost_price: Prezzo di Costo
-        description: Descrizione
-        master_price: Prezzo
-        name: Nome
-        on_hand: Disponibilità
-        shipping_category: Categoria di Spedizione
-        tax_category: Categoria di Tassazione
         depth: Profondità
+        description: Descrizione
         height: Altezza
+        master_price: Prezzo
         meta_description: Meta Description
         meta_keywords: Meta Keywords
         meta_title: Meta Title
+        name: Nome
+        on_hand: Disponibilità
         price: Prezzo principale
         promotionable: Promuovibile
+        shipping_category: Categoria di Spedizione
         slug: Permalink
+        tax_category: Categoria di Tassazione
         weight: Peso
         width: Larghezza
+      spree/product_property:
+        value: Valore
       spree/promotion:
         advertise: Publicizza
+        apply_automatically: 
         code: Codice
         description: Descrizione
         event_name: Nome Evento
         expires_at: Scade il
         name: Nome
         path: Percorso
+        per_code_usage_limit: 
         promotion_category: Categoria Promozione
+        promotion_uses: 
         starts_at: Inizia il
+        status: 
         usage_limit: Limite di Utilizzo
+      spree/promotion/actions/create_adjustment:
+        description: 
+      spree/promotion/actions/create_item_adjustments:
+        description: 
+      spree/promotion/actions/create_quantity_adjustments:
+        description: 
+      spree/promotion/actions/free_shipping:
+        description: 
+      spree/promotion/rules/first_order:
+        description: 
+      spree/promotion/rules/first_repeat_purchase_since:
+        description: 
+        form_text: 
+      spree/promotion/rules/item_total:
+        description: 
+      spree/promotion/rules/landing_page:
+        description: 
+      spree/promotion/rules/nth_order:
+        description: 
+        form_text: 
+      spree/promotion/rules/one_use_per_user:
+        description: 
+      spree/promotion/rules/option_value:
+        description: 
+      spree/promotion/rules/product:
+        description: 
+      spree/promotion/rules/store:
+        description: 
+      spree/promotion/rules/taxon:
+        description: 
+      spree/promotion/rules/user:
+        description: 
+      spree/promotion/rules/user_logged_in:
+        description: 
+      spree/promotion/rules/user_role:
+        description: 
       spree/promotion_category:
         code: Codice
         name: Nome
@@ -134,11 +238,69 @@ it:
         presentation: Presentazione
       spree/prototype:
         name: Nome
+      spree/refund:
+        amount: Quantità
+        description: Descrizione
+        refund_reason_id: Motivazione
+      spree/refund_reason:
+        active: Attivo
+        code: Codice
+        name: Nome
+      spree/reimbursement:
+        created_at: 
+        number: Numero
+        reimbursement_status: Stato
+        total: Totale
+      spree/reimbursement/credit:
+        amount: Quantità
+      spree/reimbursement_type:
+        created_at: 
+        name: Nome
+        type: Tipo
       spree/return_authorization:
         amount: Quantità
         pre_tax_total: Totale al lordo delle tasse
+        total_excluding_vat: 
+      spree/return_item:
+        acceptance_status: Stato Accettazione
+        acceptance_status_errors: Errori Accettazione
+        amount: 
+        charged: Addebitato
+        exchange_variant: Cambio per
+        inventory_unit_state: Stato
+        item_received?: 
+        override_reimbursement_type_id: Override Tipologia Rimborso
+        preferred_reimbursement_type_id: Tipologia di rimborso preferita
+        reception_status: 
+        resellable: 
+        return_reason: Motivazione
+        total: Totale
+      spree/return_reason:
+        active: Attivo
+        created_at: 
+        memo: Memo
+        name: Nome
+        number: Numero RMA
+        state: Stato
       spree/role:
         name: Nome
+      spree/shipment:
+        tracking: Codice Tracciamento
+      spree/shipping_category:
+        name: Nome
+      spree/shipping_method:
+        admin_name: Nome Interno
+        carrier: 
+        code: Codice
+        display_on: Mostra
+        name: Nome
+        service_level: 
+        tracking_url: URL Tracciamento
+      spree/shipping_rate:
+        amount: Quantità
+        label: 
+        shipping_rate: 
+        tax_rate: Aliquota
       spree/state:
         abbr: Abbreviazione
         name: Nome
@@ -150,38 +312,95 @@ it:
         type: Tipo
         updated: Aggiornato
         user: Utente
+      spree/stock_item:
+        count_on_hand: Disponibilità
+      spree/stock_location:
+        active: Attivo
+        address1: Indirizzo
+        address2: Indirizzo (agg.)
+        admin_name: Nome Interno
+        backorderable_default: Ordinabile di default
+        check_stock_on_transfer: 
+        city: Città
+        code: Codice
+        country_id: Paese
+        default: Default
+        fulfillable: 
+        internal_name: Nome Interno
+        name: Nome
+        phone: Telefono
+        propagate_all_variants: Propaga a tutte le varianti
+        restock_inventory: 
+        state_id: Stato
+        zipcode: Cap
+      spree/stock_movement:
+        action: Azione
+        originated_by: 
+        quantity: Quantità
+        variant: 
+      spree/stock_transfer:
+        created_at: Creato Il
+        description: Descrizione
+        tracking_number: Codice Tracciamento
       spree/store:
+        available_locales: 
+        cart_tax_country_iso: 
+        default: 
+        default_currency: 
         mail_from_address: Indirizzo Mittente Email
         meta_description: Meta Description
         meta_keywords: Meta Keywords
         name: Nome
         seo_title: Titolo SEO
         url: URL Sito
+      spree/store_credit:
+        amount: Quantità
+        amount_authorized: 
+        amount_credited: 
+        amount_used: 
+        category_id: 
+        created_at: 
+        created_by_id: 
+        invalidated_at: 
+        memo: Memo
+      spree/store_credit_event:
+        action: Azione
+        amount_remaining: 
+        user_total_amount: 
+      spree/store_credit_update_reason:
+        name: 
       spree/tax_category:
         description: Descrizione
-        name: Nome
         is_default: Default
+        name: Nome
         tax_code: Codice Tassa
       spree/tax_rate:
         amount: Tasso
+        expires_at: 
         included_in_price: Incluso nel Prezzo
+        name: Nome
         show_rate_in_label: Mostra tasso nell'etichetta
-        name: Nome
+        starts_at: 
       spree/taxon:
-        name: Nome
-        permalink: Permalink
-        position: Posizione
         description: Descrizione
         icon: Icona
         meta_description: Meta Description
         meta_keywords: Meta Keywords
         meta_title: Meta Title
+        name: Nome
+        permalink: Permalink
+        position: Posizione
       spree/taxonomy:
         name: Nome
+      spree/tracker:
+        active: Attivo
+        analytics_id: Analytics ID
       spree/user:
         email: Email
+        lifetime_value: 
         password: Password
         password_confirmation: Conferma Password
+        spree_roles: 
       spree/variant:
         cost_currency: Valuta Costo
         cost_price: Prezzo di Costo
@@ -189,137 +408,33 @@ it:
         height: Altezza
         price: Prezzo
         sku: SKU
+        tax_category: 
         weight: Peso
         width: Larghezza
       spree/zone:
-        description: Descrizione
-        name: Nome
         default_tax: Zona di Tassazione di Default
-      spree/adjustment:
-        adjustable: Variabile
-        amount: Quantità
-        label: Descrizione
-        name: Nome
-        state: Stato
-        adjustment_reason_id: Motivazione
-      spree/adjustment_reason:
-        active: Attivo
-        code: Codice
-        name: Nome
-        state: Stato
-      spree/carton:
-        tracking: Tracciamento
-      spree/customer_return:
-        number: Numero Reso
-        pre_tax_total: Totale al lordo delle tasse
-        total: Totale
-        reimbursement_status: Stato Rimborso
-        name: Nome
-      spree/image:
-        alt: Testo Alternativo
-        attachment: Nome del file
-      spree/legacy_user:
-        email: Email
-        password: Password
-        password_confirmation: Conferma Password
-      spree/option_value:
-        name: Nome
-        presentation: Presentazione
-      spree/product_property:
-        value: Valore
-      spree/refund:
-        amount: Quantità
         description: Descrizione
-        refund_reason_id: Motivazione
-      spree/refund_reason:
-        active: Attivo
         name: Nome
-        code: Codice
-      spree/reimbursement:
-        number: Numero
-        reimbursement_status: Stato
-        total: Totale
-      spree/reimbursement/credit:
-        amount: Quantità
-      spree/reimbursement_type:
-        name: Nome
-        type: Tipo
-      spree/return_item:
-        acceptance_status: Stato Accettazione
-        acceptance_status_errors: Errori Accettazione
-        charged: Addebitato
-        exchange_variant: Cambio per
-        inventory_unit_state: Stato
-        override_reimbursement_type_id: Override Tipologia Rimborso
-        preferred_reimbursement_type_id: Tipologia di rimborso preferita
-        reception_status:
-        return_reason: Motivazione
-        total: Totale
-      spree/return_reason:
-        name: Nome
-        active: Attivo
-        memo: Memo
-        number: Numero RMA
-        state: Stato
-      spree/shipping_category:
-        name: Nome
-      spree/shipment:
-        tracking: Codice Tracciamento
-      spree/shipping_method:
-        admin_name: Nome Interno
-        code: Codice
-        display_on: Mostra
-        name: Nome
-        tracking_url: URL Tracciamento
-      spree/shipping_rate:
-        tax_rate: Aliquota
-        amount: Quantità
-      spree/store_credit:
-        amount: Quantità
-        memo: Memo
-      spree/store_credit_event:
-        action: Azione
-      spree/stock_item:
-        count_on_hand: Disponibilità
-      spree/stock_location:
-        admin_name: Nome Interno
-        active: Attivo
-        address1: Indirizzo
-        address2: Indirizzo (agg.)
-        backorderable_default: Ordinabile di default
-        city: Città
-        code: Codice
-        country_id: Paese
-        default: Default
-        internal_name: Nome Interno
-        name: Nome
-        phone: Telefono
-        propagate_all_variants: Propaga a tutte le varianti
-        state_id: Stato
-        zipcode: Cap
-      spree/stock_movement:
-        action: Azione
-        quantity: Quantità
-      spree/stock_transfer:
-        created_at: Creato Il
-        description: Descrizione
-        tracking_number: Codice Tracciamento
-      spree/tracker:
-        analytics_id: Analytics ID
-        active: Attivo
     errors:
       models:
+        spree/address:
+          attributes:
+            state:
+              does_not_match_country: 
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: Le chiavi dei livelli devono tutti essere numeri maggiori di 0
+              keys_should_be_positive_number: Le chiavi dei livelli devono tutti essere
+                numeri maggiori di 0
             preferred_tiers:
               should_be_hash: deve essere un Hash
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: Le chiavi dei livelli devono tutti essere numeri maggiori di 0
-              values_should_be_percent: I valori dei livelli devono tutti essere percentuali tra 0% e 100%
+              keys_should_be_positive_number: Le chiavi dei livelli devono tutti essere
+                numeri maggiori di 0
+              values_should_be_percent: I valori dei livelli devono tutti essere percentuali
+                tra 0% e 100%
             preferred_tiers:
               should_be_hash: deve essere un Hash
         spree/classification:
@@ -331,10 +446,27 @@ it:
             base:
               card_expired: La Carta è scaduta
               expiry_invalid: La scadenza della Carta non è valida
+        spree/inventory_unit:
+          attributes:
+            base:
+              cannot_destroy_shipment_state: 
+            state:
+              cannot_destroy: 
         spree/line_item:
           attributes:
             currency:
               must_match_order_currency: Deve corrispondere alla Valuta dell'Ordine
+            price:
+              not_a_number: 
+        spree/price:
+          attributes:
+            currency:
+              invalid_code: 
+        spree/promotion:
+          attributes:
+            apply_automatically:
+              disallowed_with_code: 
+              disallowed_with_path: 
         spree/refund:
           attributes:
             amount:
@@ -342,21 +474,99 @@ it:
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match: Uno o più degli articoli resi specificate non appartengono allo stesso ordine del rimborso.
+              return_items_order_id_does_not_match: Uno o più degli articoli resi
+                specificate non appartengono allo stesso ordine del rimborso.
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists: "%{inventory_unit_id} è già stato preso dall'articolo reso %{return_item_id}"
+              other_completed_return_item_exists: "%{inventory_unit_id} è già stato
+                preso dall'articolo reso %{return_item_id}"
             reimbursement:
-              cannot_be_associated_unless_accepted: non può essere associato a un articolo reso che non è accettato.
+              cannot_be_associated_unless_accepted: non può essere associato a un
+                articolo reso che non è accettato.
+        spree/shipment:
+          attributes:
+            base:
+              cannot_remove_items_shipment_state: 
+            state:
+              cannot_destroy: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store: Non è possibile eliminare lo Store di default.
+              cannot_destroy_default_store: Non è possibile eliminare lo Store di
+                default.
+        spree/user_address:
+          attributes:
+            user_id:
+              default_address_exists: 
+        spree/wallet_payment_source:
+          attributes:
+            payment_source:
+              has_to_be_payment_source_class: 
     models:
       spree/address:
         one: Indirizzo
         other: Indirizzi
+      spree/adjustment:
+        one: 
+        other: 
+      spree/adjustment_reason:
+        one: 
+        other: 
+      spree/calculator:
+        one: 
+        other: 
+      spree/calculator/default_tax:
+        one: 
+        other: 
+      spree/calculator/distributed_amount:
+        one: 
+        other: 
+      spree/calculator/flat_percent_item_total:
+        one: 
+        other: 
+      spree/calculator/flat_rate:
+        one: 
+        other: 
+      spree/calculator/flexi_rate:
+        one: 
+        other: 
+      spree/calculator/free_shipping:
+        one: 
+        other: 
+      spree/calculator/percent_on_line_item:
+        one: 
+        other: 
+      spree/calculator/percent_per_item:
+        one: 
+        other: 
+      spree/calculator/price_sack:
+        one: 
+        other: 
+      spree/calculator/returns/default_refund_amount:
+        one: 
+        other: 
+      spree/calculator/shipping/flat_percent_item_total:
+        one: 
+        other: 
+      spree/calculator/shipping/flat_rate:
+        one: 
+        other: 
+      spree/calculator/shipping/flexi_rate:
+        one: 
+        other: 
+      spree/calculator/shipping/per_item:
+        one: 
+        other: 
+      spree/calculator/shipping/price_sack:
+        one: 
+        other: 
+      spree/calculator/tiered_flat_rate:
+        one: 
+        other: 
+      spree/calculator/tiered_percent:
+        one: 
+        other: 
       spree/country:
         one: Nazione
         other: Nazioni
@@ -366,12 +576,24 @@ it:
       spree/customer_return:
         one: Reso Cliente
         other: Resi Cliente
+      spree/exchange:
+        one: 
+        other: 
+      spree/image:
+        one: 
+        other: 
       spree/inventory_unit:
         one: Unità di Inventario
         other: Unità di Inventario
+      spree/legacy_user:
+        one: 
+        other: 
       spree/line_item:
         one: Riga d'Ordine
         other: Righe d'Ordine
+      spree/log_entry:
+        one: 
+        other: 
       spree/option_type:
         one: Opzione
         other: Opzioni
@@ -384,24 +606,62 @@ it:
       spree/payment:
         one: Pagamento
         other: Pagamenti
+      spree/payment_capture_event:
+        one: 
+        other: 
       spree/payment_method:
         one: Metodo di Pagamento
         other: Metodi di Pagamento
+      spree/payment_method/bogus_credit_card: 
+      spree/payment_method/check: 
+      spree/payment_method/simple_bogus_credit_card: 
+      spree/payment_method/store_credit: 
+      spree/price:
+        one: 
+        other: 
       spree/product:
         one: Prodotto
         other: Prodotti
+      spree/product_property:
+        one: 
+        other: 
       spree/promotion:
         one: Promozione
         other: Promozioni
+      spree/promotion/actions/create_adjustment: 
+      spree/promotion/actions/create_item_adjustments: 
+      spree/promotion/actions/create_quantity_adjustments: 
+      spree/promotion/actions/free_shipping: 
+      spree/promotion/rules/first_order: 
+      spree/promotion/rules/first_repeat_purchase_since: 
+      spree/promotion/rules/item_total: 
+      spree/promotion/rules/landing_page: 
+      spree/promotion/rules/nth_order: 
+      spree/promotion/rules/one_use_per_user: 
+      spree/promotion/rules/option_value: 
+      spree/promotion/rules/product: 
+      spree/promotion/rules/taxon: 
+      spree/promotion/rules/user: 
+      spree/promotion/rules/user_logged_in: 
+      spree/promotion/rules/user_role: 
       spree/promotion_category:
         one: Categoria Promozione
         other: Categorie Promozione
+      spree/promotion_code:
+        one: 
+        other: 
+      spree/promotion_code_batch:
+        one: 
+        other: 
       spree/property:
         one: Proprietà
         other: Proprietà
       spree/prototype:
         one: Prototipo
         other: Prototipi
+      spree/refund:
+        one: 
+        other: 
       spree/refund_reason:
         one: Motivazione Rimborso
         other: Motivazioni Rimborso
@@ -417,6 +677,9 @@ it:
       spree/return_authorization_reason:
         one: Motivazione Autorizzazione Restituzione
         other: Motivazioni Autorizzazione Restituzione
+      spree/return_reason:
+        one: 
+        other: 
       spree/role:
         one: Ruolo
         other: Ruoli
@@ -435,6 +698,10 @@ it:
       spree/state_change:
         one: Cambio di Stato
         other: Cambi di Stato
+      spree/stock: 
+      spree/stock_item:
+        one: 
+        other: 
       spree/stock_location:
         one: Magazzino
         other: Magazzini
@@ -444,6 +711,15 @@ it:
       spree/stock_transfer:
         one: Trasferimento di Magazzino
         other: Trasferimenti di Magazzino
+      spree/store:
+        one: 
+        other: 
+      spree/store_credit:
+        one: 
+        other: 
+      spree/store_credit_category:
+        one: 
+        other: 
       spree/tax_category:
         one: Categoria di Tassazione
         other: Categorie di Tassazione
@@ -468,31 +744,55 @@ it:
       spree/zone:
         one: Zona
         other: Zone
-  activemodel:
-    attributes:
-      spree/adjustment:
-        one: Variazione
-        other: Variazioni
-      spree/calculator:
-        one: Calcolatore
-      spree/legacy_user:
-        one: Utente
-        other: Utenti
-      spree/log_entry:
-        other: Voci Log
-      spree/order_cancellations:
-        quantity: Quantità
-        state: Stato
-        shipment: Spedizione
-        cancel: Annulla
-      spree/product_property:
-        other: Proprietà del prodotto
-      spree/refund:
-        one: Rimborso
-        other: Rimborsi
-      spree/store_credit_category:
-        one: Categoria
-        other: Categorie
+      user:
+        one: 
+        other: 
+  devise:
+    confirmations:
+      confirmed: 
+      send_instructions: 
+    failure:
+      inactive: 
+      invalid: 
+      invalid_token: 
+      locked: 
+      timeout: 
+      unauthenticated: 
+      unconfirmed: 
+    mailer:
+      confirmation_instructions:
+        subject: 
+      reset_password_instructions:
+        subject: 
+      unlock_instructions:
+        subject: 
+    oauth_callbacks:
+      failure: 
+      success: 
+    unlocks:
+      send_instructions: 
+      unlocked: 
+    user_passwords:
+      user:
+        cannot_be_blank: 
+        send_instructions: 
+        updated: 
+    user_registrations:
+      destroyed: 
+      inactive_signed_up: 
+      signed_up: 
+      updated: 
+    user_sessions:
+      signed_in: 
+      signed_out: 
+  errors:
+    messages:
+      already_confirmed: 
+      not_found: 
+      not_locked: 
+      not_saved:
+        one: 
+        other: 
   spree:
     abbreviation: Abbreviazione
     accept: Accetta
@@ -503,28 +803,30 @@ it:
     account_updated: Account aggiornato
     action: Azione
     actions:
+      add: Aggiungi
       cancel: Annulla
       continue: Continua
       create: Crea
+      delete: Elimina
       destroy: Elimina
       edit: Modifica
       list: Lista
       listing: Lista
       new: Nuovo
+      receive: 
       refund: Rimborso
-      save: Salva
-      update: Aggiorna
-      add: Aggiungi
-      delete: Elimina
       remove: Rimuovi
+      save: Salva
       ship: spedisci
       split: Diviso
+      update: Aggiorna
     activate: Attiva
     active: Attivo
     add: Aggiungi
     add_action_of_type: Aggiungi tipologia azione
     add_country: Aggiungi Paese
     add_coupon_code: Aggiungi Codice Coupon
+    add_line_item: 
     add_new_header: Aggiungi Nuovo Header
     add_new_style: Aggiungi Nuovo Stile
     add_one: Aggiungine Uno
@@ -537,7 +839,11 @@ it:
     add_stock_management: Gestione Scorte
     add_taxon: Aggiungi elemento
     add_to_cart: Aggiungi al Carrello
+    add_to_stock_location: 
     add_variant: Aggiungi Variante
+    add_variant_properties: 
+    added: 
+    adding_match: 
     additional_item: Costo Aggiuntivo Articolo
     address1: Indirizzo
     address2: Indirizzo (cont.)
@@ -545,25 +851,119 @@ it:
     adjustment: Variazione
     adjustment_amount: Importo
     adjustment_labels:
+      line_item: 
+      order: 
       tax_rates:
+        sales_tax: 
         sales_tax_with_rate: tasse
+        vat: 
         vat_with_rate: di cui tasse
+    adjustment_reasons: 
     adjustment_successfully_closed: La variazione è stata chiusa correttamente
     adjustment_successfully_opened: La variazione è stata aperta correttamente
     adjustment_total: Totale Variazione
+    adjustment_type: 
     adjustments: Variazioni
     admin:
+      images:
+        index:
+          choose_files: 
+          drag_and_drop: 
+          image_process_failed: 
+          upload_images: 
+      payments:
+        source_forms:
+          storecredit:
+            not_supported: 
+      prices:
+        any_country: Tutte le nazioni
+        edit:
+          edit_price: 
+        index:
+          amount_greater_than: Quantità maggiore di
+          amount_less_than: Quantità minore di
+          new_price: Nuovo prezzo
+        new:
+          new_price: 
+      promotions:
+        actions:
+          calculator_label: 
+        activations_edit:
+          auto: 
+          multiple_codes_html: 
+          single_code_html: 
+        activations_new:
+          auto: 
+          multiple_codes: 
+          single_code: 
+        form:
+          activation: 
+          expires_at_placeholder: 
+          general: 
+          starts_at_placeholder: 
+      stock_locations:
+        form:
+          address: 
+          general: 
+          settings: 
+      store_credits:
+        add: Nuovo credito
+        amount_authorized: 
+        amount_credited: 
+        amount_used: 
+        back_to_edit: 
+        back_to_store_credit_list: 
+        back_to_user_list: Lista utenti
+        change_amount: 
+        created_at: 
+        created_by: 
+        credit_type: 
+        current_balance: 
+        edit: 
+        edit_amount: 
+        errors:
+          amount_authorized_exceeds_total_credit: 
+          amount_used_cannot_be_greater: 
+          amount_used_not_zero: 
+          cannot_be_modified: 
+          cannot_change_used_store_credit: 
+          update_reason_required: 
+        history: 
+        invalidate_store_credit: 
+        invalidated: 
+        issued_on: 
+        memo: 
+        new: 
+        no_store_credit_selected: 
+        payment_originator: 
+        reason_for_updating: 
+        refund_originator: 
+        resource_name: 
+        select_amount_update_reason: 
+        select_reason: Motivo
+        total_unused: 
+        type_html_header: 
+        unable_to_create: 
+        unable_to_delete: 
+        unable_to_invalidate: 
+        unable_to_update: 
+        user_originator: 
+        view: 
+      stores:
+        form:
+          no_cart_tax_country: 
       tab:
         areas: Zone
         checkout: Checkout
         configuration: Impostazioni
+        display_order: 
         general: Generale
         option_types: Opzioni
         orders: Ordini
         overview: Quadro generale
         payments: Pagamenti
         products: Prodotti
-        promotion_categories:
+        promotion_categories: 
         promotions: Promozioni
         properties: Proprietà
         prototypes: Prototipi
@@ -574,16 +974,14 @@ it:
         stock: Stock
         stock_items: Magazzino
         stock_transfers: Trasferimento di magazzino
+        stores: 
         taxes: Tasse
         taxonomies: Tassonomie
         taxons: Taxon
         users: Utenti
-        checkout: Checkout
-        general: Generale
-        payments: Pagamenti
-        settings: Impostazioni
-        shipping: Spedizione
-        stock: Stock
+        zones: 
+      taxons:
+        display_order: 
       user:
         account: Account
         addresses: Indirizzi
@@ -592,18 +990,32 @@ it:
         order_history: Storia Ordini
         order_num: 'Ordine #'
         orders: Ordini
-        user_information: Informazioni Utente
         store_credit: Credito
-      prices:
-        any_country: Tutte le nazioni
-        index:
-          amount_less_than: Quantità minore di
-          amount_greater_than: Quantità maggiore di
-          new_price: Nuovo prezzo
-      store_credits:
-        add: Nuovo credito
-        back_to_user_list: Lista utenti
-        select_reason: Motivo
+        user_information: Informazioni Utente
+      users:
+        edit:
+          api_access: 
+          clear_key: 
+          confirm_clear_key: 
+          confirm_regenerate_key: 
+          generate_key: 
+          key: 
+          no_key: 
+          regenerate_key: 
+        user_page_actions:
+          create_order: 
+      variants:
+        edit:
+          edit_variant: 
+        form:
+          dimensions: 
+          pricing: 
+          pricing_hint: 
+          use_product_tax_category: 
+        new:
+          new_variant: 
+        table_filter:
+          show_deleted: 
     admin_login: Login
     administration: Amministrazione
     advertise: Promuovi
@@ -611,10 +1023,13 @@ it:
     agree_to_terms_of_service: Accetta i Termini di Servizio
     all: Tutto
     all_adjustments_closed: Tutte le variazioni chiuse correttamente!
+    all_adjustments_finalized: 
     all_adjustments_opened: Tutte le variazioni aperte correttamente!
+    all_adjustments_unfinalized: 
     all_departments: Tutti i dipartimenti
     all_items_have_been_returned: Tutti gli Articoli sono stati restituiti
-    allow_ssl_in_development_and_test: Consenti l'utilizzo di SSL in modalità development e test
+    allow_ssl_in_development_and_test: Consenti l'utilizzo di SSL in modalità development
+      e test
     allow_ssl_in_production: Consenti l'utilizzo di SSL in modalità production
     allow_ssl_in_staging: Consenti l'utilizzo di SSL in modalità staging
     already_signed_up_for_analytics: Sei già registrato per Spree Analytics
@@ -622,7 +1037,8 @@ it:
     alternative_phone: Telefono Alternativo
     amount: Quantità
     analytics_desc_header_1: Spree Analytics
-    analytics_desc_header_2: Analytics in tempo reale integrato nella tua dashboard di Spree
+    analytics_desc_header_2: Analytics in tempo reale integrato nella tua dashboard
+      di Spree
     analytics_desc_list_1: Ottieni informazioni sulle vendite in tempo reale
     analytics_desc_list_2: È richiesto un account gratuito Spree per l'attivazione
     analytics_desc_list_3: Assolutamente nessun codice da installare
@@ -631,43 +1047,62 @@ it:
     and: e
     api:
       access: Accesso
-      key: Chiave
-      no_key: Nessuna Chiave
       clear_key: Elimina Chiave
       generate_key: Genera Chiave
+      key: Chiave
+      no_key: Nessuna Chiave
       regenerate_key: Genera nuova Chiave
+    apply_code: 
     approve: approva
     approved_at: Approvato il
     approver: Approvatore
     are_you_sure: Sei sicuro?
     are_you_sure_delete: Sei sicuro di voler eliminare questo record?
-    associated_adjustment_closed: La variazione associata è chiusa e non verrà ricalcolata. Vuoi riaprirla?
+    associated_adjustment_closed: La variazione associata è chiusa e non verrà ricalcolata.
+      Vuoi riaprirla?
     at_symbol: "@"
     authorization_failure: Autorizzazione Fallita
     authorized: Autorizzato
     auto_capture: Riscossione Automatica
+    auto_receive: 
     available_on: Disponibile dal
     average_order_value: Valore medio Ordine
     avs_response: Risposta AVS
     back: Indietro
     back_end: Backend
     back_to_adjustment_reason_list: Lista motivi di modifica
+    back_to_adjustments_list: 
     back_to_countries_list: Lista nazioni
+    back_to_customer_return: 
+    back_to_customer_return_list: 
+    back_to_images_list: 
+    back_to_option_types_list: 
     back_to_orders_list: Lista ordini
     back_to_payment: Torna al Pagamento
+    back_to_payment_methods_list: 
+    back_to_payments_list: 
     back_to_products_list: Lista prodotti
+    back_to_promotion_categories_list: 
+    back_to_promotions_list: 
+    back_to_properties_list: 
+    back_to_refund_reason_list: 
+    back_to_reimbursement_type_list: 
     back_to_reports_list: Lista reports
-    back_to_resource_list: "Torna alla Lista %{resource}"
+    back_to_resource_list: Torna alla Lista %{resource}
+    back_to_return_authorizations_list: 
     back_to_rma_reason_list: Torna alla Lista Motivazioni RMA
     back_to_shipping_categories: Lista categorie di spedizione
+    back_to_shipping_categories_list: 
     back_to_shipping_methods_list: Lista metodi di spedizione
     back_to_states_list: Lista stati
     back_to_stock_locations_list: Lista aliquote
+    back_to_stock_movements_list: 
     back_to_stock_transfers_list: Lista trasferimenti di magazzino
     back_to_store: Torna al Negozio
     back_to_tax_categories_list: Lista categorie di tassazione
     back_to_tax_rates_list: Lista aliquote
     back_to_taxonomies_list: Lista tassonomie
+    back_to_trackers_list: 
     back_to_users_list: Torna alla Lista degli Utenti
     back_to_zones_list: Lista zone
     backorderable: Ordinabile anche se terminato
@@ -684,18 +1119,27 @@ it:
     both: Entrambi
     calculated_reimbursements: Rimborsi Calcolati
     calculator: Calcolatore
-    calculator_settings_warning: Se stai cambiando la tipologia di calcolatore, devi prima salvare per modificare le impostazioni del calcolatore
+    calculator_settings_warning: Se stai cambiando la tipologia di calcolatore, devi
+      prima salvare per modificare le impostazioni del calcolatore
     cancel: annulla
     cancel_inventory: Annulla movimento
     canceled: annullato
     canceled_at: Annullato il
     canceler: Annullatore
+    cancellation: 
     cannot_create_customer_returns: Impossibile Create Resi Cliente
     cannot_create_payment_link: Per favore definisci prima dei metodi di pagamento.
-    cannot_create_payment_without_payment_methods: Non puoi creare un pagamento per l'ordine senza alcun metodo di pagamento specificato.
-    cannot_create_returns: Impossibile creare un reso perché questo ordine non ha unità spedite.
+    cannot_create_payment_without_payment_methods: Non puoi creare un pagamento per
+      l'ordine senza alcun metodo di pagamento specificato.
+    cannot_create_payment_without_payment_methods_html: 
+    cannot_create_returns: Impossibile creare un reso perché questo ordine non ha
+      unità spedite.
     cannot_perform_operation: Impossible effettuare l'operazione richiesta
-    cannot_set_shipping_method_without_address: Impossibile impostare un metodo di spedizione finché i dettagli del cliente non vengono specificati.
+    cannot_rebuild_shipments_order_completed: 
+    cannot_rebuild_shipments_shipments_not_pending: 
+    cannot_set_shipping_method_without_address: Impossibile impostare un metodo di
+      spedizione finché i dettagli del cliente non vengono specificati.
+    cannot_update_email: 
     capture: Riscuoti
     capture_events: Eventi di riscossione
     card_code: Codice Carta
@@ -706,39 +1150,54 @@ it:
     cart_subtotal:
       one: Subtotale (1 articolo)
       other: Subtotale (%{count} articoli)
+    carton_external_number: 
+    carton_orders: 
     categories: Categorie
     category: Categoria
+    character_limit: 
     charged: Addebitato
+    check: 
     check_for_spree_alerts: Visualizza le segnalazioni di Spree
+    check_stock_on_transfer: 
     checkout: Checkout
     choose_a_customer: Scegli un cliente
     choose_a_taxon_to_sort_products_for: Scegli un taxon con cui ordinare i prodotti
     choose_currency: Scegli una Valuta
     choose_dashboard_locale: Scegli una Lingua per la Dashboard
     choose_location: Scegli Località
+    choose_promotion_action: 
+    choose_promotion_rule: 
+    choose_reason: 
     city: Città
     clear_cache: Pulisci la Cache
     clear_cache_ok: La Cache è stato pulita
-    clear_cache_warning: Pulire la Cache ridurrà temporaneamente le performance del Sito.
-    click_and_drag_on_the_products_to_sort_them: Clicca e trascina i prodotti per ordinarli.
+    clear_cache_warning: Pulire la Cache ridurrà temporaneamente le performance del
+      Sito.
+    click_and_drag_on_the_products_to_sort_them: Clicca e trascina i prodotti per
+      ordinarli.
     clone: Clona
     close: Chiudi
     close_all_adjustments: Chiudi Tutte le Variazioni
+    closed: 
     code: Codice
     company: Azienda
     complete: completo
+    complete_order: 
     configuration: Impostazione
     configurations: Impostazioni
     confirm: Conferma
     confirm_delete: Conferma Eliminazione
+    confirm_order: 
     confirm_password: Conferma Password
     continue: Continua
     continue_shopping: Continua gli acquisti
     cost_currency: Valuta Costo
     cost_price: Prezzo di Costo
-    could_not_connect_to_jirafe: Impossibile connettersi a Jirafe per aggiornare i dati. L'aggiornamento verrà riprovato automaticamente più tardi.
+    could_not_connect_to_jirafe: Impossibile connettersi a Jirafe per aggiornare i
+      dati. L'aggiornamento verrà riprovato automaticamente più tardi.
     could_not_create_customer_return: Impossibile creare Reso Cliente
-    could_not_create_stock_movement: Si è verificato un problema nel salvare il movimento di magazzino. Per favore prova di nuovo.
+    could_not_create_stock_movement: Si è verificato un problema nel salvare il movimento
+      di magazzino. Per favore prova di nuovo.
     count_on_hand: Disponibilità
     countries: Paesi
     country: Paese
@@ -753,19 +1212,25 @@ it:
     coupon_code: Codice coupon
     coupon_code_already_applied: Il codice coupon è stato già applicato a quest'ordine
     coupon_code_applied: Il codice coupon è stato applicato al tuo ordine con successo.
-    coupon_code_better_exists: Il coupon applicato in precedenza garantisce un'offerta migliore
+    coupon_code_better_exists: Il coupon applicato in precedenza garantisce un'offerta
+      migliore
     coupon_code_expired: Il codice coupon è scaduto
     coupon_code_max_usage: Limite di utilizzo codice coupon superato
     coupon_code_not_eligible: Questo codice coupon non è applicabile a quest'ordine
-    coupon_code_not_found: Il codice coupon inserito non esiste. Per favore prova ancora.
+    coupon_code_not_found: Il codice coupon inserito non esiste. Per favore prova
+      ancora.
     coupon_code_unknown_error: Questo codice coupon non può essere applicabile a quest'ordine
     create: Crea
     create_a_new_account: Crea un nuovo account
     create_new_order: Crea Nuovo Ordine
     create_one: Creane una
+    create_promotion_code: 
     create_reimbursement: Crea Rimborso
     created_at: Creato Il
+    created_by: 
+    created_successfully: 
     credit: Credito
+    credit_allowed: 
     credit_card: Carta di Credito
     credit_cards: Carte di Credito
     credit_owed: Credito Dovuto
@@ -789,8 +1254,10 @@ it:
       jirafe:
         app_id: App ID
         app_token: App Token
-        currently_unavailable: Jirafe non è disponibile al momento. Spree si connetterà automaticamente a Jirafe una volta disponibile.
-        explanation: I campi sottostanti potrebbero essere popolati se avessi scelto di usare Jirafe dalla dashboard di amministrazione.
+        currently_unavailable: Jirafe non è disponibile al momento. Spree si connetterà
+          automaticamente a Jirafe una volta disponibile.
+        explanation: I campi sottostanti potrebbero essere popolati se avessi scelto
+          di usare Jirafe dalla dashboard di amministrazione.
         header: Impostazioni Jirafe Analytics
         site_id: ID Sito
         token: Token
@@ -808,45 +1275,77 @@ it:
     default_tax_zone: Zona di Tassazione di Default
     delete: Elimina
     delete_from_taxon: Rimuovi dalla Taxon
-    deleted_variants_present: Alcune linee di questo ordine hanno prodotti che non sono più disponibili.
+    deleted_successfully: 
+    deleted_variants_present: Alcune linee di questo ordine hanno prodotti che non
+      sono più disponibili.
     delivery: Consegna
     depth: Profondità
     description: Descrizione
     destination: Destinazione
+    destination_location: 
     destroy: Elimina
     details: Dettagli
     discount_amount: Importo dello sconto
+    discount_rules: 
     dismiss_banner: No, grazie! Non sono interessato, non mostrare più questo messaggio
     display: Mostra
     display_currency: Mostra valuta
     doesnt_track_inventory: Non tiene traccia dell'inventario
+    download_promotion_codes_list: 
     edit: Modifica
+    edit_refund_reason: 
+    editing_adjustment_reason: 
     editing_country: Modifica nazione
-    editing_resource: 'Modifica %{resource}'
+    editing_option_type: 
+    editing_payment_method: 
+    editing_product: 
+    editing_promotion: 
+    editing_promotion_category: 
+    editing_property: 
+    editing_refund: 
+    editing_refund_reason: 
+    editing_reimbursement: 
+    editing_reimbursement_type: 
+    editing_resource: Modifica %{resource}
     editing_rma_reason: Modifica Motivazione RMA
-    editing_shipping_method: Modifica metodo di spedizione
     editing_shipping_category: Modifica categoria di spedizione
+    editing_shipping_method: Modifica metodo di spedizione
     editing_state: Modifica stati
     editing_stock_location: Modifica magazzino
+    editing_stock_movement: 
     editing_tax_category: Modifica catgoria di tassazione
     editing_tax_rate: Modifica aliquota
+    editing_tracker: 
     editing_user: Modifica Utente
     editing_zone: Modifica zona
     eligibility_errors:
       messages:
-        has_excluded_product: Il carrello contiene un prodotto che non permette l'applicazione di questo codice coupon.
-        item_total_less_than: Questo codice coupon non può essere applicato a ordini di importo inferiore a %{amount}.
-        item_total_less_than_or_equal: Questo codice coupon non può essere applicato a ordini di importo inferiore o uguale a %{amount}.
-        item_total_more_than: Questo codice coupon non può essere applicato a ordini di importo maggiore di %{amount}.
-        item_total_more_than_or_equal: Questo codice coupon non può essere applicato a ordini di importo maggiore o uguale di %{amount}.
-        limit_once_per_user: Questo codice coupon può essere usato solamente una volta per utente.
-        missing_product: Questo codice coupon non può essere applicato poiché non hai nel carrello tutti i prodotti necessari.
-        missing_taxon: Devi aggiungere un prodotto da tutte le categorie appropriate prima di applicare questo codice coupon.
-        no_applicable_products: Devi aggiungere un prodotto appropriato prima di applicare questo codice coupon.
-        no_matching_taxons: Devi aggiungere un prodotto da una categorie appropriata prima di applicare questo codice coupon.
-        no_user_or_email_specified: Devi fare il login o fornire una email prima di applicare questo codice coupon.
+        has_excluded_product: Il carrello contiene un prodotto che non permette l'applicazione
+          di questo codice coupon.
+        has_excluded_taxon: 
+        item_total_less_than: Questo codice coupon non può essere applicato a ordini
+          di importo inferiore a %{amount}.
+        item_total_less_than_or_equal: Questo codice coupon non può essere applicato
+          a ordini di importo inferiore o uguale a %{amount}.
+        item_total_more_than: Questo codice coupon non può essere applicato a ordini
+          di importo maggiore di %{amount}.
+        item_total_more_than_or_equal: Questo codice coupon non può essere applicato
+          a ordini di importo maggiore o uguale di %{amount}.
+        limit_once_per_user: Questo codice coupon può essere usato solamente una volta
+          per utente.
+        missing_product: Questo codice coupon non può essere applicato poiché non
+          hai nel carrello tutti i prodotti necessari.
+        missing_taxon: Devi aggiungere un prodotto da tutte le categorie appropriate
+          prima di applicare questo codice coupon.
+        no_applicable_products: Devi aggiungere un prodotto appropriato prima di applicare
+          questo codice coupon.
+        no_matching_taxons: Devi aggiungere un prodotto da una categorie appropriata
+          prima di applicare questo codice coupon.
+        no_user_or_email_specified: Devi fare il login o fornire una email prima di
+          applicare questo codice coupon.
         no_user_specified: Devi fare il login prima di applicare questo codice coupon.
-        not_first_order: Questo codice coupon può essere applicato solo al tuo primo ordine.
+        not_first_order: Questo codice coupon può essere applicato solo al tuo primo
+          ordine.
     email: Email
     empty: Vuoto
     empty_cart: Vuota Carrello
@@ -857,9 +1356,12 @@ it:
     error: errore
     errors:
       messages:
+        cannot_delete_finalized_stock_location: 
         could_not_create_taxon: Non è possibile creare il taxon
-        no_payment_methods_available: Non ci sono metodi di pagamenti configurati per questo ambiente
-        no_shipping_methods_available: Non ci sono metodi di spedizione disponibili per l'indirizzo scelto, prova ancora.
+        no_payment_methods_available: Non ci sono metodi di pagamenti configurati
+          per questo ambiente
+        no_shipping_methods_available: Non ci sono metodi di spedizione disponibili
+          per l'indirizzo scelto, prova ancora.
     errors_prohibited_this_record_from_being_saved:
       one: un errore non ha permesso di salvare questo record
       other: "%{count} errori non hanno permesso di salvare questo record"
@@ -878,14 +1380,21 @@ it:
         user:
           signup: Registrazione dell'utente
     exceptions:
-      count_on_hand_setter: Non è possibile impostare la disponibilità manualmente dato che è calcolata automaticamente dalla callback "recalculate_count_on_hand". Per favore usa il metodo "update_column(:count_on_hand, value)".
+      count_on_hand_setter: Non è possibile impostare la disponibilità manualmente
+        dato che è calcolata automaticamente dalla callback "recalculate_count_on_hand".
+        Per favore usa il metodo "update_column(:count_on_hand, value)".
     exchange_for: Cambio per
     excl: escl.
     existing_shipments: Spedizioni esistenti
-    expedited_exchanges_warning: Ogni cambio specificato sarà spedito al cliente immediatamente dopo il salvataggio. Al cliente sarà addebitato l'importo completo dell'articolo se l'articolo originale non verrà restituito entro %{days_window} giorni.
+    expected: 
+    expected_items: 
+    expedited_exchanges_warning: Ogni cambio specificato sarà spedito al cliente immediatamente
+      dopo il salvataggio. Al cliente sarà addebitato l'importo completo dell'articolo
+      se l'articolo originale non verrà restituito entro %{days_window} giorni.
     expiration: Scadenza
     extension: Estensione
     failed_payment_attempts: Tentativi di Pagamento falliti
+    failure: 
     filename: Nome del file
     fill_in_customer_info: Per favore completa le informazioni sul cliente
     filter: Filtro
@@ -893,6 +1402,8 @@ it:
     finalize: Concludi
     finalize_all_adjustments: Conferma la registrazione
     finalized: Concluso
+    finalized_at: 
+    finalized_by: 
     find_a_taxon: Cerca un Taxon
     first_item: Costo primo articolo
     first_name: Nome
@@ -903,6 +1414,7 @@ it:
     forgot_password: Password Dimenticata?
     free_shipping: Consegna Gratuita
     free_shipping_amount: "-"
+    from: 
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway non disponibile per questo environment
@@ -911,11 +1423,48 @@ it:
     general_settings: Impostazioni Generali
     google_analytics: Google Analytics
     google_analytics_id: Analytics ID
+    group_size: 
     guest_checkout: Checkout Ospite
     guest_user_account: Checkout come Ospite
     has_no_shipped_units: non ha prodotti spediti
     height: Altezza
+    helpers:
+      products:
+        price_diff_add_html: 
+        price_diff_subtract_html: 
+    hidden: 
     hide_cents: Nascondi centesimi
+    hide_out_of_stock: 
+    hints:
+      spree/price:
+        country: 
+        master_variant: 
+        options: 
+      spree/product:
+        available_on: 
+        promotionable: 
+        shipping_category: 
+        tax_category: 
+      spree/promotion:
+        expires_at: 
+        starts_at: 
+      spree/stock_location:
+        active: 
+        backorderable_default: 
+        check_stock_on_transfer: 
+        fulfillable: 
+        propagate_all_variants: 
+        restock_inventory: 
+      spree/store:
+        available_locales: 
+        cart_tax_country_iso: 
+      spree/tax_rate:
+        validity_period: 
+      spree/variant:
+        deleted: 
+        deleted_explanation: 
+        deleted_explanation_with_replacement: 
+        tax_category: 
     home: Home
     i18n:
       available_locales: Lingue Disponibili
@@ -931,14 +1480,17 @@ it:
       this_file_language: Italiano (IT)
       translations: Traduzioni
     icon: Icona
+    id: 
+    identifier: 
     image: Immagine
     images: Immagini
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
     inactive: Inattivo
     incl: incl.
     included_in_price: Incluso nel prezzo
-    included_price_validation: non può essere selezionato senza aver impostato una Zona di Tassazione di Default
+    included_price_validation: non può essere selezionato senza aver impostato una
+      Zona di Tassazione di Default
     incomplete: incompleto
     info_number_of_skus_not_shown:
       one: e un'altra
@@ -946,24 +1498,33 @@ it:
     info_product_has_multiple_skus: 'Questo prodotto ha %{count} varianti:'
     instructions_to_reset_password: Per favore inserisci la tua email nel form sottostante
     insufficient_stock: Scorte insufficienti, ne rimangono solo %{on_hand}
-    insufficient_stock_lines_present: Alcune linee di questo ordine hanno quantità insufficiente.
+    insufficient_stock_for_order: 
+    insufficient_stock_lines_present: Alcune linee di questo ordine hanno quantità
+      insufficiente.
     intercept_email_address: Intercetta indirizzo Email
-    intercept_email_instructions: Sovrascrivi il destinatario dell'email con questo indirizzo.
+    intercept_email_instructions: Sovrascrivi il destinatario dell'email con questo
+      indirizzo.
     internal_name: Nome Interno
     invalid_credit_card: Carta di Credito non valida.
     invalid_exchange_variant: Variante di cambio non valida.
+    invalid_payment_method_type: 
     invalid_payment_provider: Provider del pagamento non valido.
     invalid_promotion_action: Azione della promozione non valida.
     invalid_promotion_rule: Regola della promozione non valida.
+    invalidate: 
     inventory: Inventario
     inventory_adjustment: Variazione dell'inventario
-    inventory_error_flash_for_insufficient_quantity: Un articolo del tuo carrello non è più disponibile.
+    inventory_canceled: 
+    inventory_error_flash_for_insufficient_quantity: Un articolo del tuo carrello
+      non è più disponibile.
+    inventory_not_available: 
     inventory_state: Stato Inventario
     inventory_states:
+      backordered: 
       canceled: annullato
+      on_hand: 
       returned: restituito
       shipped: spedito
-      on_hand: disponibile
     is_not_available_to_shipment_address: non è disponibile per l'indirizzo di spedizione
     iso_name: Nome Iso
     item: articolo
@@ -975,7 +1536,8 @@ it:
         gte: maggiore o uguale di
         lt: minore di
         lte: minore o uguale di
-    items_cannot_be_shipped: Non siamo in grado di spedire l'articolo selezionato al tuo indirizzo. Per favore scegli un altro indirizzo di spedizione.
+    items_cannot_be_shipped: Non siamo in grado di spedire l'articolo selezionato
+      al tuo indirizzo. Per favore scegli un altro indirizzo di spedizione.
     items_in_rmas: Articoli in RMA
     items_reimbursed: Articoli Rimborsati
     items_to_be_reimbursed: Articoli che devono essere rimborsati
@@ -1010,12 +1572,15 @@ it:
     logs: Log
     look_for_similar_items: Cerca articoli simili
     make_refund: Esegui rimborso
-    make_sure_the_above_reimbursement_amount_is_correct: Assicurati che l'importo di rimborso qui sopra sia corretto
+    make_sure_the_above_reimbursement_amount_is_correct: Assicurati che l'importo
+      di rimborso qui sopra sia corretto
     manage_promotion_categories: Gestisci Categorie di Promozione
     manage_stock: Gestisci magazzino
     manage_variants: Gestisci le Varianti
     manual_intervention_required: È richiesto un'intervento manuale
     master_price: Prezzo principale
+    master_sku: 
+    master_variant: 
     match_choices:
       all: Tutti
       none: Nessuno
@@ -1027,6 +1592,7 @@ it:
     meta_title: Meta Title
     metadata: Metadata
     minimal_amount: Quantità minima
+    modify_stock_count: 
     month: Mese
     more: Ancora
     move_stock_between_locations: Trasferisci Scorte tra Magazzini
@@ -1035,6 +1601,7 @@ it:
     name: Nome
     name_on_card: Nome sulla carta
     name_or_sku: Nome o SKU (inserisci almeno i primi 4 caratteri del nome del prodotto)
+    negative_movement_absent_item: 
     new: Nuovo
     new_adjustment: Nuova Variazione
     new_adjustment_reason: Nuovo motivo di modifica
@@ -1050,6 +1617,7 @@ it:
     new_product: Nuovo Prodotto
     new_promotion: Nuova Promozione
     new_promotion_category: Nuova Categoria Promozione
+    new_promotion_code_batch: 
     new_property: Nuova Proprietà
     new_prototype: Nuovo Prototipo
     new_refund: Nuovo
@@ -1063,6 +1631,8 @@ it:
     new_stock_location: Nuovo Magazzino
     new_stock_movement: Nuovo Movimento di Magazzino
     new_stock_transfer: Nuovo Trasferimento di Magazzino
+    new_store: 
+    new_store_credit: 
     new_tax_category: Nuova Categoria di Tassazione
     new_tax_rate: Nuova Aliquota
     new_taxon: Nuovo Taxon
@@ -1074,26 +1644,39 @@ it:
     next: Prossimo
     no_actions_added: Nessuna azione aggiunta
     no_images_found: Nessuna immagine
+    no_inventory_selected: 
+    no_option_values_on_product_html: 
+    no_orders_found: 
     no_payment_found: Nessun pagamento trovato
+    no_payment_methods_found: 
     no_pending_payments: Nessun pagamento pendente
     no_products_found: Nessun prodotto trovato
+    no_promotions_found: 
     no_resource: Nessuna risorsa
-    no_resource_found: "Nessun %{resource} trovato"
+    no_resource_found: Nessun %{resource} trovato
+    no_resource_found_html: 
     no_resource_found_link: Aggiungine Uno
     no_results: Nessun risultato
     no_returns_found: Nessuna restituazione trovata
     no_rules_added: Nessuna regola aggiunta
     no_shipping_method_selected: Nessun metodo di spedizione selezionato.
+    no_shipping_methods_found: 
     no_state_changes: Nessun cambio di stato
+    no_stock_locations_found: 
+    no_trackers_found: 
     no_tracking_present: Non sono stati forniti dettagli sul tracciamento
+    no_variants_found: 
+    no_variants_found_try_again: 
     none: Niente
     none_selected: Nessuno selezionato
     normal_amount: Quantità Normale
     not: 'no'
     not_available: Non disponibile
-    not_enough_stock: Non ci sono abbastanza scorte nel magazzino di partenza per completare questo trasferimento.
+    not_enough_stock: Non ci sono abbastanza scorte nel magazzino di partenza per
+      completare questo trasferimento.
     not_found: "%{resource} non trovato"
     note: Nota
+    note_already_received_a_refund: 
     notice_messages:
       product_cloned: Il prodotto è stato clonato
       product_deleted: Il prodotto è stato eliminato
@@ -1103,6 +1686,7 @@ it:
       variant_not_deleted: La variante non può essere eliminata
     num_orders: "# Ordini"
     number: Numero
+    number_of_codes: 
     on_hand: Disponibilità
     open: Apri
     open_all_adjustments: Apri tutte le variazioni
@@ -1117,9 +1701,11 @@ it:
     or_over_price: "%{price} o maggiore"
     order: Ordine
     order_adjustments: Variazioni dell'ordine
+    order_already_completed: 
     order_already_updated: L'ordine è già stato aggiornato.
     order_approved: Ordine Approvato
     order_canceled: Ordine Annullato
+    order_completed: 
     order_details: Dettagli Ordine
     order_email_resent: Email dell'ordine inviata nuovamente
     order_information: Informazioni sull'Ordine
@@ -1128,7 +1714,8 @@ it:
         dear_customer: 'Gentile Cliente,
 
 '
-        instructions: Il tuo ordine è stato ANNULLATO. Per favore conserva queste informazioni per attestare l'annullamento.
+        instructions: Il tuo ordine è stato ANNULLATO. Per favore conserva queste
+          informazioni per attestare l'annullamento.
         order_summary_canceled: Riassunto Ordine [ANNULLATO]
         subject: Annullamento Ordine
         subtotal: 'Subtotale:'
@@ -1147,9 +1734,17 @@ it:
         dear_customer: 'Gentile Cliente,
 
 '
+        instructions: 
+        order_summary_canceled: 
+        subject: 
+    order_mutex_admin_error: 
+    order_mutex_error: 
     order_not_found: Non abbiamo trovato il tuo ordine. Per favore riprova ancora.
     order_number: Ordine %{number}
+    order_please_refresh: 
     order_processed_successfully: Il tuo ordine è stato processato con successo
+    order_ready_for_confirm: 
+    order_refresh_totals: 
     order_resumed: Ordine Riattivato
     order_state:
       address: indirizzo
@@ -1168,7 +1763,7 @@ it:
     order_total: Totale Ordine
     order_updated: Ordine Aggiornato
     orders: Ordini
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Non disponibile
     overview: Panoramica
     package_from: pacco da
@@ -1181,14 +1776,19 @@ it:
     path: Percorso
     pay: paga
     payment: Pagamento
+    payment_amount: 
     payment_could_not_be_created: Il Pagamento non può essere creato.
     payment_identifier: Identificativo Pagamento
     payment_information: Informazioni Pagamento
     payment_method: Metodo di Pagamento
-    payment_method_not_supported: Quel metodo di pagamento non è supportato. Per favore scegline un'altro.
+    payment_method_not_supported: Quel metodo di pagamento non è supportato. Per favore
+      scegline un'altro.
+    payment_method_settings_warning: 
     payment_methods: Metodi di Pagamento
-    payment_processing_failed: Il pagamento non è stato processato correttamente, per favore controlla i dati inseriti
-    payment_processor_choose_banner_text: Se hai bisogno di assistenza nella scelta di un processore di pagamento, per favore visita
+    payment_processing_failed: Il pagamento non è stato processato correttamente,
+      per favore controlla i dati inseriti
+    payment_processor_choose_banner_text: Se hai bisogno di assistenza nella scelta
+      di un processore di pagamento, per favore visita
     payment_processor_choose_link: la nostra pagina dei pagamenti
     payment_state: Stato Pagamento
     payment_states:
@@ -1197,12 +1797,16 @@ it:
       completed: completato
       credit_owed: credito dovuto
       failed: fallito
+      invalid: 
       paid: pagato
       pending: in sospeso
       processing: in lavorazione
       void: annullato
     payment_updated: Pagamento Aggiornato
     payments: Pagamenti
+    payments_failed_count:
+      one: 
+      other: 
     pending: in sospeso
     percent: Percentuale
     percent_per_item: Percentuale per articolo
@@ -1210,11 +1814,15 @@ it:
     phone: Telefono
     place_order: Completa Ordine
     please_define_payment_methods: Per favore definisci prima dei metodi di pagamento.
-    populate_get_error: Qualcosa è andato storto. Per favore prova ad aggiungere di nuovo l'articolo.
+    please_enter_reasonable_quantity: 
+    populate_get_error: Qualcosa è andato storto. Per favore prova ad aggiungere di
+      nuovo l'articolo.
     powered_by: Powered by
     pre_tax_amount: Importo al lordo delle tasse
     pre_tax_refund_amount: Importo Rimborso al lordo delle tasse
     pre_tax_total: Totale al lordo delle tasse
+    preference_source_none: 
+    preference_source_using: 
     preferred_reimbursement_type: Tipologia di rimborso preferita
     presentation: Presentazione
     previous: Precedente
@@ -1226,7 +1834,8 @@ it:
     product: Prodotto
     product_details: Dettagli Prodotto
     product_has_no_description: Questo prodotto non ha una descrizione
-    product_not_available_in_this_currency: Questo prodotto non è disponibile nella valuta selezionata
+    product_not_available_in_this_currency: Questo prodotto non è disponibile nella
+      valuta selezionata
     product_properties: Proprietà del prodotto
     product_rule:
       choose_products: Scegli i prodotti
@@ -1255,6 +1864,17 @@ it:
         name: Spedizione Gratuita
     promotion_actions: Azioni
     promotion_category: Categoria Promozione
+    promotion_code_batch_mailer:
+      promotion_code_batch_errored:
+        message: 
+        subject: 
+      promotion_code_batch_finished:
+        message: 
+        subject: 
+    promotion_code_batches:
+      errored: 
+      finished: 
+      processing: 
     promotion_form:
       match_policies:
         all: Rispetta tutte queste regole
@@ -1288,6 +1908,8 @@ it:
       user_logged_in:
         description: Disponibile solo per utenti autenticati
         name: L'utente ha effettuato il login
+    promotion_successfully_created: 
+    promotion_total_changed_before_complete: 
     promotion_uses: Utilizzi Promozione
     promotionable: Promuovibile
     promotions: Promozioni
@@ -1297,21 +1919,39 @@ it:
     prototype: Prototipo
     prototypes: Prototipi
     provider: Fornitore
-    provider_settings_warning: Se stai cambiando la tipologia di fornitore, devi prima aver salvato le impostazioni del fornitore
+    provider_settings_warning: Se stai cambiando la tipologia di fornitore, devi prima
+      aver salvato le impostazioni del fornitore
     qty: Qtà
     quantity: Quantità
     quantity_returned: Quantità Restituita
     quantity_shipped: Quantità Spedita
     quick_search: Ricerca Veloce
     rate: Percentuale
+    ready_to_ship: 
     reason: Motivazione
     receive: ricevi
     receive_stock: Ricevi Scorte
     received: Ricevuto
-    reception_status:
+    received_items: 
+    received_successfully: 
+    receiving: 
+    receiving_match: 
+    reception_states:
+      awaiting: 
+      cancelled: 
+      expired: 
+      given_to_customer: 
+      in_transit: 
+      lost_in_transit: 
+      received: 
+      shipped_wrong_item: 
+      short_shipped: 
+      unexchanged: 
+    reception_status: 
     reference: Riferimento
     refund: Rimborso
-    refund_amount_must_be_greater_than_zero: L'importo del rimborso deve essere maggiore di zero
+    refund_amount_must_be_greater_than_zero: L'importo del rimborso deve essere maggiore
+      di zero
     refund_reasons: Motivazioni Rimborso
     refunded_amount: Importo Rimborsato
     refunds: Rimborsi
@@ -1322,7 +1962,8 @@ it:
     reimbursement: Rimborso
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send: Hai %{days} giorni per rispedire indietro gli articoli in attesa di cambio.
+        days_to_send: Hai %{days} giorni per rispedire indietro gli articoli in attesa
+          di cambio.
         dear_customer: Gentile Cliente,
         exchange_summary: Riassunto cambi
         for: per
@@ -1330,7 +1971,12 @@ it:
         refund_summary: Riassunto rimborso
         subject: Notifica di Rimborso
         total_refunded: 'Totale Rimborsato: %{total}'
-    reimbursement_perform_failed: 'Il rimborso non può essere effettuato. Errore: %{error}'
+    reimbursement_perform_failed: 'Il rimborso non può essere effettuato. Errore:
+      %{error}'
+    reimbursement_states:
+      errored: 
+      pending: 
+      reimbursed: 
     reimbursement_status: Stato Rimborso
     reimbursement_type: Tipologia Rimborso
     reimbursement_type_override: Override Tipologia Rimborso
@@ -1346,21 +1992,32 @@ it:
     resend: Rinvio
     reset_password: Resetta la mia password
     response_code: Codice di Risposta
+    restock_inventory: 
     resume: Riattiva
     resumed: Riattivato
     return: ritorna
     return_authorization: Autorizzazione Restituzione
+    return_authorization_fire_error: 
     return_authorization_reasons: Motivazioni Autorizzazione Restituzione
+    return_authorization_states:
+      authorized: 
+      canceled: 
     return_authorization_updated: Autorizzazione Restituzione aggiornata
     return_authorizations: Autorizzazioni Restituzione
-    return_item_inventory_unit_ineligible: L'unita di inventario dell'articolo reso deve essere spedita
-    return_item_inventory_unit_reimbursed: L'unita di inventario dell'articolo è già stata rimborsata
+    return_item_inventory_unit_ineligible: L'unita di inventario dell'articolo reso
+      deve essere spedita
+    return_item_inventory_unit_reimbursed: L'unita di inventario dell'articolo è già
+      stata rimborsata
+    return_item_order_not_completed: 
     return_item_rma_ineligible: L'articolo reso richiede un RMA
     return_item_time_period_ineligible: L'articolo reso è fuori dal periodo idoneo
     return_items: Articoli Reso
-    return_items_cannot_be_associated_with_multiple_orders: Gli articoli reso non possono essere associati a ordini multipli.
+    return_items_cannot_be_associated_with_multiple_orders: Gli articoli reso non
+      possono essere associati a ordini multipli.
+    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: 
     return_number: Numero Reso
     return_quantity: Quantità Reso
+    return_reasons: 
     returned: Restituito
     returns: Resi
     review: Rivedi
@@ -1387,21 +2044,26 @@ it:
     secure_connection_type: Tipologia Connessione Sicura
     security_settings: Impostazioni Sicurezza
     select: Seleziona
-    select_a_return_authorization_reason: Seleziona una motivazione di autorizzazione reso
+    select_a_reason: 
+    select_a_return_authorization_reason: Seleziona una motivazione di autorizzazione
+      reso
     select_a_stock_location: Seleziona un Magazzino
     select_from_prototype: Seleziona da Prototipo
     select_stock: Seleziona Scorte
     selected_quantity_not_available: La quantità selezionata non è disponibile
     send_copy_of_all_mails_to: Invia una Copia di Tutte le Mail a
+    send_mailer: 
     send_mails_as: Invia Mail come
     server: Server
     server_error: Il server ha ritornato un errore
     settings: Impostazioni
     ship: spedisci
     ship_address: Indirizzo di Spedizione
+    ship_address_required: 
     ship_total: Totale Spedizione
     shipment: Spedizione
     shipment_adjustments: Variazioni spedizioni
+    shipment_date: 
     shipment_details: Da %{stock_location} via %{shipping_method}
     shipment_mailer:
       shipped_email:
@@ -1415,6 +2077,7 @@ it:
         track_information: 'Informazione Tracciamento: %{tracking}'
         track_link: 'Link Tracciamento: %{url}'
     shipment_number: Numero di spedizione
+    shipment_numbers: 
     shipment_state: Stato Spedizione
     shipment_states:
       backorder: arretrato
@@ -1427,6 +2090,7 @@ it:
     shipment_transfer_success: Varianti trasferite con successo
     shipments: Spedizioni
     shipped: Spedito
+    shipped_at: 
     shipping: Spedizione
     shipping_address: Indirizzo di Spedizione
     shipping_categories: Categorie di Spedizione
@@ -1438,6 +2102,14 @@ it:
     shipping_method: Metodo di Spedizione
     shipping_methods: Metodi di Spedizione
     shipping_price_sack: Costo imballaggio
+    shipping_rate:
+      display_price:
+        display_price_with_explanations: 
+        tax_label_separator: 
+    shipping_rate_tax:
+      label:
+        sales_tax: 
+        vat: 
     shipping_total: Totale Spedizione
     shop_by_taxonomy: Acquista per %{taxonomy}
     shopping_cart: Carrello
@@ -1452,11 +2124,16 @@ it:
     skus: SKU
     slug: Slug
     source: Origine
+    source_location: 
     special_instructions: Istruzioni Speciali
     split: Diviso
-    spree_gateway_error_flash_for_checkout: Si è verificato un problema con le tue informazioni di pagamento. Per favore controlla le tue informazioni e prova ancora.
+    split_failed: 
+    spree_gateway_error_flash_for_checkout: Si è verificato un problema con le tue
+      informazioni di pagamento. Per favore controlla le tue informazioni e prova
+      ancora.
     ssl:
-      change_protocol: Per favore passa all'utilizzo di HTTP (invece che HTTPS) e riprova questa richiesta.
+      change_protocol: Per favore passa all'utilizzo di HTTP (invece che HTTPS) e
+        riprova questa richiesta.
     start: Inizio
     state: Stato
     state_based: Basato sullo Stato
@@ -1467,22 +2144,22 @@ it:
       awaiting: In Attesa
       awaiting_return: In attesa di reso
       backordered: Arretrato
-      cart: Carrello
       canceled: Annullato
+      cart: Carrello
       checkout: Checkout
-      confirm: Conferma
+      closed: Chiuso
       complete: Completo
       completed: Completato
-      closed: Chiuso
+      confirm: Conferma
       delivery: Spedizione
       errored: In Errore
       failed: Fallito
       given_to_customer: Dato al Cliente
       invalid: Non Valido
       manual_intervention_required: Richiesto intervento manuale
+      on_hand: Disponibile
       open: Aperto
       order: Ordine
-      on_hand: Disponibile
       payment: Pagamento
       pending: In Sospeso
       processing: In Lavorazione
@@ -1493,31 +2170,63 @@ it:
       shipped: Spedito
       void: Nullo
     states: Stati
+    states_count:
+      one: 
+      other: 
     states_required: Stati Necessari
     status: Stato
     stock: Stock
     stock_location: Magazzino
     stock_location_info: Informazioni Magazzino
     stock_locations: Magazzini
-    stock_locations_need_a_default_country: Devi creare un paese dei default prima di un magazzino.
+    stock_locations_need_a_default_country: Devi creare un paese dei default prima
+      di un magazzino.
     stock_management: Gestione Scorte
-    stock_management_requires_a_stock_location: Per favore crea un Magazzino per poter gestire le scorte.
+    stock_management_requires_a_stock_location: Per favore crea un Magazzino per poter
+      gestire le scorte.
     stock_movements: Movimenti di Magazzino
     stock_movements_for_stock_location: Movimenti di Magazzino per %{stock_location_name}
+    stock_not_below_zero: 
     stock_successfully_transferred: Le scorte sono state trasferito con successo.
     stock_transfer: Trasferimento di Magazzino
     stock_transfers: Trasferimenti di Magazzino
     stop: Stop
     store: Negozio
     store_credit:
+      actions:
+        invalidate: 
+      credit_allocation_memo: 
+      currency_mismatch: 
       display_action:
         adjustment: Variazione
         admin:
           authorize: Autorizzato
+          eligible: 
+          void: 
+        allocation: 
+        capture: 
         credit: Credito
+        invalidate: 
         void: Credito
+      errors:
+        cannot_invalidate_uncaptured_authorization: 
+        unable_to_fund: 
+      expiring: 
+      insufficient_authorized_amount: 
+      insufficient_funds: 
+      non_expiring: 
+      select_one_store_credit: 
+      store_credit: 
+      successful_action: 
+      unable_to_credit: 
+      unable_to_find: 
+      unable_to_find_for_action: 
+      unable_to_void: 
+      user_has_no_store_credits: 
     store_credit_category:
       default: Default
+    store_rule:
+      choose_stores: 
     street_address: Indirizzo
     street_address_2: Indirizzo (agg.)
     subtotal: Totale
@@ -1526,7 +2235,8 @@ it:
     successfully_created: "%{resource} è stata creata con successo!"
     successfully_refunded: "%{resource} è stato rimborsato con successo!"
     successfully_removed: "%{resource} è stato rimosso con successo!"
-    successfully_signed_up_for_analytics: Registrazione a Spree Analytics avvenuta con successo
+    successfully_signed_up_for_analytics: Registrazione a Spree Analytics avvenuta
+      con successo
     successfully_updated: "%{resource} è stata aggiornata con successo!"
     summary: Riassunto
     tax: Tassazione
@@ -1534,7 +2244,8 @@ it:
     tax_category: Categoria di Tassazione
     tax_code: Codice Tassa
     tax_included: Tassa (incl.)
-    tax_rate_amount_explanation: Le aliquote sono specificate con valore decimale per facilitare le operazioni, (es. se l'aliquota è al 5% inserisci 0.05)
+    tax_rate_amount_explanation: Le aliquote sono specificate con valore decimale
+      per facilitare le operazioni, (es. se l'aliquota è al 5% inserisci 0.05)
     tax_rates: Aliquote
     taxon: Taxon
     taxon_edit: Modifica Taxon
@@ -1544,114 +2255,128 @@ it:
       label: L?ordine deve contenere quantità x di queste taxon
       match_all: tutte
       match_any: almeno una
+      match_none: 
     taxonomies: Tassonomie
     taxonomy: Tassonomia
     taxonomy_edit: Modifica tassonomia
-    taxonomy_tree_error: La modifica richiesta non è stata accettata e l'albero è stato riportato allo stato precedente, per favore riprova.
-    taxonomy_tree_instruction: "* Click destro su un nodo nell'albero per accedere al menu e aggiungere, rimuovere o ordinare."
+    taxonomy_tree_error: La modifica richiesta non è stata accettata e l'albero è
+      stato riportato allo stato precedente, per favore riprova.
+    taxonomy_tree_instruction: "* Click destro su un nodo nell'albero per accedere
+      al menu e aggiungere, rimuovere o ordinare."
     taxons: Taxon
     test: Test
     test_mailer:
       test_email:
         greeting: Congratulazioni!
-        message: Se hai ricevuto questa email, allora le tue impostazioni email sono corrette.
+        message: Se hai ricevuto questa email, allora le tue impostazioni email sono
+          corrette.
         subject: E-Mail di Test
     test_mode: Modalità Test
-    thank_you_for_your_order: Grazie per il tuo ordine. Per favore stampa una copia di questa conferma come riferimento.
-    there_are_no_items_for_this_order: Non ci sono articoli per questo ordine. Per favore aggiungi un articolo all'ordine per continuare.
-    there_were_problems_with_the_following_fields: Ci sono dei problemi con i seguenti campi
+    thank_you_for_your_order: Grazie per il tuo ordine. Per favore stampa una copia
+      di questa conferma come riferimento.
+    there_are_no_items_for_this_order: Non ci sono articoli per questo ordine. Per
+      favore aggiungi un articolo all'ordine per continuare.
+    there_were_problems_with_the_following_fields: Ci sono dei problemi con i seguenti
+      campi
     this_order_has_already_received_a_refund: Questo ordine ha già ricevuto un rimborso
     thumbnail: Immagine
     tiered_flat_rate: Tariffa Fissa a Livelli
     tiered_percent: Tariffa Fissa a Percentuale
     tiers: Livelli
     time: Ora
+    to: 
     to_add_variants_you_must_first_define: Per aggiungere varianti, devi prima definire
     total: Totale
+    total_excluding_vat: 
     total_per_item: Totale per articolo
     total_pre_tax_refund: Totale Rimborso al lordo delle tasse
     total_price: Prezzo totale
     total_sales: Acquisti Totali
     track_inventory: Traccia Inventario
     tracking: Tracciamento
+    tracking_info: 
     tracking_number: Codice Tracciamento
     tracking_url: URL Tracciamento
     tracking_url_placeholder: es. http://quickship.com/package?num=:tracking
     transaction_id: ID transazione
     transfer_from_location: Trasferisci Da
+    transfer_number: 
     transfer_stock: Trasferisci Scorte
     transfer_to_location: Trasferisci A
     tree: Albero
+    try_changing_search_values: 
     type: Tipo
     type_to_search: Digita per cercare
     unable_to_connect_to_gateway: Impossibile connettersi al gateway.
-    unable_to_create_reimbursements: Impossibile creare rimborsi perché ci sono articoli in attesa di intervento manuale.
-    under_price: "Inferiore di %{price}"
+    unable_to_create_reimbursements: Impossibile creare rimborsi perché ci sono articoli
+      in attesa di intervento manuale.
+    unable_to_find_all_inventory_units: 
+    under_price: Inferiore di %{price}
     unfinalize_all_adjustments: Annulla la registrazione
     unlock: Sblocca
     unrecognized_card_type: Carda di credito non riconosciuta
     unshippable_items: Impossibile spedire gli articoli
     update: Aggiorna
+    updated_successfully: 
     updating: Aggiornando
     usage_limit: Limite di Utilizzo
     use_app_default: Usa il Default dell'App
     use_billing_address: Usa Indirizzo di Fatturazione
+    use_existing_cc: 
     use_new_cc: Usa una nuova carta
     use_new_cc_or_payment_method: Usa una nuova carta / Metodo di Pagamento
     use_s3: Usa Amazon S3 per le Immagini
     user: Utente
+    user_role_rule:
+      choose_roles: 
+      label: 
+      match_all: 
+      match_any: 
     user_rule:
       choose_users: Scegli utenti
     users: Utenti
     validation:
-      cannot_be_less_than_shipped_units: non può essere inferiore al numero di unità spedite.
-      cannot_destroy_line_item_as_inventory_units_have_shipped: Impossibile eliminare le righe d'ordine poiché alcune unità di inventario sono state spedite.
-      exceeds_available_stock: supera la disponibilità di magazzino. Per favore assicurati che la quantità degli articoli sia valida.
+      cannot_be_less_than_shipped_units: non può essere inferiore al numero di unità
+        spedite.
+      cannot_destroy_line_item_as_inventory_units_have_shipped: Impossibile eliminare
+        le righe d'ordine poiché alcune unità di inventario sono state spedite.
+      exceeds_available_stock: supera la disponibilità di magazzino. Per favore assicurati
+        che la quantità degli articoli sia valida.
       is_too_large: è troppo grande -- il magazzino non può coprire la quantità richiesta!
       must_be_int: deve essere un intero
       must_be_non_negative: deve essere un valore non negativo
-      unpaid_amount_not_zero: 'L''importo non è stato completamente rimborsato. Rimangono: %{amount}'
+      unpaid_amount_not_zero: 'L''importo non è stato completamente rimborsato. Rimangono:
+        %{amount}'
+    validity_period: 
     value: Valore
     variant: Variante
     variant_placeholder: Scegli una variante
+    variant_pricing: 
     variant_properties: Proprietà variante
+    variant_search: 
     variant_search_placeholder: Cerca variante
+    variant_to_add: 
+    variant_to_be_received: 
     variants: Varianti
     version: Versione
+    view_promotion_codes_list: 
     void: Annullato
     weight: Peso
     what_is_a_cvv: Cos'è il Codice CVV?
     what_is_this: Cos'è Questo?
     width: Larghezza
     year: Anno
+    you_cannot_undo_action: 
     you_have_no_orders_yet: Non hai alcun ordine
     your_cart_is_empty: Il tuo carrello è vuoto
-    your_order_is_empty_add_product: Il tuo ordine è vuoto, per favore cerca e aggiungi un prodotto
+    your_order_is_empty_add_product: Il tuo ordine è vuoto, per favore cerca e aggiungi
+      un prodotto
     zip: Cap
     zipcode: Codice Cap
     zone: Zona
     zones: Zone
-    canceled: annullato
-    cannot_create_payment_link: Per favore definisci prima dei metodi di pagamento.
-    inventory_states:
-      canceled: annullato
-      returned: restituito
-      shipped: spedito
-    no_resource_found_link: Aggiungine Uno
-    number: Numero
-    store_credit:
-      display_action:
-        adjustment: Variazione
-        credit: Credito
-        void: Credito
-        admin:
-          authorize: Autorizzato
-    store_credit_category:
-      default: Default
-  activemodel:
-    attributes:
-      spree/order_cancellations:
-        quantity: Quantità
-        state: Stato
-        shipment: Spedizione
-        cancel: Annulla
+  time:
+    formats:
+      solidus:
+        long: 
+        short: 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -550,8 +550,8 @@ it:
         one: Percentuale per elemento
         other: Percentuali per elemento
       spree/calculator/price_sack:
-        one:
-        other:
+        one: Costo imballaggio
+        other: Costi imballaggio
       spree/calculator/returns/default_refund_amount:
         one: Importo predefinito rimborso
         other: Importo predefinito rimborso
@@ -568,8 +568,8 @@ it:
         one: Tasso fisso per elemento
         other: Tassi fissi per elemento
       spree/calculator/shipping/price_sack:
-        one:
-        other:
+        one: Costo imballaggio
+        other: Costi imballaggio
       spree/calculator/tiered_flat_rate:
         one: Tasso fisso a scaglioni
         other: Tassi fissi a scaglioni
@@ -621,10 +621,11 @@ it:
       spree/payment_method:
         one: Metodo di Pagamento
         other: Metodi di Pagamento
-      spree/payment_method/bogus_credit_card:
-      spree/payment_method/check:
-      spree/payment_method/simple_bogus_credit_card:
-      spree/payment_method/store_credit:
+      spree/payment_method/bogus_credit_card: Pagamento Carta di credito fittizia
+      spree/payment_method/check: Pagamento con assegno
+      spree/payment_method/simple_bogus_credit_card: Pagamento semplice con carta
+        di credito fittizia
+      spree/payment_method/store_credit: Pagamento con credito negozio
       spree/price:
         one: Prezzo
         other: Prezzi
@@ -637,22 +638,24 @@ it:
       spree/promotion:
         one: Promozione
         other: Promozioni
-      spree/promotion/actions/create_adjustment:
-      spree/promotion/actions/create_item_adjustments:
-      spree/promotion/actions/create_quantity_adjustments:
-      spree/promotion/actions/free_shipping:
-      spree/promotion/rules/first_order:
-      spree/promotion/rules/first_repeat_purchase_since:
-      spree/promotion/rules/item_total:
-      spree/promotion/rules/landing_page:
-      spree/promotion/rules/nth_order:
-      spree/promotion/rules/one_use_per_user:
-      spree/promotion/rules/option_value:
-      spree/promotion/rules/product:
-      spree/promotion/rules/taxon:
-      spree/promotion/rules/user:
-      spree/promotion/rules/user_logged_in:
-      spree/promotion/rules/user_role:
+      spree/promotion/actions/create_adjustment: Crea variazione per ordine completo
+      spree/promotion/actions/create_item_adjustments: Crea variazione per articolo
+        carrello
+      spree/promotion/actions/create_quantity_adjustments: Crea una variazione per
+        quantità
+      spree/promotion/actions/free_shipping: Spedizione gratuita
+      spree/promotion/rules/first_order: Primo ordine
+      spree/promotion/rules/first_repeat_purchase_since: Primo acquisto ripetuto da
+      spree/promotion/rules/item_total: Totale articolo
+      spree/promotion/rules/landing_page: Landing Page
+      spree/promotion/rules/nth_order: Ordine N
+      spree/promotion/rules/one_use_per_user: Un uso per utente
+      spree/promotion/rules/option_value: Valore(i) opzione
+      spree/promotion/rules/product: Prodotto(i)
+      spree/promotion/rules/taxon: Categoria(e)
+      spree/promotion/rules/user: Utente
+      spree/promotion/rules/user_logged_in: Utente autenticato
+      spree/promotion/rules/user_role: Ruolo(i) utente
       spree/promotion_category:
         one: Categoria Promozione
         other: Categorie Promozione
@@ -707,7 +710,7 @@ it:
       spree/state_change:
         one: Cambio di Stato
         other: Cambi di Stato
-      spree/stock:
+      spree/stock: Scorte
       spree/stock_item:
         one: Articolo magazzino
         other: Articoli magazzino
@@ -916,7 +919,7 @@ it:
         select_amount_update_reason: Seleziona un motivo per l'aggiornamento dell'importo
         select_reason: Motivo
         total_unused: Totale non usato
-        type_html_header:
+        type_html_header: Tipo di credito
         unable_to_create: Impossibile creare
         unable_to_delete: Impossibile eliminare
         unable_to_invalidate: Impossibile invalidare
@@ -930,7 +933,7 @@ it:
         areas: Zone
         checkout: Checkout
         configuration: Impostazioni
-        display_order:
+        display_order: Mostra ordine
         general: Generale
         option_types: Opzioni
         orders: Ordini
@@ -1691,7 +1694,8 @@ it:
       completare questo trasferimento.
     not_found: "%{resource} non trovato"
     note: Nota
-    note_already_received_a_refund:
+    note_already_received_a_refund: 'Nota: Questo ordine ha già ricevuto un rimborso.
+      Controllare che l''importo del rimborso sopra indicato sia corretto.'
     notice_messages:
       product_cloned: Il prodotto è stato clonato
       product_deleted: Il prodotto è stato eliminato
@@ -1949,8 +1953,8 @@ it:
     received: Ricevuto
     received_items: Articoli ricevuti
     received_successfully: Ricevuto con successo
-    receiving: In ricezione
-    receiving_match:
+    receiving: Ricevendo
+    receiving_match: Ricevendo una corrispondenza
     reception_states:
       awaiting: in attesa
       cancelled: annullato

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -12,11 +12,13 @@ it:
         spree/fulfilment_changer:
           attributes:
             current_shipment:
-              can_not_have_backordered_inventory_units: 
-              has_already_been_shipped: 
+              can_not_have_backordered_inventory_units: ha unità di inventario posticipate
+              has_already_been_shipped: già spedito
             desired_shipment:
-              can_not_transfer_within_same_shipment: 
-              not_enough_stock_at_desired_location: 
+              can_not_transfer_within_same_shipment: non può essere uguale alla spedizione
+                corrente
+              not_enough_stock_at_desired_location: scorte insufficienti nel magazzino
+                desiderato
   activerecord:
     attributes:
       spree/address:
@@ -33,7 +35,7 @@ it:
       spree/adjustment:
         adjustable: Variabile
         adjustment_reason_id: Motivazione
-        amount: Quantità
+        amount: Importo
         label: Descrizione
         name: Nome
         state: Stato
@@ -43,14 +45,14 @@ it:
         name: Nome
         state: Stato
       spree/calculator/flat_rate:
-        preferred_amount: 
+        preferred_amount: Importo
       spree/calculator/tiered_flat_rate:
         preferred_base_amount: Importo Base
-        preferred_currency: 
+        preferred_currency: Valuta
         preferred_tiers: Livelli
       spree/calculator/tiered_percent:
         preferred_base_percent: Percentuale Base
-        preferred_currency: 
+        preferred_currency: Valuta
         preferred_tiers: Livelli
       spree/carton:
         tracking: Tracciamento
@@ -60,7 +62,7 @@ it:
         iso_name: Nome ISO
         name: Nome
         numcode: Codice ISO
-        states_required: Province o Stati Necessari
+        states_required: Province o Stati necessari
       spree/credit_card:
         base: ''
         card_code: Codice Carta
@@ -72,13 +74,13 @@ it:
         verification_value: Codice di Verifica
         year: Anno
       spree/customer_return:
-        created_at: 
+        created_at: Data/Ora
         name: Nome
         number: Numero Reso
         pre_tax_total: Totale al lordo delle tasse
         reimbursement_status: Stato Rimborso
         total: Totale
-        total_excluding_vat: 
+        total_excluding_vat: Totale al lordo delle tasse
       spree/image:
         alt: Testo Alternativo
         attachment: Nome del file
@@ -88,7 +90,7 @@ it:
         email: Email
         password: Password
         password_confirmation: Conferma Password
-        spree_roles: 
+        spree_roles: Ruoli
       spree/line_item:
         description: Descrizione dell'articolo
         name: Nome
@@ -140,9 +142,9 @@ it:
         state: Provincia indirizzo di spedizione
         zipcode: CAP indirizzo di spedizione
       spree/payment:
-        amount: Quantità
-        created_at: 
-        number: 
+        amount: Importo
+        created_at: Data/Ora
+        number: Identificativo
         response_code: ID transazione
         state: Stato Pagamento
       spree/payment_method:
@@ -151,12 +153,12 @@ it:
         description: Descrizione
         display_on: Mostra
         name: Nome
-        preference_source: 
+        preference_source: Origine preferenze
         type: Fornitore
       spree/price:
-        amount: 
-        currency: 
-        is_default: 
+        amount: Importo
+        currency: Valuta
+        is_default: Valido
       spree/product:
         available_on: Disponibile dal
         cost_currency: Valuta Costo
@@ -180,56 +182,60 @@ it:
       spree/product_property:
         value: Valore
       spree/promotion:
-        advertise: Publicizza
-        apply_automatically: 
+        advertise: Pubblicizza
+        apply_automatically: Applica automaticamente
         code: Codice
         description: Descrizione
         event_name: Nome Evento
         expires_at: Scade il
         name: Nome
         path: Percorso
-        per_code_usage_limit: 
+        per_code_usage_limit: Limite di Utilizzo per Codice
         promotion_category: Categoria Promozione
-        promotion_uses: 
+        promotion_uses: Promozione usa
         starts_at: Inizia il
-        status: 
+        status: Stato
         usage_limit: Limite di Utilizzo
       spree/promotion/actions/create_adjustment:
-        description: 
+        description: Crea una variazione promozionale sull'ordine
       spree/promotion/actions/create_item_adjustments:
-        description: 
+        description: Crea una variazione promozionale per un articolo
       spree/promotion/actions/create_quantity_adjustments:
-        description: 
+        description: Crea una variazione promozionale per un articolo basata sulla
+          quantità
       spree/promotion/actions/free_shipping:
-        description: 
+        description: Rendi gratuite tutte le spedizioni dell'ordine
       spree/promotion/rules/first_order:
-        description: 
+        description: Deve essere il primo ordine del cliente
       spree/promotion/rules/first_repeat_purchase_since:
-        description: 
-        form_text: 
+        description: Disponibile solo se il cliente non ha ordinato da un po'
+        form_text: 'Applica questa promozione ai clienti il cui ultimo ordine è stato
+          più di X giorni fa: '
       spree/promotion/rules/item_total:
-        description: 
+        description: Il totale dell'ordine soddisfa questi criteri
       spree/promotion/rules/landing_page:
-        description: 
+        description: Il cliente deve aver visitato la pagina specificata
       spree/promotion/rules/nth_order:
-        description: 
-        form_text: 
+        description: Applica questa promozione per ogni ordine N che il cliente ha
+          completato.
+        form_text: 'Applica questa promozione ad ogni ordine N: '
       spree/promotion/rules/one_use_per_user:
-        description: 
+        description: Solo un utilizzo per cliente
       spree/promotion/rules/option_value:
-        description: 
+        description: L'ordine include i prodotti specificati con corrispondenti valori
+          opzione
       spree/promotion/rules/product:
-        description: 
+        description: L'ordine include i prodotti specificati
       spree/promotion/rules/store:
-        description: 
+        description: Disponibile solo per gli Store specificati
       spree/promotion/rules/taxon:
-        description: 
+        description: L'ordine include prodotti delle categorie specificate
       spree/promotion/rules/user:
-        description: 
+        description: Disponibile solo per gli utenti specificati
       spree/promotion/rules/user_logged_in:
-        description: 
+        description: Disponibile solo per utenti autenticati
       spree/promotion/rules/user_role:
-        description: 
+        description: Disponibile solo per gli utenti con i ruoli specificati
       spree/promotion_category:
         code: Codice
         name: Nome
@@ -239,7 +245,7 @@ it:
       spree/prototype:
         name: Nome
       spree/refund:
-        amount: Quantità
+        amount: Importo
         description: Descrizione
         refund_reason_id: Motivazione
       spree/refund_reason:
@@ -247,37 +253,37 @@ it:
         code: Codice
         name: Nome
       spree/reimbursement:
-        created_at: 
+        created_at: Data/Ora
         number: Numero
         reimbursement_status: Stato
         total: Totale
       spree/reimbursement/credit:
-        amount: Quantità
+        amount: Importo
       spree/reimbursement_type:
-        created_at: 
+        created_at: Data/Ora
         name: Nome
         type: Tipo
       spree/return_authorization:
-        amount: Quantità
+        amount: Importo
         pre_tax_total: Totale al lordo delle tasse
-        total_excluding_vat: 
+        total_excluding_vat: Totale al lordo delle tasse
       spree/return_item:
         acceptance_status: Stato Accettazione
         acceptance_status_errors: Errori Accettazione
-        amount: 
+        amount: Importo
         charged: Addebitato
         exchange_variant: Cambio per
         inventory_unit_state: Stato
-        item_received?: 
+        item_received?: Prodotto ricevuto?
         override_reimbursement_type_id: Override Tipologia Rimborso
         preferred_reimbursement_type_id: Tipologia di rimborso preferita
-        reception_status: 
-        resellable: 
+        reception_status: Stato ricezione
+        resellable: Rivendibile?
         return_reason: Motivazione
         total: Totale
       spree/return_reason:
         active: Attivo
-        created_at: 
+        created_at: Data/Ora
         memo: Memo
         name: Nome
         number: Numero RMA
@@ -290,16 +296,16 @@ it:
         name: Nome
       spree/shipping_method:
         admin_name: Nome Interno
-        carrier: 
+        carrier: Vettore
         code: Codice
         display_on: Mostra
         name: Nome
-        service_level: 
+        service_level: Livello Servizio
         tracking_url: URL Tracciamento
       spree/shipping_rate:
-        amount: Quantità
-        label: 
-        shipping_rate: 
+        amount: Importo
+        label: Etichetta
+        shipping_rate: Tasso spedizione
         tax_rate: Aliquota
       spree/state:
         abbr: Abbreviazione
@@ -320,33 +326,33 @@ it:
         address2: Indirizzo (agg.)
         admin_name: Nome Interno
         backorderable_default: Ordinabile di default
-        check_stock_on_transfer: 
+        check_stock_on_transfer: Controlla scorte al trasferimento
         city: Città
         code: Codice
         country_id: Paese
-        default: Default
-        fulfillable: 
+        default: Predefinito
+        fulfillable:
         internal_name: Nome Interno
         name: Nome
         phone: Telefono
         propagate_all_variants: Propaga a tutte le varianti
-        restock_inventory: 
+        restock_inventory: re-immagazzinare inventario
         state_id: Stato
         zipcode: Cap
       spree/stock_movement:
         action: Azione
-        originated_by: 
+        originated_by: Originato da
         quantity: Quantità
-        variant: 
+        variant: Variante
       spree/stock_transfer:
         created_at: Creato Il
         description: Descrizione
         tracking_number: Codice Tracciamento
       spree/store:
-        available_locales: 
-        cart_tax_country_iso: 
-        default: 
-        default_currency: 
+        available_locales: Lingue disponibili
+        cart_tax_country_iso: Codice ISO per nazione predefinita del carrello
+        default: Predefinita
+        default_currency: Valuta predefinita
         mail_from_address: Indirizzo Mittente Email
         meta_description: Meta Description
         meta_keywords: Meta Keywords
@@ -354,33 +360,33 @@ it:
         seo_title: Titolo SEO
         url: URL Sito
       spree/store_credit:
-        amount: Quantità
-        amount_authorized: 
-        amount_credited: 
-        amount_used: 
-        category_id: 
-        created_at: 
-        created_by_id: 
-        invalidated_at: 
+        amount: Importo
+        amount_authorized: Importo Autorizzato
+        amount_credited: Importo accreditato
+        amount_used: Importo usato
+        category_id: Tipo Credito
+        created_at: Creato il
+        created_by_id: Creato da
+        invalidated_at: Invalidato
         memo: Memo
       spree/store_credit_event:
         action: Azione
-        amount_remaining: 
-        user_total_amount: 
+        amount_remaining: Importo rimanente
+        user_total_amount: Importo totale
       spree/store_credit_update_reason:
-        name: 
+        name: Motivo per l'aggiornamento
       spree/tax_category:
         description: Descrizione
-        is_default: Default
+        is_default: Predefinito
         name: Nome
         tax_code: Codice Tassa
       spree/tax_rate:
         amount: Tasso
-        expires_at: 
+        expires_at: Finisce il
         included_in_price: Incluso nel Prezzo
         name: Nome
         show_rate_in_label: Mostra tasso nell'etichetta
-        starts_at: 
+        starts_at: Comincia il
       spree/taxon:
         description: Descrizione
         icon: Icona
@@ -397,10 +403,10 @@ it:
         analytics_id: Analytics ID
       spree/user:
         email: Email
-        lifetime_value: 
+        lifetime_value: Totale speso
         password: Password
         password_confirmation: Conferma Password
-        spree_roles: 
+        spree_roles: Ruoli
       spree/variant:
         cost_currency: Valuta Costo
         cost_price: Prezzo di Costo
@@ -408,7 +414,7 @@ it:
         height: Altezza
         price: Prezzo
         sku: SKU
-        tax_category: 
+        tax_category: Categoria tassa
         weight: Peso
         width: Larghezza
       spree/zone:
@@ -420,7 +426,7 @@ it:
         spree/address:
           attributes:
             state:
-              does_not_match_country: 
+              does_not_match_country: Non corrisponde alla nazione
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
@@ -449,24 +455,26 @@ it:
         spree/inventory_unit:
           attributes:
             base:
-              cannot_destroy_shipment_state: 
+              cannot_destroy_shipment_state: Impossibile cancellare un'unità inventario
+                per una spedizione nello stato %{state}
             state:
-              cannot_destroy: 
+              cannot_destroy: Impossibile cancellare un'unità inventario nello stato
+                %{state}
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency: Deve corrispondere alla Valuta dell'Ordine
+              must_match_order_currency: Deve corrispondere alla valuta dell'ordine
             price:
-              not_a_number: 
+              not_a_number: non è valido
         spree/price:
           attributes:
             currency:
-              invalid_code: 
+              invalid_code: non è un codice valuta valido
         spree/promotion:
           attributes:
             apply_automatically:
-              disallowed_with_code: 
-              disallowed_with_path: 
+              disallowed_with_code: Non permesso per promozioni con un codice
+              disallowed_with_path: Non permesso per promozioni con un percorso
         spree/refund:
           attributes:
             amount:
@@ -487,9 +495,10 @@ it:
         spree/shipment:
           attributes:
             base:
-              cannot_remove_items_shipment_state: 
+              cannot_remove_items_shipment_state: Impossibile rimuovere elementi da
+                una spedizione nello stato %{state}
             state:
-              cannot_destroy: 
+              cannot_destroy: Impossibile rimuovere una spedizione nello stato %{state}
         spree/store:
           attributes:
             base:
@@ -498,75 +507,75 @@ it:
         spree/user_address:
           attributes:
             user_id:
-              default_address_exists: 
+              default_address_exists: ha già un indirizzo predefinito
         spree/wallet_payment_source:
           attributes:
             payment_source:
-              has_to_be_payment_source_class: 
+              has_to_be_payment_source_class: deve essere un Spree::PaymentSource
     models:
       spree/address:
         one: Indirizzo
         other: Indirizzi
       spree/adjustment:
-        one: 
-        other: 
+        one: Variazione
+        other: Variazioni
       spree/adjustment_reason:
-        one: 
-        other: 
+        one: Motivo per la variazione
+        other: Motivi per la variazione
       spree/calculator:
-        one: 
-        other: 
+        one: Calcolatore base
+        other: Calcolatori base
       spree/calculator/default_tax:
-        one: 
-        other: 
+        one: Tassa predefinita
+        other: Tasse predefinite
       spree/calculator/distributed_amount:
-        one: 
-        other: 
+        one: Importo distribuito
+        other: Importi distribuiti
       spree/calculator/flat_percent_item_total:
-        one: 
-        other: 
+        one: Percentuale fissa
+        other: Percentuali fisse
       spree/calculator/flat_rate:
-        one: 
-        other: 
+        one: Tasso fisso
+        other: Tassi fissi
       spree/calculator/flexi_rate:
-        one: 
-        other: 
+        one: Tasso variabile
+        other: Tassi variabili
       spree/calculator/free_shipping:
-        one: 
-        other: 
+        one: Spedizione gratuita
+        other: Spedizioni gratuite
       spree/calculator/percent_on_line_item:
-        one: 
-        other: 
+        one: Percentuale per riga d'ordine
+        other: Percentuali per riga d'ordine
       spree/calculator/percent_per_item:
-        one: 
-        other: 
+        one: Percentuale per elemento
+        other: Percentuali per elemento
       spree/calculator/price_sack:
-        one: 
-        other: 
+        one:
+        other:
       spree/calculator/returns/default_refund_amount:
-        one: 
-        other: 
+        one: Importo predefinito rimborso
+        other: Importo predefinito rimborso
       spree/calculator/shipping/flat_percent_item_total:
-        one: 
-        other: 
+        one: Percentuale fissa
+        other: Percentuali fisse
       spree/calculator/shipping/flat_rate:
-        one: 
-        other: 
+        one: Tasso fisso
+        other: Tassi fissi
       spree/calculator/shipping/flexi_rate:
-        one: 
-        other: 
+        one: Tasso variabile
+        other: Tassi variabili
       spree/calculator/shipping/per_item:
-        one: 
-        other: 
+        one: Tasso fisso per elemento
+        other: Tassi fissi per elemento
       spree/calculator/shipping/price_sack:
-        one: 
-        other: 
+        one:
+        other:
       spree/calculator/tiered_flat_rate:
-        one: 
-        other: 
+        one: Tasso fisso a scaglioni
+        other: Tassi fissi a scaglioni
       spree/calculator/tiered_percent:
-        one: 
-        other: 
+        one: Percentuale a scaglioni
+        other: Percentuali a scaglioni
       spree/country:
         one: Nazione
         other: Nazioni
@@ -577,23 +586,23 @@ it:
         one: Reso Cliente
         other: Resi Cliente
       spree/exchange:
-        one: 
-        other: 
+        one: Cambio
+        other: Cambi
       spree/image:
-        one: 
-        other: 
+        one: Immagine
+        other: Immagini
       spree/inventory_unit:
         one: Unità di Inventario
         other: Unità di Inventario
       spree/legacy_user:
-        one: 
-        other: 
+        one: Utente legacy
+        other: Utenti legacy
       spree/line_item:
         one: Riga d'Ordine
         other: Righe d'Ordine
       spree/log_entry:
-        one: 
-        other: 
+        one: Voce di registro
+        other: Voci di registro
       spree/option_type:
         one: Opzione
         other: Opzioni
@@ -607,52 +616,52 @@ it:
         one: Pagamento
         other: Pagamenti
       spree/payment_capture_event:
-        one: 
-        other: 
+        one: Evento di cattura pagamento
+        other: Eventi di cattura pagamento
       spree/payment_method:
         one: Metodo di Pagamento
         other: Metodi di Pagamento
-      spree/payment_method/bogus_credit_card: 
-      spree/payment_method/check: 
-      spree/payment_method/simple_bogus_credit_card: 
-      spree/payment_method/store_credit: 
+      spree/payment_method/bogus_credit_card:
+      spree/payment_method/check:
+      spree/payment_method/simple_bogus_credit_card:
+      spree/payment_method/store_credit:
       spree/price:
-        one: 
-        other: 
+        one: Prezzo
+        other: Prezzi
       spree/product:
         one: Prodotto
         other: Prodotti
       spree/product_property:
-        one: 
-        other: 
+        one: Categoria prodotto
+        other: Categorie prodotto
       spree/promotion:
         one: Promozione
         other: Promozioni
-      spree/promotion/actions/create_adjustment: 
-      spree/promotion/actions/create_item_adjustments: 
-      spree/promotion/actions/create_quantity_adjustments: 
-      spree/promotion/actions/free_shipping: 
-      spree/promotion/rules/first_order: 
-      spree/promotion/rules/first_repeat_purchase_since: 
-      spree/promotion/rules/item_total: 
-      spree/promotion/rules/landing_page: 
-      spree/promotion/rules/nth_order: 
-      spree/promotion/rules/one_use_per_user: 
-      spree/promotion/rules/option_value: 
-      spree/promotion/rules/product: 
-      spree/promotion/rules/taxon: 
-      spree/promotion/rules/user: 
-      spree/promotion/rules/user_logged_in: 
-      spree/promotion/rules/user_role: 
+      spree/promotion/actions/create_adjustment:
+      spree/promotion/actions/create_item_adjustments:
+      spree/promotion/actions/create_quantity_adjustments:
+      spree/promotion/actions/free_shipping:
+      spree/promotion/rules/first_order:
+      spree/promotion/rules/first_repeat_purchase_since:
+      spree/promotion/rules/item_total:
+      spree/promotion/rules/landing_page:
+      spree/promotion/rules/nth_order:
+      spree/promotion/rules/one_use_per_user:
+      spree/promotion/rules/option_value:
+      spree/promotion/rules/product:
+      spree/promotion/rules/taxon:
+      spree/promotion/rules/user:
+      spree/promotion/rules/user_logged_in:
+      spree/promotion/rules/user_role:
       spree/promotion_category:
         one: Categoria Promozione
         other: Categorie Promozione
       spree/promotion_code:
-        one: 
-        other: 
+        one: Codice promozione
+        other: Codici promozione
       spree/promotion_code_batch:
-        one: 
-        other: 
+        one: Lotto di codici promozione
+        other: Lotti di codici promozione
       spree/property:
         one: Proprietà
         other: Proprietà
@@ -660,8 +669,8 @@ it:
         one: Prototipo
         other: Prototipi
       spree/refund:
-        one: 
-        other: 
+        one: Rimborso
+        other: Rimborsi
       spree/refund_reason:
         one: Motivazione Rimborso
         other: Motivazioni Rimborso
@@ -678,8 +687,8 @@ it:
         one: Motivazione Autorizzazione Restituzione
         other: Motivazioni Autorizzazione Restituzione
       spree/return_reason:
-        one: 
-        other: 
+        one: Motivo restituzione
+        other: Motivi restituzione
       spree/role:
         one: Ruolo
         other: Ruoli
@@ -698,10 +707,10 @@ it:
       spree/state_change:
         one: Cambio di Stato
         other: Cambi di Stato
-      spree/stock: 
+      spree/stock:
       spree/stock_item:
-        one: 
-        other: 
+        one: Articolo magazzino
+        other: Articoli magazzino
       spree/stock_location:
         one: Magazzino
         other: Magazzini
@@ -712,14 +721,14 @@ it:
         one: Trasferimento di Magazzino
         other: Trasferimenti di Magazzino
       spree/store:
-        one: 
-        other: 
+        one: Negozio
+        other: Negozi
       spree/store_credit:
-        one: 
-        other: 
+        one: Credito negozio
+        other: Crediti negozio
       spree/store_credit_category:
-        one: 
-        other: 
+        one: Categoria del credito negozio
+        other: Categorie del credito negozio
       spree/tax_category:
         one: Categoria di Tassazione
         other: Categorie di Tassazione
@@ -727,8 +736,8 @@ it:
         one: Aliquota
         other: Aliquote
       spree/taxon:
-        one: Taxon
-        other: Taxon
+        one: Categoria
+        other: Categorie
       spree/taxonomy:
         one: Tassonomia
         other: Tassonomie
@@ -745,54 +754,16 @@ it:
         one: Zona
         other: Zone
       user:
-        one: 
-        other: 
-  devise:
-    confirmations:
-      confirmed: 
-      send_instructions: 
-    failure:
-      inactive: 
-      invalid: 
-      invalid_token: 
-      locked: 
-      timeout: 
-      unauthenticated: 
-      unconfirmed: 
-    mailer:
-      confirmation_instructions:
-        subject: 
-      reset_password_instructions:
-        subject: 
-      unlock_instructions:
-        subject: 
-    oauth_callbacks:
-      failure: 
-      success: 
-    unlocks:
-      send_instructions: 
-      unlocked: 
-    user_passwords:
-      user:
-        cannot_be_blank: 
-        send_instructions: 
-        updated: 
-    user_registrations:
-      destroyed: 
-      inactive_signed_up: 
-      signed_up: 
-      updated: 
-    user_sessions:
-      signed_in: 
-      signed_out: 
+        one: Utente
+        other: Utenti
   errors:
     messages:
-      already_confirmed: 
-      not_found: 
-      not_locked: 
+      already_confirmed: già confermato
+      not_found: non trovato
+      not_locked: non era bloccato
       not_saved:
-        one: 
-        other: 
+        one: '1 errore ha impedito di salvare %{resource}:'
+        other: "%{count} errori hanno impedito di salvare %{resource}:"
   spree:
     abbreviation: Abbreviazione
     accept: Accetta
@@ -813,7 +784,7 @@ it:
       list: Lista
       listing: Lista
       new: Nuovo
-      receive: 
+      receive: Ricevi
       refund: Rimborso
       remove: Rimuovi
       save: Salva
@@ -826,7 +797,7 @@ it:
     add_action_of_type: Aggiungi tipologia azione
     add_country: Aggiungi Paese
     add_coupon_code: Aggiungi Codice Coupon
-    add_line_item: 
+    add_line_item: Aggiungi articolo all'ordine
     add_new_header: Aggiungi Nuovo Header
     add_new_style: Aggiungi Nuovo Stile
     add_one: Aggiungine Uno
@@ -837,185 +808,190 @@ it:
     add_state: Aggiungi Stato/Provincia
     add_stock: Aggiungi Scorte
     add_stock_management: Gestione Scorte
-    add_taxon: Aggiungi elemento
+    add_taxon: Aggiungi categoria
     add_to_cart: Aggiungi al Carrello
-    add_to_stock_location: 
+    add_to_stock_location: Aggiungi al magazzino
     add_variant: Aggiungi Variante
-    add_variant_properties: 
-    added: 
-    adding_match: 
-    additional_item: Costo Aggiuntivo Articolo
+    add_variant_properties: Aggiunti proprietà della variante
+    added: Aggiunto
+    adding_match: Aggiungere corrispondenza
+    additional_item: Costo aggiuntivo articolo
     address1: Indirizzo
     address2: Indirizzo (cont.)
     adjustable: Variabile
     adjustment: Variazione
     adjustment_amount: Importo
     adjustment_labels:
-      line_item: 
-      order: 
+      line_item: "%{promotion} (%{promotion_name})"
+      order: "%{promotion} (%{promotion_name})"
       tax_rates:
-        sales_tax: 
-        sales_tax_with_rate: tasse
-        vat: 
-        vat_with_rate: di cui tasse
-    adjustment_reasons: 
+        sales_tax: "%{name}"
+        sales_tax_with_rate: "%{name} %{amount}"
+        vat: "%{name} (Inclusa nel prezzo)"
+        vat_with_rate: "%{name} %{amount} (Inclusa nel prezzo)"
+    adjustment_reasons: Motivi di variazione
     adjustment_successfully_closed: La variazione è stata chiusa correttamente
     adjustment_successfully_opened: La variazione è stata aperta correttamente
     adjustment_total: Totale Variazione
-    adjustment_type: 
+    adjustment_type: Tipo di variazione
     adjustments: Variazioni
     admin:
       images:
         index:
-          choose_files: 
-          drag_and_drop: 
-          image_process_failed: 
-          upload_images: 
+          choose_files: Scegli files da caricare
+          drag_and_drop: o drag and drop qui
+          image_process_failed: Il server non ha potuto processare l'immagine
+          upload_images: Carica immagini
       payments:
         source_forms:
           storecredit:
-            not_supported: 
+            not_supported: Al momento non è possibile creare un pagamento di tipo
+              credito negozio dall'interfaccia di amministrazione
       prices:
         any_country: Tutte le nazioni
         edit:
-          edit_price: 
+          edit_price: Modifica prezzo
         index:
           amount_greater_than: Quantità maggiore di
           amount_less_than: Quantità minore di
           new_price: Nuovo prezzo
         new:
-          new_price: 
+          new_price: Nuovo prezzo
       promotions:
         actions:
-          calculator_label: 
+          calculator_label: Calcolato da
         activations_edit:
-          auto: 
-          multiple_codes_html: 
-          single_code_html: 
+          auto: Tutti gli ordini tenteranno di usare questa promozione
+          multiple_codes_html: Questa promozione usa %{count} codici promozionali
+          single_code_html: 'Questa promozione usa il codice promozionale: <code>%{code}</code>'
         activations_new:
-          auto: 
-          multiple_codes: 
-          single_code: 
+          auto: Applica a tutti gli ordini
+          multiple_codes: Codici promozionali multipli
+          single_code: Codice promozionale singolo
         form:
-          activation: 
-          expires_at_placeholder: 
-          general: 
-          starts_at_placeholder: 
+          activation: Attivazione
+          expires_at_placeholder: Mai
+          general: Generale
+          starts_at_placeholder: Immediatamente
       stock_locations:
         form:
-          address: 
-          general: 
-          settings: 
+          address: Indirizzo
+          general: Generale
+          settings: Impostazioni
       store_credits:
         add: Nuovo credito
-        amount_authorized: 
-        amount_credited: 
-        amount_used: 
-        back_to_edit: 
-        back_to_store_credit_list: 
+        amount_authorized: Autorizzato
+        amount_credited: Accreditato
+        amount_used: Usato
+        back_to_edit: Torna a Modifica
+        back_to_store_credit_list: Torna alla Lista dei crediti negozio
         back_to_user_list: Lista utenti
-        change_amount: 
-        created_at: 
-        created_by: 
-        credit_type: 
-        current_balance: 
-        edit: 
-        edit_amount: 
+        change_amount: Cambia Importo
+        created_at: Emesso il
+        created_by: Creato da
+        credit_type: Tipo di credito
+        current_balance: 'Bilancio corrente:'
+        edit: Modifica credito negozio
+        edit_amount: Modifica importo del credito negozio
         errors:
-          amount_authorized_exceeds_total_credit: 
-          amount_used_cannot_be_greater: 
-          amount_used_not_zero: 
-          cannot_be_modified: 
-          cannot_change_used_store_credit: 
-          update_reason_required: 
-        history: 
-        invalidate_store_credit: 
-        invalidated: 
-        issued_on: 
-        memo: 
-        new: 
-        no_store_credit_selected: 
-        payment_originator: 
-        reason_for_updating: 
-        refund_originator: 
-        resource_name: 
-        select_amount_update_reason: 
+          amount_authorized_exceeds_total_credit: Supera il credito disponibile
+          amount_used_cannot_be_greater: Non può essere maggiore dell'importo accreditato
+          amount_used_not_zero: è maggiore di zero. Impossibile cancellare il credito
+            negozio
+          cannot_be_modified: Non può essere modificato
+          cannot_change_used_store_credit: Il credito negozio già richiesto non può
+            essere cambiato
+          update_reason_required: Bisogna selezionare un motivo per il cambiamento
+        history: Storico del credito negozio
+        invalidate_store_credit: Invalidamento del credito negozio
+        invalidated: Invalidato
+        issued_on: Emesso il
+        memo: Memo
+        new: Nuovo credito negozio
+        no_store_credit_selected: Nessun credito negozio selezionato
+        payment_originator: 'Pagamento - Ordine #%{order_number}'
+        reason_for_updating: Motivo per l'aggiornamento
+        refund_originator: 'Rimborso - Ordine #%{order_number}'
+        resource_name: Nome risorsa
+        select_amount_update_reason: Seleziona un motivo per l'aggiornamento dell'importo
         select_reason: Motivo
-        total_unused: 
-        type_html_header: 
-        unable_to_create: 
-        unable_to_delete: 
-        unable_to_invalidate: 
-        unable_to_update: 
-        user_originator: 
-        view: 
+        total_unused: Totale non usato
+        type_html_header:
+        unable_to_create: Impossibile creare
+        unable_to_delete: Impossibile eliminare
+        unable_to_invalidate: Impossibile invalidare
+        unable_to_update: Impossibile aggiornare
+        user_originator: Utente - %{email}
+        view: Visualizza credito negozio
       stores:
         form:
-          no_cart_tax_country: 
+          no_cart_tax_country: Nessun Codice ISO per nazione predefinita del carrello
       tab:
         areas: Zone
         checkout: Checkout
         configuration: Impostazioni
-        display_order: 
+        display_order:
         general: Generale
         option_types: Opzioni
         orders: Ordini
         overview: Quadro generale
         payments: Pagamenti
         products: Prodotti
-        promotion_categories: 
+        promotion_categories: Categorie promozioni
         promotions: Promozioni
         properties: Proprietà
         prototypes: Prototipi
         reports: Report
-        rma: Rma
+        rma: RMA
         settings: Impostazioni
         shipping: Spedizione
         stock: Stock
         stock_items: Magazzino
         stock_transfers: Trasferimento di magazzino
-        stores: 
+        stores: Negozi
         taxes: Tasse
         taxonomies: Tassonomie
-        taxons: Taxon
+        taxons: Categorie
         users: Utenti
-        zones: 
+        zones: Zone
       taxons:
-        display_order: 
+        display_order: Visualizza Ordine
       user:
         account: Account
         addresses: Indirizzi
         items: Articoli
         items_purchased: Articoli Acquistati
-        order_history: Storia Ordini
+        order_history: Storico Ordini
         order_num: 'Ordine #'
         orders: Ordini
         store_credit: Credito
         user_information: Informazioni Utente
       users:
         edit:
-          api_access: 
-          clear_key: 
-          confirm_clear_key: 
-          confirm_regenerate_key: 
-          generate_key: 
-          key: 
-          no_key: 
-          regenerate_key: 
+          api_access: Accesso API
+          clear_key: Elmina chiave
+          confirm_clear_key: Sei sicuro di voler elminare la chiave API per questo
+            utente? Questa azione invaliderà la chiave esistente.
+          confirm_regenerate_key: Sei sicuro di voler rigenerare la chiave API per
+            questo utente? Questa azione invaliderà la chiave esistente.
+          generate_key: Genera chiave
+          key: Chiave
+          no_key: Nessuna chiave
+          regenerate_key: Rigenera chiave
         user_page_actions:
-          create_order: 
+          create_order: Crea Ordine
       variants:
         edit:
-          edit_variant: 
+          edit_variant: Modifica variante
         form:
-          dimensions: 
-          pricing: 
-          pricing_hint: 
-          use_product_tax_category: 
+          dimensions: Dimensioni
+          pricing: Prezzo
+          pricing_hint: Suggerimento prezzo
+          use_product_tax_category: Usa categoria tassazione prodotto
         new:
-          new_variant: 
+          new_variant: Nuova variante
         table_filter:
-          show_deleted: 
+          show_deleted: Mostra varianti eliminate
     admin_login: Login
     administration: Amministrazione
     advertise: Promuovi
@@ -1023,9 +999,9 @@ it:
     agree_to_terms_of_service: Accetta i Termini di Servizio
     all: Tutto
     all_adjustments_closed: Tutte le variazioni chiuse correttamente!
-    all_adjustments_finalized: 
+    all_adjustments_finalized: Tutte le variazioni finalizzate!
     all_adjustments_opened: Tutte le variazioni aperte correttamente!
-    all_adjustments_unfinalized: 
+    all_adjustments_unfinalized: Tutte le variazioni non finalizzate!
     all_departments: Tutti i dipartimenti
     all_items_have_been_returned: Tutti gli Articoli sono stati restituiti
     allow_ssl_in_development_and_test: Consenti l'utilizzo di SSL in modalità development
@@ -1035,7 +1011,7 @@ it:
     already_signed_up_for_analytics: Sei già registrato per Spree Analytics
     alt_text: Testo Alternativo
     alternative_phone: Telefono Alternativo
-    amount: Quantità
+    amount: Importo
     analytics_desc_header_1: Spree Analytics
     analytics_desc_header_2: Analytics in tempo reale integrato nella tua dashboard
       di Spree
@@ -1052,7 +1028,7 @@ it:
       key: Chiave
       no_key: Nessuna Chiave
       regenerate_key: Genera nuova Chiave
-    apply_code: 
+    apply_code: Applica codice
     approve: approva
     approved_at: Approvato il
     approver: Approvatore
@@ -1064,51 +1040,51 @@ it:
     authorization_failure: Autorizzazione Fallita
     authorized: Autorizzato
     auto_capture: Riscossione Automatica
-    auto_receive: 
+    auto_receive: Ricezione Automatica
     available_on: Disponibile dal
     average_order_value: Valore medio Ordine
     avs_response: Risposta AVS
     back: Indietro
     back_end: Backend
     back_to_adjustment_reason_list: Lista motivi di modifica
-    back_to_adjustments_list: 
+    back_to_adjustments_list: Lista variazioni
     back_to_countries_list: Lista nazioni
-    back_to_customer_return: 
-    back_to_customer_return_list: 
-    back_to_images_list: 
-    back_to_option_types_list: 
+    back_to_customer_return: Restituzione cliente
+    back_to_customer_return_list: List restituzioni cliente
+    back_to_images_list: Lista immagini
+    back_to_option_types_list: Lista Tipi opzione
     back_to_orders_list: Lista ordini
     back_to_payment: Torna al Pagamento
-    back_to_payment_methods_list: 
-    back_to_payments_list: 
+    back_to_payment_methods_list: Lista metodi di pagamento
+    back_to_payments_list: Lista pagamenti
     back_to_products_list: Lista prodotti
-    back_to_promotion_categories_list: 
-    back_to_promotions_list: 
-    back_to_properties_list: 
-    back_to_refund_reason_list: 
-    back_to_reimbursement_type_list: 
+    back_to_promotion_categories_list: Lista categorie promozione
+    back_to_promotions_list: Lista promozioni
+    back_to_properties_list: Lista proprietà
+    back_to_refund_reason_list: Lista motivi di rimborso
+    back_to_reimbursement_type_list: Lista tipi di rimborso
     back_to_reports_list: Lista reports
     back_to_resource_list: Torna alla Lista %{resource}
-    back_to_return_authorizations_list: 
+    back_to_return_authorizations_list: Lista autorizzazioni di restituzione
     back_to_rma_reason_list: Torna alla Lista Motivazioni RMA
     back_to_shipping_categories: Lista categorie di spedizione
-    back_to_shipping_categories_list: 
+    back_to_shipping_categories_list: Lista categorie spedizione
     back_to_shipping_methods_list: Lista metodi di spedizione
     back_to_states_list: Lista stati
     back_to_stock_locations_list: Lista aliquote
-    back_to_stock_movements_list: 
+    back_to_stock_movements_list: Lista movimenti magazzino
     back_to_stock_transfers_list: Lista trasferimenti di magazzino
     back_to_store: Torna al Negozio
     back_to_tax_categories_list: Lista categorie di tassazione
     back_to_tax_rates_list: Lista aliquote
     back_to_taxonomies_list: Lista tassonomie
-    back_to_trackers_list: 
+    back_to_trackers_list: Lista trackers
     back_to_users_list: Torna alla Lista degli Utenti
     back_to_zones_list: Lista zone
     backorderable: Ordinabile anche se terminato
     backorderable_default: Ordinabile di default
     backorderable_header: Approvvigionamento
-    backordered: Arretrato
+    backordered: Ordinato anche se terminato
     backorders_allowed: consentiti ordini anche se terminato
     balance_due: Saldo Dovuto
     base_amount: Importo Base
@@ -1121,25 +1097,29 @@ it:
     calculator: Calcolatore
     calculator_settings_warning: Se stai cambiando la tipologia di calcolatore, devi
       prima salvare per modificare le impostazioni del calcolatore
-    cancel: annulla
-    cancel_inventory: Annulla movimento
-    canceled: annullato
-    canceled_at: Annullato il
-    canceler: Annullatore
-    cancellation: 
+    cancel: Cancella
+    cancel_inventory: Cancella movimento
+    canceled: Cancellato
+    canceled_at: Cancellato il
+    canceler: Cancellato da
+    cancellation: Cancellazione
     cannot_create_customer_returns: Impossibile Create Resi Cliente
     cannot_create_payment_link: Per favore definisci prima dei metodi di pagamento.
     cannot_create_payment_without_payment_methods: Non puoi creare un pagamento per
       l'ordine senza alcun metodo di pagamento specificato.
-    cannot_create_payment_without_payment_methods_html: 
+    cannot_create_payment_without_payment_methods_html: Impossibile creare un pagamento
+      per un ordine senza nessuno metodo di pagamento definito. %{link}
     cannot_create_returns: Impossibile creare un reso perché questo ordine non ha
       unità spedite.
     cannot_perform_operation: Impossible effettuare l'operazione richiesta
-    cannot_rebuild_shipments_order_completed: 
-    cannot_rebuild_shipments_shipments_not_pending: 
+    cannot_rebuild_shipments_order_completed: Impossibile ricreare spedizioni per
+      un ordine completato.
+    cannot_rebuild_shipments_shipments_not_pending: Impossibile ricreare spedizioni
+      per un ordine con spedizioni non incomplete.
     cannot_set_shipping_method_without_address: Impossibile impostare un metodo di
       spedizione finché i dettagli del cliente non vengono specificati.
-    cannot_update_email: 
+    cannot_update_email: Non hai accesso per aggiornare l'indirizzo email di questo
+      utente.<br />Per favore contatta l'amministratore se devi eseguire questa operazione.
     capture: Riscuoti
     capture_events: Eventi di riscossione
     card_code: Codice Carta
@@ -1150,24 +1130,24 @@ it:
     cart_subtotal:
       one: Subtotale (1 articolo)
       other: Subtotale (%{count} articoli)
-    carton_external_number: 
-    carton_orders: 
+    carton_external_number: Numero esterno confezione
+    carton_orders: Altri ordini con confezione
     categories: Categorie
     category: Categoria
-    character_limit: 
+    character_limit: Limite caratteri
     charged: Addebitato
-    check: 
+    check: Controlla
     check_for_spree_alerts: Visualizza le segnalazioni di Spree
-    check_stock_on_transfer: 
+    check_stock_on_transfer: Controlla magazzino al trasferimento
     checkout: Checkout
     choose_a_customer: Scegli un cliente
-    choose_a_taxon_to_sort_products_for: Scegli un taxon con cui ordinare i prodotti
-    choose_currency: Scegli una Valuta
-    choose_dashboard_locale: Scegli una Lingua per la Dashboard
+    choose_a_taxon_to_sort_products_for: Scegli una categoria con cui ordinare i prodotti
+    choose_currency: Scegli una valuta
+    choose_dashboard_locale: Scegli una lingua per la Dashboard
     choose_location: Scegli Località
-    choose_promotion_action: 
-    choose_promotion_rule: 
-    choose_reason: 
+    choose_promotion_action: Scegli azione
+    choose_promotion_rule: Scegli regola
+    choose_reason: Scegli motivo
     city: Città
     clear_cache: Pulisci la Cache
     clear_cache_ok: La Cache è stato pulita
@@ -1178,16 +1158,16 @@ it:
     clone: Clona
     close: Chiudi
     close_all_adjustments: Chiudi Tutte le Variazioni
-    closed: 
+    closed: Chiuso
     code: Codice
     company: Azienda
-    complete: completo
-    complete_order: 
+    complete: Completo
+    complete_order: Completa ordine
     configuration: Impostazione
     configurations: Impostazioni
     confirm: Conferma
     confirm_delete: Conferma Eliminazione
-    confirm_order: 
+    confirm_order: Conferma ordine
     confirm_password: Conferma Password
     continue: Continua
     continue_shopping: Continua gli acquisti
@@ -1224,13 +1204,13 @@ it:
     create_a_new_account: Crea un nuovo account
     create_new_order: Crea Nuovo Ordine
     create_one: Creane una
-    create_promotion_code: 
+    create_promotion_code: Crea codice promozione
     create_reimbursement: Crea Rimborso
     created_at: Creato Il
-    created_by: 
-    created_successfully: 
+    created_by: Creato da
+    created_successfully: Creato con successo
     credit: Credito
-    credit_allowed: 
+    credit_allowed: Credito permesso
     credit_card: Carta di Credito
     credit_cards: Carte di Credito
     credit_owed: Credito Dovuto
@@ -1274,55 +1254,56 @@ it:
     default_tax: Tassazione di default
     default_tax_zone: Zona di Tassazione di Default
     delete: Elimina
-    delete_from_taxon: Rimuovi dalla Taxon
-    deleted_successfully: 
+    delete_from_taxon: Elimina dalla categoria
+    deleted_successfully: Elminato con successo
     deleted_variants_present: Alcune linee di questo ordine hanno prodotti che non
       sono più disponibili.
     delivery: Consegna
     depth: Profondità
     description: Descrizione
     destination: Destinazione
-    destination_location: 
+    destination_location: Località destinazione
     destroy: Elimina
     details: Dettagli
     discount_amount: Importo dello sconto
-    discount_rules: 
+    discount_rules: Regole sconto
     dismiss_banner: No, grazie! Non sono interessato, non mostrare più questo messaggio
     display: Mostra
     display_currency: Mostra valuta
     doesnt_track_inventory: Non tiene traccia dell'inventario
-    download_promotion_codes_list: 
+    download_promotion_codes_list: Scarica lista codici promozione
     edit: Modifica
-    edit_refund_reason: 
-    editing_adjustment_reason: 
+    edit_refund_reason: Modifica motivo rimborso
+    editing_adjustment_reason: Modifica motivo variazione
     editing_country: Modifica nazione
-    editing_option_type: 
-    editing_payment_method: 
-    editing_product: 
-    editing_promotion: 
-    editing_promotion_category: 
-    editing_property: 
-    editing_refund: 
-    editing_refund_reason: 
-    editing_reimbursement: 
-    editing_reimbursement_type: 
+    editing_option_type: Modifica tipo opzione
+    editing_payment_method: Modifica metodo di pagamento
+    editing_product: Modifica prodotto
+    editing_promotion: Modifica promozione
+    editing_promotion_category: Modifica categoria promozione
+    editing_property: Modifica proprietà
+    editing_refund: Modifica rimborso
+    editing_refund_reason: Modifica motivo rimborso
+    editing_reimbursement: Modifica rimborso
+    editing_reimbursement_type: Modifica tipo rimborso
     editing_resource: Modifica %{resource}
     editing_rma_reason: Modifica Motivazione RMA
     editing_shipping_category: Modifica categoria di spedizione
     editing_shipping_method: Modifica metodo di spedizione
     editing_state: Modifica stati
     editing_stock_location: Modifica magazzino
-    editing_stock_movement: 
+    editing_stock_movement: Modifica movimento magazzino
     editing_tax_category: Modifica catgoria di tassazione
     editing_tax_rate: Modifica aliquota
-    editing_tracker: 
+    editing_tracker: Modifica tracker
     editing_user: Modifica Utente
     editing_zone: Modifica zona
     eligibility_errors:
       messages:
         has_excluded_product: Il carrello contiene un prodotto che non permette l'applicazione
           di questo codice coupon.
-        has_excluded_taxon: 
+        has_excluded_taxon: Il tuo carrello contiene un prodotto di una categoria
+          che non permette l'applicazione di questo codice coupon.
         item_total_less_than: Questo codice coupon non può essere applicato a ordini
           di importo inferiore a %{amount}.
         item_total_less_than_or_equal: Questo codice coupon non può essere applicato
@@ -1339,7 +1320,7 @@ it:
           prima di applicare questo codice coupon.
         no_applicable_products: Devi aggiungere un prodotto appropriato prima di applicare
           questo codice coupon.
-        no_matching_taxons: Devi aggiungere un prodotto da una categorie appropriata
+        no_matching_taxons: Devi aggiungere un prodotto da una categoria appropriata
           prima di applicare questo codice coupon.
         no_user_or_email_specified: Devi fare il login o fornire una email prima di
           applicare questo codice coupon.
@@ -1356,8 +1337,9 @@ it:
     error: errore
     errors:
       messages:
-        cannot_delete_finalized_stock_location: 
-        could_not_create_taxon: Non è possibile creare il taxon
+        cannot_delete_finalized_stock_location: Impossibile eliminare località di
+          un magazzino finalizzato
+        could_not_create_taxon: Non è possibile creare la categoria
         no_payment_methods_available: Non ci sono metodi di pagamenti configurati
           per questo ambiente
         no_shipping_methods_available: Non ci sono metodi di spedizione disponibili
@@ -1386,15 +1368,15 @@ it:
     exchange_for: Cambio per
     excl: escl.
     existing_shipments: Spedizioni esistenti
-    expected: 
-    expected_items: 
+    expected: Atteso
+    expected_items: Articoli attesi
     expedited_exchanges_warning: Ogni cambio specificato sarà spedito al cliente immediatamente
       dopo il salvataggio. Al cliente sarà addebitato l'importo completo dell'articolo
       se l'articolo originale non verrà restituito entro %{days_window} giorni.
     expiration: Scadenza
     extension: Estensione
     failed_payment_attempts: Tentativi di Pagamento falliti
-    failure: 
+    failure: Fallimento
     filename: Nome del file
     fill_in_customer_info: Per favore completa le informazioni sul cliente
     filter: Filtro
@@ -1402,9 +1384,9 @@ it:
     finalize: Concludi
     finalize_all_adjustments: Conferma la registrazione
     finalized: Concluso
-    finalized_at: 
-    finalized_by: 
-    find_a_taxon: Cerca un Taxon
+    finalized_at: Finalizzato il
+    finalized_by: Finalizzato da
+    find_a_taxon: Cerca una categoria
     first_item: Costo primo articolo
     first_name: Nome
     first_name_begins_with: Nome Comincia Con
@@ -1414,7 +1396,7 @@ it:
     forgot_password: Password Dimenticata?
     free_shipping: Consegna Gratuita
     free_shipping_amount: "-"
-    from: 
+    from: Da
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway non disponibile per questo environment
@@ -1423,51 +1405,81 @@ it:
     general_settings: Impostazioni Generali
     google_analytics: Google Analytics
     google_analytics_id: Analytics ID
-    group_size: 
+    group_size: Dimensione gruppo
     guest_checkout: Checkout Ospite
     guest_user_account: Checkout come Ospite
     has_no_shipped_units: non ha prodotti spediti
     height: Altezza
     helpers:
       products:
-        price_diff_add_html: 
-        price_diff_subtract_html: 
-    hidden: 
+        price_diff_add_html: "(Aggiungi: %{amount_html})"
+        price_diff_subtract_html: "(Sottrai: %{amount_html})"
+    hidden: Nascosto
     hide_cents: Nascondi centesimi
-    hide_out_of_stock: 
+    hide_out_of_stock: Nascondi 'Non disponibile'
     hints:
       spree/price:
-        country: 
-        master_variant: 
-        options: 
+        country: 'Questo determina in quale nazione il prezzo è valido.<br/>Predefinito:
+          Tutte'
+        master_variant: Cambiare i prezzi della variante principale non cambierà i
+          prezzi della variante di seguito, ma sarà usato per popolare tutte le nuove
+          varianti
+        options: Queste opzioni sono usate per creare varianti nella tabella varianti.
+          Posso essere cambiate nella scheda Varianti
       spree/product:
-        available_on: 
-        promotionable: 
-        shipping_category: 
-        tax_category: 
+        available_on: Questo imposta la data di disponibilità per il prodotto. Se
+          il valore non è impostato o è una data futura, allora il prodotto non è
+          disponibile nel negozio pubblico.
+        promotionable: 'Questo determina se le promozioni possono essere applicate
+          a questo prodotto.<br/>Predefinito: Sì'
+        shipping_category: 'Questo determina quale tipo di spedizione questo prodotto
+          richiede.<br/> Predefinito: Predefinita'
+        tax_category: 'Questo determina quale tipo di tassazione è applicata a questo
+          prodotto.<br/> Predefinito: Nessuna'
       spree/promotion:
-        expires_at: 
-        starts_at: 
+        expires_at: Questo determina quando termina la promozione.<br/>Se nessun valore
+          è specificato, la promozione non terminerà mai.
+        starts_at: Questo determina quando la promozione può essere applicata agli
+          ordini.<br/>Se nessun valore è specificato, la promozione sarà immediatamente
+          disponibile.
       spree/stock_location:
-        active: 
-        backorderable_default: 
-        check_stock_on_transfer: 
-        fulfillable: 
-        propagate_all_variants: 
-        restock_inventory: 
+        active: 'Questo determina se il magazzino da questa località può essere usato
+          per creare confezioni.<br/>Predefinito: Sì'
+        backorderable_default: 'Se spuntato, gli articoli del magazzino in questa
+          località permetteranno ordini anche se terminati.<br/> Predefinito: No'
+        check_stock_on_transfer: 'Se spuntato, i livelli di inventario saranno controllati
+          nei trasferimenti di magazzino.<br/> Predefinito: Sì'
+        fulfillable: 'Se non spuntato, questo indica che gli articoli in questa località
+          non richiedono un reale adempimento. Il magazzino non sarà controllato quando
+          la spedizione e le email non sono inviate.<br/>Predefinito: Sì'
+        propagate_all_variants: 'Se spuntato, questo creerà un articolo magazzino
+          in questa località<br/>Predefinito: Sì'
+        restock_inventory: 'Se spuntato, l''inventario ritornato può essere aggiunto
+          nuovamente ai livelli del magazzino di questa località.<br/>Predefinito:
+          Sì'
       spree/store:
-        available_locales: 
-        cart_tax_country_iso: 
+        available_locales: Questo determina quali lingue sono disponibili per i tuoi
+          clienti da scegliere nel negozio.
+        cart_tax_country_iso: 'Questo determina quale nazione è usata per le tasse
+          nei carrelli (per ordini che non hanno ancora un indirizzo).<br/>Predefinito:
+          Nessuna'
       spree/tax_rate:
-        validity_period: 
+        validity_period: Questo determina il periodo di validità entro il quale l'aliquota
+          d'imposta è valida e sarà applicata agli articoli.<br />Se non è specificata
+          nessuna data iniziale, l'aliquota d'imposta sarà disponibile immediatamente.<br
+          />Se non è specificata nessuna data finale, l'aliquota d'imposta non terminerà
+          mai
       spree/variant:
-        deleted: 
-        deleted_explanation: 
-        deleted_explanation_with_replacement: 
-        tax_category: 
+        deleted: Variante eliminata
+        deleted_explanation: Questa variante è stata eliminata il %{date}.
+        deleted_explanation_with_replacement: Questa variante è stata eliminata il
+          %{date}. È stata sostituita da un'altra con lo stesso SKU.
+        tax_category: 'Questo determina quale tipo di tassazione è applicata a questa
+          variante.<br/>Predefinito: Usa la categoria di tassazione del prodotto associato
+          a questa variante'
     home: Home
     i18n:
-      available_locales: Lingue Disponibili
+      available_locales: Lingue disponibili
       fields: Campi
       language: Lingua
       locales_displayed_on_frontend_select_box: Lingue selezionabili nel frontend
@@ -1480,17 +1492,19 @@ it:
       this_file_language: Italiano (IT)
       translations: Traduzioni
     icon: Icona
-    id: 
-    identifier: 
+    id: ID
+    identifier: Identificativo
     image: Immagine
     images: Immagini
-    implement_eligible_for_return: 
-    implement_requires_manual_intervention: 
+    implement_eligible_for_return: 'Devi implementare #eligible_for_return? per il
+      tuo EligibilityValidator.'
+    implement_requires_manual_intervention: 'Devi implementare #requires_manual_intervention?
+      per il tuo EligibilityValidator.'
     inactive: Inattivo
     incl: incl.
     included_in_price: Incluso nel prezzo
     included_price_validation: non può essere selezionato senza aver impostato una
-      Zona di Tassazione di Default
+      Zona di Tassazione predefinita
     incomplete: incompleto
     info_number_of_skus_not_shown:
       one: e un'altra
@@ -1498,31 +1512,29 @@ it:
     info_product_has_multiple_skus: 'Questo prodotto ha %{count} varianti:'
     instructions_to_reset_password: Per favore inserisci la tua email nel form sottostante
     insufficient_stock: Scorte insufficienti, ne rimangono solo %{on_hand}
-    insufficient_stock_for_order: 
-    insufficient_stock_lines_present: Alcune linee di questo ordine hanno quantità
-      insufficiente.
+    insufficient_stock_for_order: Scorte insufficienti per l'ordine
+    insufficient_stock_lines_present: Alcune linee di questo ordine hanno scorte insufficienti.
     intercept_email_address: Intercetta indirizzo Email
     intercept_email_instructions: Sovrascrivi il destinatario dell'email con questo
       indirizzo.
     internal_name: Nome Interno
     invalid_credit_card: Carta di Credito non valida.
     invalid_exchange_variant: Variante di cambio non valida.
-    invalid_payment_method_type: 
+    invalid_payment_method_type: Tipo di metodo di pagamento non valido.
     invalid_payment_provider: Provider del pagamento non valido.
     invalid_promotion_action: Azione della promozione non valida.
     invalid_promotion_rule: Regola della promozione non valida.
-    invalidate: 
+    invalidate: Invalidare
     inventory: Inventario
     inventory_adjustment: Variazione dell'inventario
-    inventory_canceled: 
-    inventory_error_flash_for_insufficient_quantity: Un articolo del tuo carrello
-      non è più disponibile.
-    inventory_not_available: 
+    inventory_canceled: Inventario cancellato
+    inventory_error_flash_for_insufficient_quantity: "%{names} non disponibile."
+    inventory_not_available: Inventario non disponibile
     inventory_state: Stato Inventario
     inventory_states:
-      backordered: 
+      backordered: ordinato anche se terminato
       canceled: annullato
-      on_hand: 
+      on_hand: disponibile
       returned: restituito
       shipped: spedito
     is_not_available_to_shipment_address: non è disponibile per l'indirizzo di spedizione
@@ -1579,8 +1591,8 @@ it:
     manage_variants: Gestisci le Varianti
     manual_intervention_required: È richiesto un'intervento manuale
     master_price: Prezzo principale
-    master_sku: 
-    master_variant: 
+    master_sku: Master SKU
+    master_variant: Variante principale
     match_choices:
       all: Tutti
       none: Nessuno
@@ -1591,8 +1603,8 @@ it:
     meta_keywords: Meta Keywords
     meta_title: Meta Title
     metadata: Metadata
-    minimal_amount: Quantità minima
-    modify_stock_count: 
+    minimal_amount: Importo minimo
+    modify_stock_count: Modifica numero scorte
     month: Mese
     more: Ancora
     move_stock_between_locations: Trasferisci Scorte tra Magazzini
@@ -1601,7 +1613,8 @@ it:
     name: Nome
     name_on_card: Nome sulla carta
     name_or_sku: Nome o SKU (inserisci almeno i primi 4 caratteri del nome del prodotto)
-    negative_movement_absent_item: 
+    negative_movement_absent_item: Impossibile creare movimento negativo per articoli
+      magazzino assenti.
     new: Nuovo
     new_adjustment: Nuova Variazione
     new_adjustment_reason: Nuovo motivo di modifica
@@ -1617,7 +1630,7 @@ it:
     new_product: Nuovo Prodotto
     new_promotion: Nuova Promozione
     new_promotion_category: Nuova Categoria Promozione
-    new_promotion_code_batch: 
+    new_promotion_code_batch: Nuovo lotto codici promozione
     new_property: Nuova Proprietà
     new_prototype: Nuovo Prototipo
     new_refund: Nuovo
@@ -1631,11 +1644,11 @@ it:
     new_stock_location: Nuovo Magazzino
     new_stock_movement: Nuovo Movimento di Magazzino
     new_stock_transfer: Nuovo Trasferimento di Magazzino
-    new_store: 
-    new_store_credit: 
+    new_store: Nuovo negozio
+    new_store_credit: Nuovo credito negozio
     new_tax_category: Nuova Categoria di Tassazione
     new_tax_rate: Nuova Aliquota
-    new_taxon: Nuovo Taxon
+    new_taxon: Nuova categoria
     new_taxonomy: Nuova Tassonomia
     new_tracker: Nuovo Tracker
     new_user: Nuovo Utente
@@ -1644,39 +1657,41 @@ it:
     next: Prossimo
     no_actions_added: Nessuna azione aggiunta
     no_images_found: Nessuna immagine
-    no_inventory_selected: 
-    no_option_values_on_product_html: 
-    no_orders_found: 
+    no_inventory_selected: Nessun inventario selezionato
+    no_option_values_on_product_html: Questo prodotto non ha nessun valore opzioni
+      associato. Aggiungine qualcuno attraverso Tipi opzione in %{link}.
+    no_orders_found: Nessun ordine trovato
     no_payment_found: Nessun pagamento trovato
-    no_payment_methods_found: 
+    no_payment_methods_found: Nessun metodo di pagamento trovato
     no_pending_payments: Nessun pagamento pendente
     no_products_found: Nessun prodotto trovato
-    no_promotions_found: 
+    no_promotions_found: Nessuna promozione trovata
     no_resource: Nessuna risorsa
     no_resource_found: Nessun %{resource} trovato
-    no_resource_found_html: 
+    no_resource_found_html: Nessun %{resource} trovato, %{add_one_link}!
     no_resource_found_link: Aggiungine Uno
     no_results: Nessun risultato
-    no_returns_found: Nessuna restituazione trovata
+    no_returns_found: Nessuna restituzione trovata
     no_rules_added: Nessuna regola aggiunta
     no_shipping_method_selected: Nessun metodo di spedizione selezionato.
-    no_shipping_methods_found: 
+    no_shipping_methods_found: Nessun metodo di spedizione trovato
     no_state_changes: Nessun cambio di stato
-    no_stock_locations_found: 
-    no_trackers_found: 
+    no_stock_locations_found: Nessun magazzino trovato
+    no_trackers_found: Nessun tracker trovato
     no_tracking_present: Non sono stati forniti dettagli sul tracciamento
-    no_variants_found: 
-    no_variants_found_try_again: 
+    no_variants_found: Nessuna variante trovata
+    no_variants_found_try_again: Nessuna variante trovata. Prova a cambiare la tua
+      ricerca.
     none: Niente
     none_selected: Nessuno selezionato
-    normal_amount: Quantità Normale
+    normal_amount: Importo Normale
     not: 'no'
     not_available: Non disponibile
     not_enough_stock: Non ci sono abbastanza scorte nel magazzino di partenza per
       completare questo trasferimento.
     not_found: "%{resource} non trovato"
     note: Nota
-    note_already_received_a_refund: 
+    note_already_received_a_refund:
     notice_messages:
       product_cloned: Il prodotto è stato clonato
       product_deleted: Il prodotto è stato eliminato
@@ -1686,7 +1701,7 @@ it:
       variant_not_deleted: La variante non può essere eliminata
     num_orders: "# Ordini"
     number: Numero
-    number_of_codes: 
+    number_of_codes: "%{count} codici"
     on_hand: Disponibilità
     open: Apri
     open_all_adjustments: Apri tutte le variazioni
@@ -1701,19 +1716,17 @@ it:
     or_over_price: "%{price} o maggiore"
     order: Ordine
     order_adjustments: Variazioni dell'ordine
-    order_already_completed: 
+    order_already_completed: L'ordine è già completato
     order_already_updated: L'ordine è già stato aggiornato.
     order_approved: Ordine Approvato
     order_canceled: Ordine Annullato
-    order_completed: 
+    order_completed: Ordine completato
     order_details: Dettagli Ordine
     order_email_resent: Email dell'ordine inviata nuovamente
     order_information: Informazioni sull'Ordine
     order_mailer:
       cancel_email:
-        dear_customer: 'Gentile Cliente,
-
-'
+        dear_customer: Gentile Cliente,
         instructions: Il tuo ordine è stato ANNULLATO. Per favore conserva queste
           informazioni per attestare l'annullamento.
         order_summary_canceled: Riassunto Ordine [ANNULLATO]
@@ -1721,9 +1734,7 @@ it:
         subtotal: 'Subtotale:'
         total: 'Totale Ordine:'
       confirm_email:
-        dear_customer: 'Gentile Cliente,
-
-'
+        dear_customer: Gentile Cliente,
         instructions: Per favore rivedi queste informazioni e conservale come riferimento.
         order_summary: Riassunto Ordine
         subject: Conferma Ordine
@@ -1731,20 +1742,21 @@ it:
         thanks: Grazie per il tuo ordine.
         total: 'Totale Ordine:'
       inventory_cancellation:
-        dear_customer: 'Gentile Cliente,
-
-'
-        instructions: 
-        order_summary_canceled: 
-        subject: 
-    order_mutex_admin_error: 
-    order_mutex_error: 
+        dear_customer: Gentile Cliente,
+        instructions: Alcuni articoli nel tuo ordine sono stati CANCELLATI. Per favore
+          mantieni questa informativa per i tuoi documenti.
+        order_summary_canceled: Articoli cancellati
+        subject: Cancellazione di articoli
+    order_mutex_admin_error: L'ordine è stato modificato da qualcun altro. Per favore
+      riprova ancora.
+    order_mutex_error: Qualcosa è andato storto. Per favore riprova ancora.
     order_not_found: Non abbiamo trovato il tuo ordine. Per favore riprova ancora.
     order_number: Ordine %{number}
-    order_please_refresh: 
+    order_please_refresh: L'ordine non è pronto per essere completato. Per favore
+      aggiorna i totali.
     order_processed_successfully: Il tuo ordine è stato processato con successo
-    order_ready_for_confirm: 
-    order_refresh_totals: 
+    order_ready_for_confirm: L'ordine è pronto per la conferma
+    order_refresh_totals: Aggiorna i totali
     order_resumed: Ordine Riattivato
     order_state:
       address: indirizzo
@@ -1763,7 +1775,7 @@ it:
     order_total: Totale Ordine
     order_updated: Ordine Aggiornato
     orders: Ordini
-    other_items_in_other: 
+    other_items_in_other: Altri articoli nell'ordine
     out_of_stock: Non disponibile
     overview: Panoramica
     package_from: pacco da
@@ -1776,14 +1788,15 @@ it:
     path: Percorso
     pay: paga
     payment: Pagamento
-    payment_amount: 
+    payment_amount: Importo pagamento
     payment_could_not_be_created: Il Pagamento non può essere creato.
     payment_identifier: Identificativo Pagamento
     payment_information: Informazioni Pagamento
     payment_method: Metodo di Pagamento
     payment_method_not_supported: Quel metodo di pagamento non è supportato. Per favore
       scegline un'altro.
-    payment_method_settings_warning: 
+    payment_method_settings_warning: Se stai cambiando il tipo di metodo di pagamento,
+      devi salvarlo prima che tu possa modificare le sue impostazioni
     payment_methods: Metodi di Pagamento
     payment_processing_failed: Il pagamento non è stato processato correttamente,
       per favore controlla i dati inseriti
@@ -1797,7 +1810,7 @@ it:
       completed: completato
       credit_owed: credito dovuto
       failed: fallito
-      invalid: 
+      invalid: invalido
       paid: pagato
       pending: in sospeso
       processing: in lavorazione
@@ -1805,8 +1818,8 @@ it:
     payment_updated: Pagamento Aggiornato
     payments: Pagamenti
     payments_failed_count:
-      one: 
-      other: 
+      one: 1 Pagamento
+      other: "%{count} Pagamenti"
     pending: in sospeso
     percent: Percentuale
     percent_per_item: Percentuale per articolo
@@ -1814,15 +1827,15 @@ it:
     phone: Telefono
     place_order: Completa Ordine
     please_define_payment_methods: Per favore definisci prima dei metodi di pagamento.
-    please_enter_reasonable_quantity: 
+    please_enter_reasonable_quantity: Per favore inserisci una quantità sensata
     populate_get_error: Qualcosa è andato storto. Per favore prova ad aggiungere di
       nuovo l'articolo.
     powered_by: Powered by
     pre_tax_amount: Importo al lordo delle tasse
     pre_tax_refund_amount: Importo Rimborso al lordo delle tasse
     pre_tax_total: Totale al lordo delle tasse
-    preference_source_none: 
-    preference_source_using: 
+    preference_source_none: "(custom)"
+    preference_source_using: Usare preferenze statiche "%{name}"
     preferred_reimbursement_type: Tipologia di rimborso preferita
     presentation: Presentazione
     previous: Precedente
@@ -1866,15 +1879,15 @@ it:
     promotion_category: Categoria Promozione
     promotion_code_batch_mailer:
       promotion_code_batch_errored:
-        message: 
-        subject: 
+        message: 'Il lotto di codici promozionali è fallito (%{error}) per la promozione: '
+        subject: Lotto di codici promozionali è fallito
       promotion_code_batch_finished:
-        message: 
-        subject: 
+        message: 'Tutti i %{number_of_codes} codici sono stati creati per la promozione: '
+        subject: Lotto di codici promozionali creato
     promotion_code_batches:
-      errored: 
-      finished: 
-      processing: 
+      errored: 'Errori: %{error}'
+      finished: Tutti i %{number_of_codes} codici sono stati creati.
+      processing: 'Processando: %{number_of_codes_processed} / %{number_of_codes}'
     promotion_form:
       match_policies:
         all: Rispetta tutte queste regole
@@ -1908,8 +1921,10 @@ it:
       user_logged_in:
         description: Disponibile solo per utenti autenticati
         name: L'utente ha effettuato il login
-    promotion_successfully_created: 
-    promotion_total_changed_before_complete: 
+    promotion_successfully_created: La promozione è stata creata con successo!
+    promotion_total_changed_before_complete: Una o più promozioni sul tuo ordine sono
+      diventate non applicabili e sono state rimosse. Per favore controlla gli importi
+      del nuovo ordine e riprova ancora.
     promotion_uses: Utilizzi Promozione
     promotionable: Promuovibile
     promotions: Promozioni
@@ -1927,27 +1942,27 @@ it:
     quantity_shipped: Quantità Spedita
     quick_search: Ricerca Veloce
     rate: Percentuale
-    ready_to_ship: 
+    ready_to_ship: Pronto per la spedizione
     reason: Motivazione
-    receive: ricevi
+    receive: Ricevi
     receive_stock: Ricevi Scorte
     received: Ricevuto
-    received_items: 
-    received_successfully: 
-    receiving: 
-    receiving_match: 
+    received_items: Articoli ricevuti
+    received_successfully: Ricevuto con successo
+    receiving: In ricezione
+    receiving_match:
     reception_states:
-      awaiting: 
-      cancelled: 
-      expired: 
-      given_to_customer: 
-      in_transit: 
-      lost_in_transit: 
-      received: 
-      shipped_wrong_item: 
-      short_shipped: 
-      unexchanged: 
-    reception_status: 
+      awaiting: in attesa
+      cancelled: annullato
+      expired: terminato
+      given_to_customer: dato al cliente
+      in_transit: in transito
+      lost_in_transit: perso in transito
+      received: ricevuto
+      shipped_wrong_item: spedito l'articolo sbagliato
+      short_shipped: spedito a breve
+      unexchanged: invariato
+    reception_status: Stato ricezione
     reference: Riferimento
     refund: Rimborso
     refund_amount_must_be_greater_than_zero: L'importo del rimborso deve essere maggiore
@@ -1974,9 +1989,9 @@ it:
     reimbursement_perform_failed: 'Il rimborso non può essere effettuato. Errore:
       %{error}'
     reimbursement_states:
-      errored: 
-      pending: 
-      reimbursed: 
+      errored: In errore
+      pending: Pendente
+      reimbursed: Rimborsato
     reimbursement_status: Stato Rimborso
     reimbursement_type: Tipologia Rimborso
     reimbursement_type_override: Override Tipologia Rimborso
@@ -1992,32 +2007,35 @@ it:
     resend: Rinvio
     reset_password: Resetta la mia password
     response_code: Codice di Risposta
-    restock_inventory: 
+    restock_inventory: rifornire l'inventario
     resume: Riattiva
     resumed: Riattivato
     return: ritorna
     return_authorization: Autorizzazione Restituzione
-    return_authorization_fire_error: 
+    return_authorization_fire_error: Impossibile eseguire questa azione alla restituzione
+      della merce
     return_authorization_reasons: Motivazioni Autorizzazione Restituzione
     return_authorization_states:
-      authorized: 
-      canceled: 
+      authorized: Autorizzato
+      canceled: Annullato
     return_authorization_updated: Autorizzazione Restituzione aggiornata
     return_authorizations: Autorizzazioni Restituzione
     return_item_inventory_unit_ineligible: L'unita di inventario dell'articolo reso
       deve essere spedita
     return_item_inventory_unit_reimbursed: L'unita di inventario dell'articolo è già
       stata rimborsata
-    return_item_order_not_completed: 
+    return_item_order_not_completed: L'ordine dell'articolo reso deve essere completato
     return_item_rma_ineligible: L'articolo reso richiede un RMA
     return_item_time_period_ineligible: L'articolo reso è fuori dal periodo idoneo
-    return_items: Articoli Reso
-    return_items_cannot_be_associated_with_multiple_orders: Gli articoli reso non
+    return_items: Articoli resi
+    return_items_cannot_be_associated_with_multiple_orders: Gli articoli resi non
       possono essere associati a ordini multipli.
-    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: 
+    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: Articoli
+      resi non possono essere creati per unità d'inventario che sono già in attesa
+      di un cambio.
     return_number: Numero Reso
     return_quantity: Quantità Reso
-    return_reasons: 
+    return_reasons: Motivi reso
     returned: Restituito
     returns: Resi
     review: Rivedi
@@ -2044,32 +2062,29 @@ it:
     secure_connection_type: Tipologia Connessione Sicura
     security_settings: Impostazioni Sicurezza
     select: Seleziona
-    select_a_reason: 
-    select_a_return_authorization_reason: Seleziona una motivazione di autorizzazione
-      reso
+    select_a_reason: Seleziona un motivo
+    select_a_return_authorization_reason: Seleziona un motivo di autorizzazione reso
     select_a_stock_location: Seleziona un Magazzino
     select_from_prototype: Seleziona da Prototipo
     select_stock: Seleziona Scorte
     selected_quantity_not_available: La quantità selezionata non è disponibile
     send_copy_of_all_mails_to: Invia una Copia di Tutte le Mail a
-    send_mailer: 
+    send_mailer: Send Mailer
     send_mails_as: Invia Mail come
     server: Server
     server_error: Il server ha ritornato un errore
     settings: Impostazioni
     ship: spedisci
     ship_address: Indirizzo di Spedizione
-    ship_address_required: 
+    ship_address_required: Indirizzo di spedizione obbligatorio
     ship_total: Totale Spedizione
     shipment: Spedizione
     shipment_adjustments: Variazioni spedizioni
-    shipment_date: 
+    shipment_date: Data di spedizione
     shipment_details: Da %{stock_location} via %{shipping_method}
     shipment_mailer:
       shipped_email:
-        dear_customer: 'Gentile Cliente,
-
-'
+        dear_customer: Gentile Cliente,
         instructions: Il tuo ordine è stato spedito
         shipment_summary: Riassunto Spedizione
         subject: Notifica di spedizione
@@ -2077,10 +2092,10 @@ it:
         track_information: 'Informazione Tracciamento: %{tracking}'
         track_link: 'Link Tracciamento: %{url}'
     shipment_number: Numero di spedizione
-    shipment_numbers: 
+    shipment_numbers: Numeri spedizione
     shipment_state: Stato Spedizione
     shipment_states:
-      backorder: arretrato
+      backorder: ordine anche se terminato
       canceled: annullato
       partial: parziale
       pending: in attesa
@@ -2090,7 +2105,7 @@ it:
     shipment_transfer_success: Varianti trasferite con successo
     shipments: Spedizioni
     shipped: Spedito
-    shipped_at: 
+    shipped_at: Spedito il
     shipping: Spedizione
     shipping_address: Indirizzo di Spedizione
     shipping_categories: Categorie di Spedizione
@@ -2104,12 +2119,12 @@ it:
     shipping_price_sack: Costo imballaggio
     shipping_rate:
       display_price:
-        display_price_with_explanations: 
-        tax_label_separator: 
+        display_price_with_explanations: "%{price} (%{explanations})"
+        tax_label_separator: ", "
     shipping_rate_tax:
       label:
-        sales_tax: 
-        vat: 
+        sales_tax: "+ %{amount} %{tax_rate_name}"
+        vat: incl. %{amount} %{tax_rate_name}
     shipping_total: Totale Spedizione
     shop_by_taxonomy: Acquista per %{taxonomy}
     shopping_cart: Carrello
@@ -2124,10 +2139,10 @@ it:
     skus: SKU
     slug: Slug
     source: Origine
-    source_location: 
+    source_location: Località origine
     special_instructions: Istruzioni Speciali
     split: Diviso
-    split_failed: 
+    split_failed: Impossibile completare la divisione
     spree_gateway_error_flash_for_checkout: Si è verificato un problema con le tue
       informazioni di pagamento. Per favore controlla le tue informazioni e prova
       ancora.
@@ -2143,7 +2158,7 @@ it:
       authorized: Autorizzato
       awaiting: In Attesa
       awaiting_return: In attesa di reso
-      backordered: Arretrato
+      backordered: Ordinato anche se terminato
       canceled: Annullato
       cart: Carrello
       checkout: Checkout
@@ -2171,22 +2186,22 @@ it:
       void: Nullo
     states: Stati
     states_count:
-      one: 
-      other: 
-    states_required: Stati Necessari
+      one: "%{count} Stato"
+      other: "%{count} Stati"
+    states_required: Stati necessari
     status: Stato
-    stock: Stock
+    stock: Scorte
     stock_location: Magazzino
     stock_location_info: Informazioni Magazzino
     stock_locations: Magazzini
-    stock_locations_need_a_default_country: Devi creare un paese dei default prima
+    stock_locations_need_a_default_country: Devi creare un paese predefinito prima
       di un magazzino.
     stock_management: Gestione Scorte
-    stock_management_requires_a_stock_location: Per favore crea un Magazzino per poter
+    stock_management_requires_a_stock_location: Per favore crea un magazzino per poter
       gestire le scorte.
-    stock_movements: Movimenti di Magazzino
+    stock_movements: Movimenti di magazzino
     stock_movements_for_stock_location: Movimenti di Magazzino per %{stock_location_name}
-    stock_not_below_zero: 
+    stock_not_below_zero: Scorte non negative
     stock_successfully_transferred: Le scorte sono state trasferito con successo.
     stock_transfer: Trasferimento di Magazzino
     stock_transfers: Trasferimenti di Magazzino
@@ -2194,39 +2209,43 @@ it:
     store: Negozio
     store_credit:
       actions:
-        invalidate: 
-      credit_allocation_memo: 
-      currency_mismatch: 
+        invalidate: Invalida
+      credit_allocation_memo: Questo è un credito dal credito negozio ID %{id}
+      currency_mismatch: La valuta del credito negozio non corrisponde alla valuta
+        dell'ordine
       display_action:
         adjustment: Variazione
         admin:
           authorize: Autorizzato
-          eligible: 
-          void: 
-        allocation: 
-        capture: 
+          eligible: Idoneità verificata
+          void: Nullo
+        allocation: Aggiunto
+        capture: Usato
         credit: Credito
-        invalidate: 
+        invalidate: Invalidato
         void: Credito
       errors:
-        cannot_invalidate_uncaptured_authorization: 
-        unable_to_fund: 
-      expiring: 
-      insufficient_authorized_amount: 
-      insufficient_funds: 
-      non_expiring: 
-      select_one_store_credit: 
-      store_credit: 
-      successful_action: 
-      unable_to_credit: 
-      unable_to_find: 
-      unable_to_find_for_action: 
-      unable_to_void: 
-      user_has_no_store_credits: 
+        cannot_invalidate_uncaptured_authorization: Impossibile invalidare un credito
+          negozio con un'autorizzazione non usata
+        unable_to_fund: Non è possibile pagare per l'ordine usando crediti negozio
+      expiring: in scadenza
+      insufficient_authorized_amount: Importo Autorizzato Insufficiente
+      insufficient_funds: fondi insufficienti
+      non_expiring: non in scadenza
+      select_one_store_credit: Seleziona un credito negozio per completare l'importo
+        rimanente
+      store_credit: Credito negozio
+      successful_action: Credito negozio %{action} con successo
+      unable_to_credit: 'Impossibile accreditare codice: %{auth_code}'
+      unable_to_find: Impossibile trovare credito negozio
+      unable_to_find_for_action: 'Impossibile trovare credito negozio per l''auth
+        code: %{auth_code} per l''azione: %{action}'
+      unable_to_void: 'Impossibile usare codice: %{auth_code}'
+      user_has_no_store_credits: L'utente non ha nessun credito negozio disponibile
     store_credit_category:
       default: Default
     store_rule:
-      choose_stores: 
+      choose_stores: Scegli Negozi
     street_address: Indirizzo
     street_address_2: Indirizzo (agg.)
     subtotal: Totale
@@ -2247,15 +2266,15 @@ it:
     tax_rate_amount_explanation: Le aliquote sono specificate con valore decimale
       per facilitare le operazioni, (es. se l'aliquota è al 5% inserisci 0.05)
     tax_rates: Aliquote
-    taxon: Taxon
-    taxon_edit: Modifica Taxon
-    taxon_placeholder: Aggiungi Taxon
+    taxon: Categoria
+    taxon_edit: Modifica Categoria
+    taxon_placeholder: Aggiungi Categoria
     taxon_rule:
-      choose_taxons: Scegli Taxon
-      label: L?ordine deve contenere quantità x di queste taxon
+      choose_taxons: Scegli Categoria
+      label: L'ordine deve contenere quantità x di queste categorie
       match_all: tutte
       match_any: almeno una
-      match_none: 
+      match_none: nessuna
     taxonomies: Tassonomie
     taxonomy: Tassonomia
     taxonomy_edit: Modifica tassonomia
@@ -2263,7 +2282,7 @@ it:
       stato riportato allo stato precedente, per favore riprova.
     taxonomy_tree_instruction: "* Click destro su un nodo nell'albero per accedere
       al menu e aggiungere, rimuovere o ordinare."
-    taxons: Taxon
+    taxons: Categorie
     test: Test
     test_mailer:
       test_email:
@@ -2284,54 +2303,54 @@ it:
     tiered_percent: Tariffa Fissa a Percentuale
     tiers: Livelli
     time: Ora
-    to: 
+    to: a
     to_add_variants_you_must_first_define: Per aggiungere varianti, devi prima definire
     total: Totale
-    total_excluding_vat: 
+    total_excluding_vat: Totale al lordo delle tasse
     total_per_item: Totale per articolo
     total_pre_tax_refund: Totale Rimborso al lordo delle tasse
     total_price: Prezzo totale
     total_sales: Acquisti Totali
     track_inventory: Traccia Inventario
     tracking: Tracciamento
-    tracking_info: 
+    tracking_info: Informazioni tracciamento
     tracking_number: Codice Tracciamento
     tracking_url: URL Tracciamento
     tracking_url_placeholder: es. http://quickship.com/package?num=:tracking
     transaction_id: ID transazione
     transfer_from_location: Trasferisci Da
-    transfer_number: 
+    transfer_number: Numero trasferimento
     transfer_stock: Trasferisci Scorte
     transfer_to_location: Trasferisci A
     tree: Albero
-    try_changing_search_values: 
+    try_changing_search_values: Prova a cambiare la ricerca
     type: Tipo
     type_to_search: Digita per cercare
     unable_to_connect_to_gateway: Impossibile connettersi al gateway.
     unable_to_create_reimbursements: Impossibile creare rimborsi perché ci sono articoli
       in attesa di intervento manuale.
-    unable_to_find_all_inventory_units: 
+    unable_to_find_all_inventory_units: Impossibile trovare tutte le unità d'inventario
     under_price: Inferiore di %{price}
     unfinalize_all_adjustments: Annulla la registrazione
     unlock: Sblocca
     unrecognized_card_type: Carda di credito non riconosciuta
     unshippable_items: Impossibile spedire gli articoli
     update: Aggiorna
-    updated_successfully: 
+    updated_successfully: Aggiornato con successo
     updating: Aggiornando
     usage_limit: Limite di Utilizzo
     use_app_default: Usa il Default dell'App
     use_billing_address: Usa Indirizzo di Fatturazione
-    use_existing_cc: 
+    use_existing_cc: Usa una carta esistente
     use_new_cc: Usa una nuova carta
     use_new_cc_or_payment_method: Usa una nuova carta / Metodo di Pagamento
     use_s3: Usa Amazon S3 per le Immagini
     user: Utente
     user_role_rule:
-      choose_roles: 
-      label: 
-      match_all: 
-      match_any: 
+      choose_roles: Scegli ruoli
+      label: L'utente deve contenere %{select} di questi ruoli
+      match_all: tutti
+      match_any: almeno uno
     user_rule:
       choose_users: Scegli utenti
     users: Utenti
@@ -2347,26 +2366,26 @@ it:
       must_be_non_negative: deve essere un valore non negativo
       unpaid_amount_not_zero: 'L''importo non è stato completamente rimborsato. Rimangono:
         %{amount}'
-    validity_period: 
+    validity_period: periodo di validità
     value: Valore
     variant: Variante
     variant_placeholder: Scegli una variante
-    variant_pricing: 
+    variant_pricing: Prezzo variante
     variant_properties: Proprietà variante
-    variant_search: 
+    variant_search: Ricerca variante
     variant_search_placeholder: Cerca variante
-    variant_to_add: 
-    variant_to_be_received: 
+    variant_to_add: Variante da aggiungere
+    variant_to_be_received: Variante da ricevere
     variants: Varianti
     version: Versione
-    view_promotion_codes_list: 
+    view_promotion_codes_list: Visualizza lista codici promozione
     void: Annullato
     weight: Peso
     what_is_a_cvv: Cos'è il Codice CVV?
     what_is_this: Cos'è Questo?
     width: Larghezza
     year: Anno
-    you_cannot_undo_action: 
+    you_cannot_undo_action: Non puoi annullare l'azione
     you_have_no_orders_yet: Non hai alcun ordine
     your_cart_is_empty: Il tuo carrello è vuoto
     your_order_is_empty_add_product: Il tuo ordine è vuoto, per favore cerca e aggiungi
@@ -2378,5 +2397,5 @@ it:
   time:
     formats:
       solidus:
-        long: 
-        short: 
+        long: "%d %B, %Y %H:%M"
+        short: "%d %b '%y %H:%M"


### PR DESCRIPTION
Not 100% completed, but almost done.
This is done with the tasks provided and based on the current status (Solidus 2.7).

I think we don't need the devise translations (we had a PR to delete them https://github.com/solidusio/solidus_i18n/pull/107), but since we have them in the source file in the solidus project, they are added again.