### PR TITLE
Remove deprecated option from gemspec

### DIFF
--- a/solidus_i18n.gemspec
+++ b/solidus_i18n.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.has_rdoc = false
-
   s.add_runtime_dependency 'solidus_core', ['>= 1.1', '< 3']
 
   s.add_development_dependency 'pry-rails', '>= 0.3.0'


### PR DESCRIPTION
As from title. This option is deprecated without replacement. This change removes it and stops annoying warnings