### PR TITLE
Normalize translations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ before_install:
   - gem update --system # https://github.com/travis-ci/travis-ci/issues/8978
   - gem install bundler
 script:
+  - bundle exec i18n-tasks check-normalized
   - bundle exec rubocop
   - bundle exec rake

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1,1284 +1,1287 @@
+---
 bg:
   activerecord:
     attributes:
       spree/address:
-        address1: "Адрес"
-        address2: "Адрес (продъл.)"
-        city: "Град"
-        country: "Държава"
-        firstname: "Име"
-        lastname: "Фамилия"
-        phone: "Телефон"
-        state: "Област"
-        zipcode: "Пощенски код"
+        address1: Адрес
+        address2: Адрес (продъл.)
+        city: Град
+        country: Държава
+        firstname: Име
+        lastname: Фамилия
+        phone: Телефон
+        state: Област
+        zipcode: Пощенски код
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
         iso_name: ISO Име
-        name: "Име"
+        name: Име
         numcode: ISO Код
       spree/credit_card:
-        base:
+        base: 
         cc_type: Type
-        month: "Месец"
-        name:
-        number: "Номер"
-        verification_value: "Стойност за потвърждение"
-        year: "Година"
+        month: Месец
+        name: 
+        number: Номер
+        verification_value: Стойност за потвърждение
+        year: Година
       spree/inventory_unit:
         state: County Държава
       spree/line_item:
-        price: "Цена"
-        quantity: "Количество"
+        price: Цена
+        quantity: Количество
       spree/option_type:
-        name: "Име"
-        presentation: "Презентация"
+        name: Име
+        presentation: Презентация
       spree/order:
-        checkout_complete: "Завършена поръчка"
-        completed_at: "Завършена на"
-        considered_risky:
-        coupon_code: "Код на ваучер"
-        created_at: "Дата на поръчка"
-        email: "Клиентски и-мейл"
+        checkout_complete: Завършена поръчка
+        completed_at: Завършена на
+        considered_risky: 
+        coupon_code: Код на ваучер
+        created_at: Дата на поръчка
+        email: Клиентски и-мейл
         ip_address: IP Адрес
-        item_total: "Общо"
-        number: "Номер"
-        payment_state: "Състояние на плащане"
-        shipment_state: "Състояние на доставка"
-        special_instructions: "Специални инструкции"
-        state: "Държава"
-        total: "Общо"
+        item_total: Общо
+        number: Номер
+        payment_state: Състояние на плащане
+        shipment_state: Състояние на доставка
+        special_instructions: Специални инструкции
+        state: Държава
+        total: Общо
       spree/order/bill_address:
-        address1: "Адрес за плащане -улица"
-        city: "Адрес за плащане - град"
-        firstname: "първо име"
-        lastname: "фамилия"
-        phone: "тел. номер"
-        state: "община"
-        zipcode: "пощенски код"
+        address1: Адрес за плащане -улица
+        city: Адрес за плащане - град
+        firstname: първо име
+        lastname: фамилия
+        phone: тел. номер
+        state: община
+        zipcode: пощенски код
       spree/order/ship_address:
-        address1: "Адрес за доставка - улица"
-        city: "Адрес за доставка - град"
-        firstname: "Адрес за доставка -първо име"
-        lastname: "Адрес за доставка - фамилия"
-        phone: "Адрес за доставка - тел. номер"
+        address1: Адрес за доставка - улица
+        city: Адрес за доставка - град
+        firstname: Адрес за доставка -първо име
+        lastname: Адрес за доставка - фамилия
+        phone: Адрес за доставка - тел. номер
         state: county Адрес за доставка - община
-        zipcode: "Адрес за доставка - пощ. код"
+        zipcode: Адрес за доставка - пощ. код
       spree/payment:
-        amount: "Сума"
+        amount: Сума
       spree/payment_method:
-        name: "Име"
+        name: Име
       spree/product:
-        available_on: "В наличност от"
-        cost_currency: "Валута"
-        cost_price: "Цена"
-        description: "Описание"
-        master_price: "Крайна цена"
-        name: "Име"
-        on_hand: "В наличие"
-        shipping_category: "Доставна категория"
-        tax_category: "Данъчна категория"
+        available_on: В наличност от
+        cost_currency: Валута
+        cost_price: Цена
+        description: Описание
+        master_price: Крайна цена
+        name: Име
+        on_hand: В наличие
+        shipping_category: Доставна категория
+        tax_category: Данъчна категория
       spree/promotion:
-        advertise: "Рекламирай"
+        advertise: Рекламирай
         code: Code Код
-        description: "Описание"
-        event_name: "Име на акция"
-        expires_at: "Изтича на"
-        name: "Име"
-        path: "Път"
-        starts_at: "Започва на"
-        usage_limit: "Лимит"
+        description: Описание
+        event_name: Име на акция
+        expires_at: Изтича на
+        name: Име
+        path: Път
+        starts_at: Започва на
+        usage_limit: Лимит
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
-        name: "Име"
-        presentation: "Презентация"
+        name: Име
+        presentation: Презентация
       spree/prototype:
-        name: "Име"
+        name: Име
       spree/return_authorization:
-        amount: "Количество"
+        amount: Количество
       spree/role:
-        name: "Име"
+        name: Име
       spree/state:
-        abbr: "Съкращение"
-        name: "Име"
+        abbr: Съкращение
+        name: Име
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
-        description: "Описание"
-        name: "Име"
+        description: Описание
+        name: Име
       spree/tax_rate:
-        amount: "Процент"
-        included_in_price: "Включен в цената"
+        amount: Процент
+        included_in_price: Включен в цената
         show_rate_in_label: label Покажи процента в цената
       spree/taxon:
-        name: "Име"
+        name: Име
         permalink: Permalink
-        position: "Позиция"
+        position: Позиция
       spree/taxonomy:
-        name: "Име"
+        name: Име
       spree/user:
         email: l И-мейл
-        password: "Парола"
-        password_confirmation: "Повтори парола"
+        password: Парола
+        password_confirmation: Повтори парола
       spree/variant:
-        cost_currency: "Валута"
+        cost_currency: Валута
         cost_price: Price Цена
-        depth: "Дълбочина"
-        height: "Височина"
-        price: "Цена"
+        depth: Дълбочина
+        height: Височина
+        price: Цена
         sku: SKU
-        weight: "Тежест"
-        width: "Ширина"
+        weight: Тежест
+        width: Ширина
       spree/zone:
-        description: "Описание"
-        name: "Име"
+        description: Описание
+        name: Име
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired: "Картата е изтекла"
-              expiry_invalid:
+              card_expired: Картата е изтекла
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
-        one: "Адрес"
-        other: "Адреси"
+        one: Адрес
+        other: Адреси
       spree/country:
-        one: "Държава"
-        other: "Държави"
+        one: Държава
+        other: Държави
       spree/credit_card:
-        one: "Кредитна карта"
-        other: "Кредитни карти"
-      spree/customer_return:
+        one: Кредитна карта
+        other: Кредитни карти
+      spree/customer_return: 
       spree/inventory_unit:
-        one: "Складна единица"
-        other: "Складни единици"
-      spree/line_item:
-      spree/option_type:
-      spree/option_value:
+        one: Складна единица
+        other: Складни единици
+      spree/line_item: 
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
-        one: "Поръчка"
-        other: "Поръчки"
+        one: Поръчка
+        other: Поръчки
       spree/payment:
-        one: "Плащане"
-        other: "Плащания"
-      spree/payment_method:
+        one: Плащане
+        other: Плащания
+      spree/payment_method: 
       spree/product:
-        one: "Продукт"
-        other: "Продукти"
-      spree/promotion:
-      spree/promotion_category:
+        one: Продукт
+        other: Продукти
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
-        one: "Харатеристика"
-        other: "Характеристики"
+        one: Харатеристика
+        other: Характеристики
       spree/prototype:
-        one: "Прототип"
-        other: "Прототипи"
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+        one: Прототип
+        other: Прототипи
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
-        one: "Върни ауторизация"
-        other: "Върни ауторизации"
-      spree/return_authorization_reason:
+        one: Върни ауторизация
+        other: Върни ауторизации
+      spree/return_authorization_reason: 
       spree/role:
-        one: "Роли"
-        other: "Роли"
+        one: Роли
+        other: Роли
       spree/shipment:
-        one: "Доставка"
-        other: "Доставки"
+        one: Доставка
+        other: Доставки
       spree/shipping_category:
-        one: "Доставна категория"
-        other: "Доставни категории"
-      spree/shipping_method:
+        one: Доставна категория
+        other: Доставни категории
+      spree/shipping_method: 
       spree/state:
-        one: "Държава"
-        other: "Държави"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+        one: Държава
+        other: Държави
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
-        one: "Данъчна категория"
-        other: "Данъчна категория"
+        one: Данъчна категория
+        other: Данъчна категория
       spree/tax_rate:
-        one: "Данъчен процент"
-        other: "данъчни проценти"
-      spree/taxon:
-      spree/taxonomy:
-      spree/tracker:
+        one: Данъчен процент
+        other: данъчни проценти
+      spree/taxon: 
+      spree/taxonomy: 
+      spree/tracker: 
       spree/user:
-        one: "Потребител"
-        other: "Потребители"
+        one: Потребител
+        other: Потребители
       spree/variant:
-        one: "Вариант"
-        other: "Варианти"
+        one: Вариант
+        other: Варианти
       spree/zone:
         one: Zone Зона
-        other: "Зони"
+        other: Зони
   spree:
-    abbreviation: "Абривиатура"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
-    account: "Акаунт"
-    account_updated: "Акаунтът бе обновен!"
-    action: "Действие"
+    abbreviation: Абривиатура
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
+    account: Акаунт
+    account_updated: Акаунтът бе обновен!
+    action: Действие
     actions:
-      cancel: "Отмени"
-      continue: "Продължи"
-      create: "Създай"
-      destroy: "Унищожи"
-      edit: "Редактирай"
-      list: "Списък"
+      cancel: Отмени
+      continue: Продължи
+      create: Създай
+      destroy: Унищожи
+      edit: Редактирай
+      list: Списък
       listing: Listing
-      new: "Нов"
-      refund:
-      save: "Запази"
-      update: "Обновни"
-    activate: "Активирай"
-    active: "Активен"
-    add: "Добави"
-    add_action_of_type: "Добави действие от тип"
-    add_country: "Добави страна"
-    add_coupon_code:
-    add_new_header: "Добави нов хедър"
-    add_new_style: "Добави нов стил"
-    add_one: "Добави едно"
-    add_option_value: "Добави опционална стойност"
-    add_product: "Добави продукт"
-    add_product_properties: "Добави характеристики на продукт"
-    add_rule_of_type: "Добави правило от тип"
-    add_state: "Добави състояние"
-    add_stock: "добави стока"
-    add_stock_management: "Добави управление на стока"
-    add_to_cart: "Добави в кошницата"
-    add_variant: "Добави вариант"
+      new: Нов
+      refund: 
+      save: Запази
+      update: Обновни
+    activate: Активирай
+    active: Активен
+    add: Добави
+    add_action_of_type: Добави действие от тип
+    add_country: Добави страна
+    add_coupon_code: 
+    add_new_header: Добави нов хедър
+    add_new_style: Добави нов стил
+    add_one: Добави едно
+    add_option_value: Добави опционална стойност
+    add_product: Добави продукт
+    add_product_properties: Добави характеристики на продукт
+    add_rule_of_type: Добави правило от тип
+    add_state: Добави състояние
+    add_stock: добави стока
+    add_stock_management: Добави управление на стока
+    add_to_cart: Добави в кошницата
+    add_variant: Добави вариант
     additional_item: Additional Цена на артикул
-    address1: "Адрес"
-    address2: "Адрес (продължение)"
-    adjustable:
-    adjustment: "Поправка"
-    adjustment_amount: "Стойност"
-    adjustment_successfully_closed: "Поправката бе успешно затворена"
-    adjustment_successfully_opened: "Поправката бе успешно отворена"
-    adjustment_total: "Обща стойност на поправката"
-    adjustments: "Поправки"
+    address1: Адрес
+    address2: Адрес (продължение)
+    adjustable: 
+    adjustment: Поправка
+    adjustment_amount: Стойност
+    adjustment_successfully_closed: Поправката бе успешно затворена
+    adjustment_successfully_opened: Поправката бе успешно отворена
+    adjustment_total: Обща стойност на поправката
+    adjustments: Поправки
     admin:
       tab:
-        configuration: "Конфигурация"
-        option_types:
-        orders: "Поръчки"
-        overview: "Прегледай"
-        products: "Продукти"
-        promotions: "Промоции"
-        promotion_categories:
-        properties:
-        prototypes:
-        reports: "Доклади"
-        taxonomies:
-        taxons:
-        users: "Потребители"
+        configuration: Конфигурация
+        option_types: 
+        orders: Поръчки
+        overview: Прегледай
+        products: Продукти
+        promotion_categories: 
+        promotions: Промоции
+        properties: 
+        prototypes: 
+        reports: Доклади
+        taxonomies: 
+        taxons: 
+        users: Потребители
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
-    administration: "Администрация"
-    advertise:
-    agree_to_privacy_policy: "Съгласен съм с политиката за защита на лични данни"
-    agree_to_terms_of_service: "Съгласен съм с Общите условия"
-    all: "Всички"
-    all_adjustments_closed: "Всички промени завършени успешно!"
-    all_adjustments_opened: "Всички промени отворено успешно!"
-    all_departments: "Всички отдели"
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test: "Позволи SSL да бъде ползвано при тестов режим"
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
-    alt_text: "Алтернативен текст"
-    alternative_phone: "Алтернативен телефон"
-    amount: "Сума"
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
-    analytics_trackers:
-    and: "и"
-    approve:
-    approved_at:
-    approver:
-    are_you_sure: "Сигурни ли сте"
-    are_you_sure_delete: "Сигурни ли сте, че искате да изтриете този запис?"
-    associated_adjustment_closed:
-    at_symbol: '@'
-    authorization_failure:
-    authorized:
-    auto_capture:
-    available_on:
-    average_order_value:
-    avs_response:
-    back:
-    back_end:
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
-    back_to_store:
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
-    balance_due:
-    base_amount:
-    base_percent:
-    bill_address: "Адрес на плащане"
-    billing: "Плащане"
-    billing_address: "Адрес на плащане"
-    both: "И двете"
-    calculated_reimbursements:
-    calculator: "Калкулатор"
-    calculator_settings_warning:
-    cancel:
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: "Не може да платите без да сте избрали начин на плащане"
-    cannot_create_returns: "Не можете да върнете стока обратно преди поръчката да е пусната."
-    cannot_perform_operation: "Желаното действие не може да бъде извършено."
-    cannot_set_shipping_method_without_address: "Начин за доставка не може да бъде зададен без данни на клиента."
-    capture: "Картина"
-    capture_events:
-    card_code: "Код на карта"
-    card_number: "Номер на карта"
-    card_type:
-    card_type_is: "Видът на картата"
-    cart: "Кошница"
-    cart_subtotal:
-    categories: "Категории"
-    category: "Категория"
-    charged:
-    check_for_spree_alerts:
-    checkout: "Плащане"
-    choose_a_customer: "Избери клиент"
-    choose_a_taxon_to_sort_products_for:
-    choose_currency: "Избери валута"
-    choose_dashboard_locale:
-    choose_location:
-    city: "Град"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
-    clone: "Клонирай"
-    close: "Затвори"
-    close_all_adjustments: "Затвори всички промени"
-    code: "Код"
-    company: "Компания"
-    complete: "Завърши"
-    configuration: "Конфигурация"
-    configurations: "Конфигурации"
-    confirm: "Потвърди"
-    confirm_delete: "Потвърди изтриване"
-    confirm_password: "Потвърди парола"
-    continue: "Продължи"
-    continue_shopping: "Продължи пазаруването"
-    cost_currency: "Валута"
-    cost_price:
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
-    country: "Страна"
-    country_based:
-    country_name: "Име"
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
+    administration: Администрация
+    advertise: 
+    agree_to_privacy_policy: Съгласен съм с политиката за защита на лични данни
+    agree_to_terms_of_service: Съгласен съм с Общите условия
+    all: Всички
+    all_adjustments_closed: Всички промени завършени успешно!
+    all_adjustments_opened: Всички промени отворено успешно!
+    all_departments: Всички отдели
+    all_items_have_been_returned: 
+    allow_ssl_in_development_and_test: Позволи SSL да бъде ползвано при тестов режим
+    allow_ssl_in_production: 
+    allow_ssl_in_staging: 
+    already_signed_up_for_analytics: 
+    alt_text: Алтернативен текст
+    alternative_phone: Алтернативен телефон
+    amount: Сума
+    analytics_desc_header_1: 
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
+    analytics_trackers: 
+    and: и
+    approve: 
+    approved_at: 
+    approver: 
+    are_you_sure: Сигурни ли сте
+    are_you_sure_delete: Сигурни ли сте, че искате да изтриете този запис?
+    associated_adjustment_closed: 
+    at_symbol: "@"
+    authorization_failure: 
+    authorized: 
+    auto_capture: 
+    available_on: 
+    average_order_value: 
+    avs_response: 
+    back: 
+    back_end: 
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
+    back_to_store: 
+    back_to_users_list: 
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
+    balance_due: 
+    base_amount: 
+    base_percent: 
+    bill_address: Адрес на плащане
+    billing: Плащане
+    billing_address: Адрес на плащане
+    both: И двете
+    calculated_reimbursements: 
+    calculator: Калкулатор
+    calculator_settings_warning: 
+    cancel: 
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: Не може да платите без да сте избрали начин на плащане
+    cannot_create_returns: Не можете да върнете стока обратно преди поръчката да е пусната.
+    cannot_perform_operation: Желаното действие не може да бъде извършено.
+    cannot_set_shipping_method_without_address: Начин за доставка не може да бъде зададен без данни на клиента.
+    capture: Картина
+    capture_events: 
+    card_code: Код на карта
+    card_number: Номер на карта
+    card_type: 
+    card_type_is: Видът на картата
+    cart: Кошница
+    cart_subtotal: 
+    categories: Категории
+    category: Категория
+    charged: 
+    check_for_spree_alerts: 
+    checkout: Плащане
+    choose_a_customer: Избери клиент
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: Избери валута
+    choose_dashboard_locale: 
+    choose_location: 
+    city: Град
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
+    clone: Клонирай
+    close: Затвори
+    close_all_adjustments: Затвори всички промени
+    code: Код
+    company: Компания
+    complete: Завърши
+    configuration: Конфигурация
+    configurations: Конфигурации
+    confirm: Потвърди
+    confirm_delete: Потвърди изтриване
+    confirm_password: Потвърди парола
+    continue: Продължи
+    continue_shopping: Продължи пазаруването
+    cost_currency: Валута
+    cost_price: 
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
+    countries: 
+    country: Страна
+    country_based: 
+    country_name: Име
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon: "Ваучер"
-    coupon_code: "Код на ваучер"
-    coupon_code_already_applied: "Този код вече е използван за тази доставка."
-    coupon_code_applied: "Този код бе успешно приложен към вашата поръчка"
-    coupon_code_better_exists: "Предишният ваучер предоставя по-добри условия"
-    coupon_code_expired: "Този ваучер е изтекъл"
-    coupon_code_max_usage: "Употребата на ваучери преминава лимита."
-    coupon_code_not_eligible: "Този код не е валиден за тази поръчка."
-    coupon_code_not_found: "Въведеният код не е валиден. Опитайте отново."
-    coupon_code_unknown_error:
-    create: "Създай"
-    create_a_new_account: "Създай нов акаунт"
-    create_new_order:
-    create_reimbursement:
-    created_at: "Създаден на"
-    credit: "Кредит"
-    credit_card: "Кредитна карта"
-    credit_cards: "Кредитни карти"
-    credit_owed: "Дължима сума по кредит"
-    credits:
-    currency: "Валута"
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
-    current:
-    current_promotion_usage:
-    customer:
-    customer_details:
-    customer_details_updated:
-    customer_return:
-    customer_returns:
-    customer_search:
-    cut:
-    cvv_response:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
+    coupon: Ваучер
+    coupon_code: Код на ваучер
+    coupon_code_already_applied: Този код вече е използван за тази доставка.
+    coupon_code_applied: Този код бе успешно приложен към вашата поръчка
+    coupon_code_better_exists: Предишният ваучер предоставя по-добри условия
+    coupon_code_expired: Този ваучер е изтекъл
+    coupon_code_max_usage: Употребата на ваучери преминава лимита.
+    coupon_code_not_eligible: Този код не е валиден за тази поръчка.
+    coupon_code_not_found: Въведеният код не е валиден. Опитайте отново.
+    coupon_code_unknown_error: 
+    create: Създай
+    create_a_new_account: Създай нов акаунт
+    create_new_order: 
+    create_reimbursement: 
+    created_at: Създаден на
+    credit: Кредит
+    credit_card: Кредитна карта
+    credit_cards: Кредитни карти
+    credit_owed: Дължима сума по кредит
+    credits: 
+    currency: Валута
+    currency_decimal_mark: 
+    currency_settings: 
+    currency_symbol_position: 
+    currency_thousands_separator: 
+    current: 
+    current_promotion_usage: 
+    customer: 
+    customer_details: 
+    customer_details_updated: 
+    customer_return: 
+    customer_returns: 
+    customer_search: 
+    cut: 
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
-    date_completed:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: 
+    date_completed: 
     date_picker:
       first_day: 0
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
-    date_range:
-    default:
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
-    delete: "Изтрий"
-    deleted_variants_present:
-    delivery:
-    depth:
-    description:
-    destination:
-    destroy:
-    details:
-    discount_amount:
-    dismiss_banner:
-    display:
-    display_currency:
-    doesnt_track_inventory:
-    edit:
-    editing_resource:
-    editing_rma_reason:
-    editing_user:
+    date_range: 
+    default: 
+    default_refund_amount: 
+    default_tax: 
+    default_tax_zone: 
+    delete: Изтрий
+    deleted_variants_present: 
+    delivery: 
+    depth: 
+    description: 
+    destination: 
+    destroy: 
+    details: 
+    discount_amount: 
+    dismiss_banner: 
+    display: 
+    display_currency: 
+    doesnt_track_inventory: 
+    edit: 
+    editing_resource: 
+    editing_rma_reason: 
+    editing_user: 
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email:
-    empty:
-    empty_cart:
-    enable_mail_delivery: "Позволи изпращане по поща"
-    end: "Край"
-    ending_in: "Приключване в"
-    environment: "среда"
-    error: "грешка"
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
+    email: 
+    empty: 
+    empty_cart: 
+    enable_mail_delivery: Позволи изпращане по поща
+    end: Край
+    ending_in: Приключване в
+    environment: среда
+    error: грешка
     errors:
       messages:
-        could_not_create_taxon: "Провал в създаването на група"
-        no_payment_methods_available: "Няма методи за заплащане конфигурирани за тази среда"
-        no_shipping_methods_available: "Няма възможност за изпращане по куриер до избраната локация, моля сменете адреса си и пробвайте пак."
+        could_not_create_taxon: Провал в създаването на група
+        no_payment_methods_available: Няма методи за заплащане конфигурирани за тази среда
+        no_shipping_methods_available: Няма възможност за изпращане по куриер до избраната локация, моля сменете адреса си и пробвайте пак.
     errors_prohibited_this_record_from_being_saved:
-      one: "Грешка попречи на тези дани да бъдат записани."
+      one: Грешка попречи на тези дани да бъдат записани.
       other: "%{count} errors prohibited this record from being saved"
-    event: "Събитие"
+    event: Събитие
     events:
       spree:
         cart:
-          add: "Добави към количка"
+          add: Добави към количка
         checkout:
-          coupon_code_added: "Купон за остъпка прибавен"
+          coupon_code_added: Купон за остъпка прибавен
         content:
-          visited: "Посети статична страница с данни"
+          visited: Посети статична страница с данни
         order:
-          contents_changed: "Реда на съдържанието променее"
-        page_view: "Статична страница видяна"
+          contents_changed: Реда на съдържанието променее
+        page_view: Статична страница видяна
         user:
-          signup: "Потребителски вход"
+          signup: Потребителски вход
     exceptions:
-      count_on_hand_setter: "Грешка при ръчното обновяването на count_on_hand, тъй като бе обновено от повик към recalculate_count_on_hand. Моля използвайте`update_column(:count_on_hand, value)` вместо това."
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
-    expiration: "Срок на годност"
-    extension: "Удъжения"
-    failed_payment_attempts:
-    filename: "Име на файл"
-    fill_in_customer_info: "Моля попълнете потребителска информация"
-    filter_results: "Филтриране на резултатите"
-    finalize: "Финализирай"
-    finalized:
-    find_a_taxon:
-    first_item: "Цена на първи предмет"
-    first_name: "Първо име"
-    first_name_begins_with: "Първо име  започва с"
-    flat_percent: "Плосък процент"
-    flat_rate_per_order: "Пропорционална такса (на поръчка)"
-    flexible_rate: "Гъвкав курс"
-    forgot_password: "Забравена парола"
-    free_shipping: "Безплатна доставка"
-    free_shipping_amount:
-    front_end: "Преден Край"
-    gateway: "Портал"
-    gateway_config_unavailable: "Порталът не е на разположение за тази среда"
-    gateway_error: "Грешка в портала"
-    general: "Генерален"
-    general_settings: "Генерални настройки"
+      count_on_hand_setter: >-
+        Грешка при ръчното обновяването на count_on_hand, тъй като бе обновено от повик към recalculate_count_on_hand. Моля използвайте`update_column(:count_on_hand,
+        value)` вместо това.
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
+    expiration: Срок на годност
+    extension: Удъжения
+    failed_payment_attempts: 
+    filename: Име на файл
+    fill_in_customer_info: Моля попълнете потребителска информация
+    filter_results: Филтриране на резултатите
+    finalize: Финализирай
+    finalized: 
+    find_a_taxon: 
+    first_item: Цена на първи предмет
+    first_name: Първо име
+    first_name_begins_with: Първо име  започва с
+    flat_percent: Плосък процент
+    flat_rate_per_order: Пропорционална такса (на поръчка)
+    flexible_rate: Гъвкав курс
+    forgot_password: Забравена парола
+    free_shipping: Безплатна доставка
+    free_shipping_amount: 
+    front_end: Преден Край
+    gateway: Портал
+    gateway_config_unavailable: Порталът не е на разположение за тази среда
+    gateway_error: Грешка в портала
+    general: Генерален
+    general_settings: Генерални настройки
     google_analytics: Google Аналитика
-    google_analytics_id: "Идентифиционен номер на аналитиката"
-    guest_checkout: "Каса за гости"
-    guest_user_account: "Маркирай като гост."
-    has_no_shipped_units: "Няма пратени единици."
-    height: "Височина"
+    google_analytics_id: Идентифиционен номер на аналитиката
+    guest_checkout: Каса за гости
+    guest_user_account: Маркирай като гост.
+    has_no_shipped_units: Няма пратени единици.
+    height: Височина
     hide_cents: Hide pence
-    home: "Дом"
+    home: Дом
     i18n:
-      available_locales: "Достъпни места"
-      language: "Език"
-      localization_settings: "Настройки за локализация"
-      this_file_language: "Български (БГ)"
-    icon: "Икона"
-    identifier:
-    image: "Образ"
-    images: "Образи"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price: "Включено в цената"
-    included_price_validation: "Не може да бъде избрано докато не изберете подходяща област"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password:
-    insufficient_stock: "Недостатъчно количество стока в наличност, само %{on_hand} остават."
-    insufficient_stock_lines_present:
-    intercept_email_address: "Пресрещане на имеил адрес"
-    intercept_email_instructions: "Отемни сегашните имеил приемници и замени с този адрес."
-    internal_name: "Вътрешно име."
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider: "Невалиден разплащателен метод."
-    invalid_promotion_action: "Невалидна промоционална дейност."
-    invalid_promotion_rule: "Невалидно промоционално правило."
-    inventory: "Инвентар"
-    inventory_adjustment: "Наглацяне на инвентара"
-    inventory_error_flash_for_insufficient_quantity: "Количествата на предмет във вашата кошница се изчерпаха."
-    inventory_state:
-    is_not_available_to_shipment_address: "Не е достъпно до адрес на доставка"
+      available_locales: Достъпни места
+      language: Език
+      localization_settings: Настройки за локализация
+      this_file_language: Български (БГ)
+    icon: Икона
+    identifier: 
+    image: Образ
+    images: Образи
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: Включено в цената
+    included_price_validation: Не може да бъде избрано докато не изберете подходяща област
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
+    instructions_to_reset_password: 
+    insufficient_stock: Недостатъчно количество стока в наличност, само %{on_hand} остават.
+    insufficient_stock_lines_present: 
+    intercept_email_address: Пресрещане на имеил адрес
+    intercept_email_instructions: Отемни сегашните имеил приемници и замени с този адрес.
+    internal_name: Вътрешно име.
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: Невалиден разплащателен метод.
+    invalid_promotion_action: Невалидна промоционална дейност.
+    invalid_promotion_rule: Невалидно промоционално правило.
+    inventory: Инвентар
+    inventory_adjustment: Наглацяне на инвентара
+    inventory_error_flash_for_insufficient_quantity: Количествата на предмет във вашата кошница се изчерпаха.
+    inventory_state: 
+    is_not_available_to_shipment_address: Не е достъпно до адрес на доставка
     iso_name: Iso Име
-    item: "Предмет"
-    item_description: "Описание на предмет"
-    item_total: "Количество"
+    item: Предмет
+    item_description: Описание на предмет
+    item_total: Количество
     item_total_rule:
       operators:
-        gt: "повече ог"
-        gte: "повече от или равно на"
-        lt:
-        lte:
-    items_cannot_be_shipped: "Нямаме възможносттта да доставим тези предмети до този адрес. Моля изберете друг адрес на доставка."
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe: "Жираф"
+        gt: повече ог
+        gte: повече от или равно на
+        lt: 
+        lte: 
+    items_cannot_be_shipped: Нямаме възможносттта да доставим тези предмети до този адрес. Моля изберете друг адрес на доставка.
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
+    jirafe: Жираф
     landing_page_rule:
-      path: "Път"
-    last_name: "Последно име"
-    last_name_begins_with: "Последното име започва с"
-    learn_more: "Научи повече"
-    lifetime_stats:
-    line_item_adjustments:
-    list: "Списък"
-    loading: "Зареждане"
-    locale_changed: "Местоположение сменено"
-    location: "Местоположение"
-    lock: "Закючи"
-    log_entries:
-    logged_in_as: "Влезте като"
-    logged_in_succesfully: "Успешно влизане"
-    logged_out: "Успешен изход."
-    login: "Вход"
-    login_as_existing: "Влезте като настоящ клиент"
-    login_failed: "Неуспешно за установяване на автентичността."
-    login_name: "Потребителско име"
-    logout: "Изход"
-    logs:
-    look_for_similar_items: "Потърси за подобни предмети"
-    make_refund: "Въстановяване на сума"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
-    master_price: "Главна сума"
+      path: Път
+    last_name: Последно име
+    last_name_begins_with: Последното име започва с
+    learn_more: Научи повече
+    lifetime_stats: 
+    line_item_adjustments: 
+    list: Списък
+    loading: Зареждане
+    locale_changed: Местоположение сменено
+    location: Местоположение
+    lock: Закючи
+    log_entries: 
+    logged_in_as: Влезте като
+    logged_in_succesfully: Успешно влизане
+    logged_out: Успешен изход.
+    login: Вход
+    login_as_existing: Влезте като настоящ клиент
+    login_failed: Неуспешно за установяване на автентичността.
+    login_name: Потребителско име
+    logout: Изход
+    logs: 
+    look_for_similar_items: Потърси за подобни предмети
+    make_refund: Въстановяване на сума
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
+    master_price: Главна сума
     match_choices:
-      all: "Всички"
-      none: "Никои"
-    max_items: "Максимален брой предмети"
-    member_since:
-    memo:
-    meta_description: "Описание"
-    meta_keywords: "Ключови думи"
-    meta_title:
-    metadata: "Дата"
-    minimal_amount: "Минимално количество"
-    month: "Месец"
-    more: "Още"
-    move_stock_between_locations: "Премести стока между местоположения."
-    my_account: "Моя профил"
-    my_orders: "Моите поръчки"
-    name: "Име"
-    name_on_card:
-    name_or_sku: "Име или Идентификационен номер на продукт"
-    new: "Име"
-    new_adjustment: "Ново нагалсяне"
-    new_country:
-    new_customer: "Нов клиент"
-    new_customer_return:
-    new_image: "Нов образ"
-    new_option_type: "Нов метод за настойки"
-    new_order: "Нова поръчка"
-    new_order_completed: "Нава поръчка завършена"
-    new_payment: "Ново заплащане"
-    new_payment_method: "Нов метод за заплащане"
-    new_product: "Нов продукт"
-    new_promotion: "Нова промоция"
-    new_promotion_category:
-    new_property: "Ново свойство"
-    new_prototype: "Нов прототип"
-    new_refund:
-    new_refund_reason:
-    new_return_authorization: "Нов метод за оторизиране на връщане"
-    new_rma_reason:
-    new_shipment_at_location:
-    new_shipping_category: "Нова категория за доставки"
-    new_shipping_method: "Нов метод за доставки"
-    new_state: "Ново състояние"
-    new_stock_location: "Ново местоположение на стока"
-    new_stock_movement: "Ново преместване на стока"
-    new_stock_transfer: "Нов трансфер на стока"
-    new_tax_category: "Нова категория такси"
-    new_tax_rate: "Новa dанъчна ставка"
-    new_taxon: "Нов таксон"
-    new_taxonomy: "Нова таксономия"
-    new_tracker: "Нов тракер"
-    new_user: "Нов потребител"
-    new_variant: "Нов вариант"
-    new_zone: "Нова зона"
-    next: "Следващ"
-    no_actions_added: "Няма избрани дейности"
-    no_payment_found:
-    no_pending_payments: "Няма настоящи плащания"
-    no_products_found: "Няма открити пордукти"
-    no_resource_found:
-    no_results: "Няма резилтати"
-    no_returns_found:
-    no_rules_added: "Никакви правила прибавени"
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present: "Няма информация за следене"
-    none: "Нищо"
-    none_selected:
-    normal_amount: "Нормално количество"
-    not: "не"
-    not_available: "Няма в наличност"
-    not_enough_stock: "Няма достатъчно налични количества в стока да се извърши поръчката."
+      all: Всички
+      none: Никои
+    max_items: Максимален брой предмети
+    member_since: 
+    memo: 
+    meta_description: Описание
+    meta_keywords: Ключови думи
+    meta_title: 
+    metadata: Дата
+    minimal_amount: Минимално количество
+    month: Месец
+    more: Още
+    move_stock_between_locations: Премести стока между местоположения.
+    my_account: Моя профил
+    my_orders: Моите поръчки
+    name: Име
+    name_on_card: 
+    name_or_sku: Име или Идентификационен номер на продукт
+    new: Име
+    new_adjustment: Ново нагалсяне
+    new_country: 
+    new_customer: Нов клиент
+    new_customer_return: 
+    new_image: Нов образ
+    new_option_type: Нов метод за настойки
+    new_order: Нова поръчка
+    new_order_completed: Нава поръчка завършена
+    new_payment: Ново заплащане
+    new_payment_method: Нов метод за заплащане
+    new_product: Нов продукт
+    new_promotion: Нова промоция
+    new_promotion_category: 
+    new_property: Ново свойство
+    new_prototype: Нов прототип
+    new_refund: 
+    new_refund_reason: 
+    new_return_authorization: Нов метод за оторизиране на връщане
+    new_rma_reason: 
+    new_shipment_at_location: 
+    new_shipping_category: Нова категория за доставки
+    new_shipping_method: Нов метод за доставки
+    new_state: Ново състояние
+    new_stock_location: Ново местоположение на стока
+    new_stock_movement: Ново преместване на стока
+    new_stock_transfer: Нов трансфер на стока
+    new_tax_category: Нова категория такси
+    new_tax_rate: Новa dанъчна ставка
+    new_taxon: Нов таксон
+    new_taxonomy: Нова таксономия
+    new_tracker: Нов тракер
+    new_user: Нов потребител
+    new_variant: Нов вариант
+    new_zone: Нова зона
+    next: Следващ
+    no_actions_added: Няма избрани дейности
+    no_payment_found: 
+    no_pending_payments: Няма настоящи плащания
+    no_products_found: Няма открити пордукти
+    no_resource_found: 
+    no_results: Няма резилтати
+    no_returns_found: 
+    no_rules_added: Никакви правила прибавени
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: Няма информация за следене
+    none: Нищо
+    none_selected: 
+    normal_amount: Нормално количество
+    not: не
+    not_available: Няма в наличност
+    not_enough_stock: Няма достатъчно налични количества в стока да се извърши поръчката.
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
-      product_cloned: "Продуктът бе дупликиран"
-      product_deleted: "Продуктът беше изтрит"
-      product_not_cloned: "Продуктът не бе клониран"
-      product_not_deleted: "Продуктът не можеше да бъде изтрит"
-      variant_deleted: "Вариантът бе изтрит"
-      variant_not_deleted: "Вариантът не можеше да бъде изтрит"
-    num_orders:
-    on_hand: "Наличност"
-    open:
-    open_all_adjustments:
-    option_type:
-    option_type_placeholder:
-    option_types:
-    option_value:
-    option_values:
-    optional:
-    options:
-    or:
-    or_over_price:
-    order:
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
-    order_details:
-    order_email_resent:
-    order_information:
+      product_cloned: Продуктът бе дупликиран
+      product_deleted: Продуктът беше изтрит
+      product_not_cloned: Продуктът не бе клониран
+      product_not_deleted: Продуктът не можеше да бъде изтрит
+      variant_deleted: Вариантът бе изтрит
+      variant_not_deleted: Вариантът не можеше да бъде изтрит
+    num_orders: 
+    on_hand: Наличност
+    open: 
+    open_all_adjustments: 
+    option_type: 
+    option_type_placeholder: 
+    option_types: 
+    option_value: 
+    option_values: 
+    optional: 
+    options: 
+    or: 
+    or_over_price: 
+    order: 
+    order_adjustments: 
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
+    order_details: 
+    order_email_resent: 
+    order_information: 
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: 
+        instructions: 
+        order_summary_canceled: 
+        subject: 
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
-    order_processed_successfully:
-    order_resumed:
+        dear_customer: 
+        instructions: 
+        order_summary: 
+        subject: 
+        subtotal: 
+        thanks: 
+        total: 
+    order_not_found: 
+    order_number: 
+    order_processed_successfully: 
+    order_resumed: 
     order_state:
-      address:
-      awaiting_return:
-      canceled: "отказано"
-      cart: "количка"
-      complete: "завършено"
-      confirm: "потвърди"
-      considered_risky:
-      delivery: "доставка"
-      payment: "плащане"
-      resumed: "възобновено"
-      returned: "върнато"
-    order_summary: "Преглед на поръчка"
-    order_sure_want_to:
-    order_total: "Цялостна стойност"
-    order_updated: "Поръчката бе обновена"
-    orders: "Поръчки"
-    other_items_in_other:
-    out_of_stock: "Не е в наличност"
-    overview: "Преглед"
+      address: 
+      awaiting_return: 
+      canceled: отказано
+      cart: количка
+      complete: завършено
+      confirm: потвърди
+      considered_risky: 
+      delivery: доставка
+      payment: плащане
+      resumed: възобновено
+      returned: върнато
+    order_summary: Преглед на поръчка
+    order_sure_want_to: 
+    order_total: Цялостна стойност
+    order_updated: Поръчката бе обновена
+    orders: Поръчки
+    other_items_in_other: 
+    out_of_stock: Не е в наличност
+    overview: Преглед
     package_from: package from
     pagination:
       next_page: next page »
       previous_page: "« previous page"
       truncate: "…"
-    password: "Парола"
-    paste: "Постави"
-    path: "Път"
-    pay: "Плати"
-    payment: "Плащане"
-    payment_could_not_be_created:
-    payment_identifier:
-    payment_information: "Информация за плащане"
-    payment_method: "Начин на плащане"
-    payment_method_not_supported:
-    payment_methods: "Методи на плащане"
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
-    payment_state: "Статус на плащането"
+    password: Парола
+    paste: Постави
+    path: Път
+    pay: Плати
+    payment: Плащане
+    payment_could_not_be_created: 
+    payment_identifier: 
+    payment_information: Информация за плащане
+    payment_method: Начин на плащане
+    payment_method_not_supported: 
+    payment_methods: Методи на плащане
+    payment_processing_failed: 
+    payment_processor_choose_banner_text: 
+    payment_processor_choose_link: 
+    payment_state: Статус на плащането
     payment_states:
-      balance_due:
-      checkout:
-      completed:
-      credit_owed:
-      failed: "провалено"
-      paid:
-      pending:
-      processing:
-      void:
-    payment_updated: "Плащането бе обновено"
-    payments: "Плащания"
-    pending:
-    percent: "Процент"
-    percent_per_item:
+      balance_due: 
+      checkout: 
+      completed: 
+      credit_owed: 
+      failed: провалено
+      paid: 
+      pending: 
+      processing: 
+      void: 
+    payment_updated: Плащането бе обновено
+    payments: Плащания
+    pending: 
+    percent: Процент
+    percent_per_item: 
     permalink: Permalink
-    phone: "Телефон"
-    place_order: "Направи поръчка"
-    please_define_payment_methods: "Моля, първо дефинирайте методи за плащане."
-    populate_get_error:
-    powered_by: "Уебсайтът е задвижван от"
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
-    presentation:
-    previous: "Предходен"
-    previous_state_missing:
-    price: "Цена"
-    price_range:
-    price_sack:
-    process: "Продукт"
+    phone: Телефон
+    place_order: Направи поръчка
+    please_define_payment_methods: Моля, първо дефинирайте методи за плащане.
+    populate_get_error: 
+    powered_by: Уебсайтът е задвижван от
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
+    presentation: 
+    previous: Предходен
+    previous_state_missing: 
+    price: Цена
+    price_range: 
+    price_sack: 
+    process: Продукт
     product: Product
-    product_details: "Информация за продукта"
-    product_has_no_description:
-    product_not_available_in_this_currency:
-    product_properties:
+    product_details: Информация за продукта
+    product_has_no_description: 
+    product_not_available_in_this_currency: 
+    product_properties: 
     product_rule:
-      choose_products: "Избери продукти"
-      label:
-      match_all: "всички"
-      match_any: "поне един"
-      match_none:
+      choose_products: Избери продукти
+      label: 
+      match_all: всички
+      match_any: поне един
+      match_none: 
       product_source:
-        group: "От продуктова група"
-        manual: "Избери ръчно"
-    products: "Продукти"
-    promotion:
-    promotion_action:
+        group: От продуктова група
+        manual: Избери ръчно
+    products: Продукти
+    promotion: 
+    promotion_action: 
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: 
+        name: 
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: 
+        name: 
+    promotion_actions: 
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: 
+        any: 
+    promotion_rule: 
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: 
+        name: 
       item_total:
-        description:
-        name:
+        description: 
+        name: 
       landing_page:
-        description: "Потребителят трябва да е посетил определена страница"
-        name: "Целева страница"
+        description: Потребителят трябва да е посетил определена страница
+        name: Целева страница
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description: "Поръчката има следният/ите продукт(и)"
-        name: "Продукт(и)"
+        description: Поръчката има следният/ите продукт(и)
+        name: Продукт(и)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
-        description: "Достъпно само за определени потребители"
-        name: "Потребител"
+        description: Достъпно само за определени потребители
+        name: Потребител
       user_logged_in:
-        description: "Достъпно само за потребители, които са влезли в сайта"
-        name: "Потребителят е влязал в сайта"
-    promotion_uses:
-    promotionable:
-    promotions:
-    propagate_all_variants:
-    properties:
-    property:
-    prototype:
-    prototypes: "Прототипи"
-    provider: "Доставчик"
-    provider_settings_warning:
-    qty: "Кол."
-    quantity: "Количество"
-    quantity_returned: "Количество върнато"
-    quantity_shipped: "Количество пратено"
-    quick_search:
+        description: Достъпно само за потребители, които са влезли в сайта
+        name: Потребителят е влязал в сайта
+    promotion_uses: 
+    promotionable: 
+    promotions: 
+    propagate_all_variants: 
+    properties: 
+    property: 
+    prototype: 
+    prototypes: Прототипи
+    provider: Доставчик
+    provider_settings_warning: 
+    qty: Кол.
+    quantity: Количество
+    quantity_returned: Количество върнато
+    quantity_shipped: Количество пратено
+    quick_search: 
     rate: Rate
-    reason: "Причина"
-    receive: "получи"
-    receive_stock:
-    received: "Получено"
-    reception_status:
-    reference:
-    refund:
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
-    register: "Регистрирай се като нов потребител"
-    registration: "Регистрация"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reason: Причина
+    receive: получи
+    receive_stock: 
+    received: Получено
+    reception_status: 
+    reference: 
+    refund: 
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
+    register: Регистрирай се като нов потребител
+    registration: Регистрация
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
-    remember_me: "Запомни ме"
-    remove: "Премахни"
-    rename: "Преименувай"
-    report:
-    reports:
-    resend: "Препрати"
-    reset_password: "Възстанови паролата"
-    response_code:
-    resume: "продължи"
-    resumed: "Продължено"
-    return: "върни"
-    return_authorization:
-    return_authorization_reasons:
-    return_authorization_updated:
-    return_authorizations:
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity:
-    returned:
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit:
-    rma_number:
-    rma_value:
-    roles: "Роли"
-    rules: "ПРавила"
-    safe:
-    sales_total:
-    sales_total_description:
-    sales_totals:
-    save_and_continue:
-    save_my_address:
-    say_no: "Не"
-    say_yes: "Да"
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
+    remember_me: Запомни ме
+    remove: Премахни
+    rename: Преименувай
+    report: 
+    reports: 
+    resend: Препрати
+    reset_password: Възстанови паролата
+    response_code: 
+    resume: продължи
+    resumed: Продължено
+    return: върни
+    return_authorization: 
+    return_authorization_reasons: 
+    return_authorization_updated: 
+    return_authorizations: 
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
+    return_quantity: 
+    returned: 
+    returns: 
+    review: 
+    risk: 
+    risk_analysis: 
+    risky: 
+    rma_credit: 
+    rma_number: 
+    rma_value: 
+    roles: Роли
+    rules: ПРавила
+    safe: 
+    sales_total: 
+    sales_total_description: 
+    sales_totals: 
+    save_and_continue: 
+    save_my_address: 
+    say_no: Не
+    say_yes: Да
     scope: Scope
-    search: "Търси"
-    search_results: "Резултати за '%{keywords}'"
-    searching: "Търсене"
-    secure_connection_type:
-    security_settings:
-    select:
-    select_a_return_authorization_reason:
-    select_a_stock_location:
-    select_from_prototype:
-    select_stock:
-    send_copy_of_all_mails_to:
-    send_mails_as:
-    server: "Сървър"
-    server_error: "Сървърът върна грешла"
-    settings: "Настройки"
-    ship: "прати"
-    ship_address: "Адрес"
-    ship_total: "Общо"
-    shipment: "Доставка"
-    shipment_adjustments:
-    shipment_details:
+    search: Търси
+    search_results: Резултати за '%{keywords}'
+    searching: Търсене
+    secure_connection_type: 
+    security_settings: 
+    select: 
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
+    select_from_prototype: 
+    select_stock: 
+    send_copy_of_all_mails_to: 
+    send_mails_as: 
+    server: Сървър
+    server_error: Сървърът върна грешла
+    settings: Настройки
+    ship: прати
+    ship_address: Адрес
+    ship_total: Общо
+    shipment: Доставка
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer: "Драги клиент"
-        instructions: "Вашата поръчка е пусната"
-        shipment_summary: "Обзор на поръчката"
+        dear_customer: Драги клиент
+        instructions: Вашата поръчка е пусната
+        shipment_summary: Обзор на поръчката
         subject: Shipment  Нотификация
-        thanks: "Благодарим Ви!"
-        track_information:
-        track_link:
-    shipment_state: "Положение на пратката"
+        thanks: Благодарим Ви!
+        track_information: 
+        track_link: 
+    shipment_state: Положение на пратката
     shipment_states:
-      backorder: "неизпълнена"
-      canceled:
-      partial: "частична"
-      pending: "изчакваща"
-      ready: "готова"
-      shipped: "пратена"
-    shipment_transfer_error:
-    shipment_transfer_success:
-    shipments:
-    shipped: "пратена"
-    shipping: "Пратки"
-    shipping_address: "Адрес на доставка"
-    shipping_categories: "Катергории за доставки"
-    shipping_category: "Категория за доставка"
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
-    shipping_instructions:
-    shipping_method:
-    shipping_methods:
-    shipping_price_sack:
-    shipping_total:
-    shop_by_taxonomy:
-    shopping_cart:
-    show:
-    show_active:
-    show_deleted:
-    show_only_complete_orders:
-    show_only_considered_risky:
-    show_rate_in_label:
-    sku:
-    skus:
-    slug:
-    source:
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+      backorder: неизпълнена
+      canceled: 
+      partial: частична
+      pending: изчакваща
+      ready: готова
+      shipped: пратена
+    shipment_transfer_error: 
+    shipment_transfer_success: 
+    shipments: 
+    shipped: пратена
+    shipping: Пратки
+    shipping_address: Адрес на доставка
+    shipping_categories: Катергории за доставки
+    shipping_category: Категория за доставка
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
+    shipping_instructions: 
+    shipping_method: 
+    shipping_methods: 
+    shipping_price_sack: 
+    shipping_total: 
+    shop_by_taxonomy: 
+    shopping_cart: 
+    show: 
+    show_active: 
+    show_deleted: 
+    show_only_complete_orders: 
+    show_only_considered_risky: 
+    show_rate_in_label: 
+    sku: 
+    skus: 
+    slug: 
+    source: 
+    special_instructions: 
+    split: 
+    spree_gateway_error_flash_for_checkout: 
     ssl:
-      change_protocol:
-    start:
-    state:
-    state_based:
+      change_protocol: 
+    start: 
+    state: 
+    state_based: 
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states:
-    states_required:
-    status:
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
-    stop:
-    store:
-    street_address:
-    street_address_2:
-    subtotal:
-    subtract:
-    success:
-    successfully_created:
-    successfully_refunded:
-    successfully_removed:
-    successfully_signed_up_for_analytics:
-    successfully_updated:
-    summary:
-    tax:
-    tax_categories:
-    tax_category:
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
-    tax_rates:
-    taxon:
-    taxon_edit: "Промени таксон"
-    taxon_placeholder: "Добави таксон"
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
+    states: 
+    states_required: 
+    status: 
+    stock: 
+    stock_location: 
+    stock_location_info: 
+    stock_locations: 
+    stock_locations_need_a_default_country: 
+    stock_management: 
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
+    stock_transfer: 
+    stock_transfers: 
+    stop: 
+    store: 
+    street_address: 
+    street_address_2: 
+    subtotal: 
+    subtract: 
+    success: 
+    successfully_created: 
+    successfully_refunded: 
+    successfully_removed: 
+    successfully_signed_up_for_analytics: 
+    successfully_updated: 
+    summary: 
+    tax: 
+    tax_categories: 
+    tax_category: 
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
+    tax_rates: 
+    taxon: 
+    taxon_edit: Промени таксон
+    taxon_placeholder: Добави таксон
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
-    taxonomies: "Таксономии"
-    taxonomy: "Таксономия"
-    taxonomy_edit: "Промени таксономия"
-    taxonomy_tree_error:
-    taxonomy_tree_instruction:
-    taxons: "Таксони"
-    test: "Тест"
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
+    taxonomies: Таксономии
+    taxonomy: Таксономия
+    taxonomy_edit: Промени таксономия
+    taxonomy_tree_error: 
+    taxonomy_tree_instruction: 
+    taxons: Таксони
+    test: Тест
     test_mailer:
       test_email:
-        greeting:
-        message:
-        subject:
-    test_mode:
-    thank_you_for_your_order:
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields:
-    this_order_has_already_received_a_refund:
-    thumbnail:
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time: "Време"
-    to_add_variants_you_must_first_define: "За да добавите варианти, трябва да дефинирате"
-    total: "Общо"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
-    tracking:
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock: "Трансферирай запаси"
-    transfer_to_location: "Трансферирай към"
-    tree: "Дърво"
-    type: "Тип"
-    type_to_search: "Тип на търсене"
-    unable_to_connect_to_gateway:
-    unable_to_create_reimbursements:
-    under_price: "Под %{price}"
-    unlock: "Отключи"
-    unrecognized_card_type: "Неразпознат тип карта"
-    unshippable_items: "Неизпращаеми артикули"
-    update: "Обнови"
-    updating: "Обновване"
-    usage_limit: "Лимит на ползване"
-    use_app_default:
-    use_billing_address: "Използвай адрес за фактуриране"
-    use_new_cc: "Използвай нова карта"
-    use_s3: "Използвай Amazon S3 за изображения"
+        greeting: 
+        message: 
+        subject: 
+    test_mode: 
+    thank_you_for_your_order: 
+    there_are_no_items_for_this_order: 
+    there_were_problems_with_the_following_fields: 
+    this_order_has_already_received_a_refund: 
+    thumbnail: 
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: Време
+    to_add_variants_you_must_first_define: За да добавите варианти, трябва да дефинирате
+    total: Общо
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
+    tracking: 
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: Трансферирай запаси
+    transfer_to_location: Трансферирай към
+    tree: Дърво
+    type: Тип
+    type_to_search: Тип на търсене
+    unable_to_connect_to_gateway: 
+    unable_to_create_reimbursements: 
+    under_price: Под %{price}
+    unlock: Отключи
+    unrecognized_card_type: Неразпознат тип карта
+    unshippable_items: Неизпращаеми артикули
+    update: Обнови
+    updating: Обновване
+    usage_limit: Лимит на ползване
+    use_app_default: 
+    use_billing_address: Използвай адрес за фактуриране
+    use_new_cc: Използвай нова карта
+    use_s3: Използвай Amazon S3 за изображения
     user: User
     user_rule:
-      choose_users: "Изберете потребители"
-    users: "Потребители"
+      choose_users: Изберете потребители
+    users: Потребители
     validation:
-      cannot_be_less_than_shipped_units: "не може да бъде по-малко от броя на изпратените единици"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock: "е над наличността. Моля, уверете че уговорните покупки имат валидна стойност."
-      is_too_large: "е прекалено голяма --  наличността не достига!"
-      must_be_int: "трябва да е цяло число"
-      must_be_non_negative: "трябва да е позитивна стойност"
-      unpaid_amount_not_zero:
-    value: "Стойност"
-    variant: "Вариант"
-    variant_placeholder: "Избери вариант"
-    variants: "Варианти"
-    version: "Версия"
-    void: "Откажи"
-    weight: "Тежест"
-    what_is_a_cvv: "Какво е CVV код?"
-    what_is_this: "Какво е това?"
-    width: "Ширина"
-    year: "Година"
-    you_have_no_orders_yet: "Все още нямате поръчки"
-    your_cart_is_empty: "Вашата кошница е празна"
-    your_order_is_empty_add_product: "Вашата кошница е празна, моля добаете артикули"
-    zip: "пощ. кид"
-    zipcode: "пощ. код"
-    zone: "Зона"
-    zones: "Зони"
+      cannot_be_less_than_shipped_units: не може да бъде по-малко от броя на изпратените единици
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: е над наличността. Моля, уверете че уговорните покупки имат валидна стойност.
+      is_too_large: е прекалено голяма --  наличността не достига!
+      must_be_int: трябва да е цяло число
+      must_be_non_negative: трябва да е позитивна стойност
+      unpaid_amount_not_zero: 
+    value: Стойност
+    variant: Вариант
+    variant_placeholder: Избери вариант
+    variants: Варианти
+    version: Версия
+    void: Откажи
+    weight: Тежест
+    what_is_a_cvv: Какво е CVV код?
+    what_is_this: Какво е това?
+    width: Ширина
+    year: Година
+    you_have_no_orders_yet: Все още нямате поръчки
+    your_cart_is_empty: Вашата кошница е празна
+    your_order_is_empty_add_product: Вашата кошница е празна, моля добаете артикули
+    zip: пощ. кид
+    zipcode: пощ. код
+    zone: Зона
+    zones: Зони

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,3 +1,4 @@
+---
 ca:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ ca:
         state: Estat
         zipcode: Codi postal
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +25,10 @@ ca:
         name: Nom
         numcode: Codi ISO
       spree/credit_card:
-        base:
+        base: 
         cc_type: Tipus
         month: Mes
-        name:
+        name: 
         number: Nombre
         verification_value: Codi de verificació
         year: Any
@@ -37,17 +38,17 @@ ca:
         price: Preu
         quantity: Quantitat
       spree/option_type:
-        name:
-        presentation:
+        name: 
+        presentation: 
       spree/order:
         checkout_complete: Comanda completada
         completed_at: Completat el
-        considered_risky:
-        coupon_code:
+        considered_risky: 
+        coupon_code: 
         created_at: Data Comanda
-        email:
+        email: 
         ip_address: Adreça IP
-        item_total:
+        item_total: 
         number: Nombre
         payment_state: Estat Pagament
         shipment_state: Estat Enviament
@@ -55,25 +56,25 @@ ca:
         state: Estat
         total: Total
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/payment:
-        amount:
+        amount: 
       spree/payment_method:
-        name:
+        name: 
       spree/product:
         available_on: Disponible en
         cost_currency: Cost Moneda
@@ -95,7 +96,7 @@ ca:
         starts_at: Comença el
         usage_limit: Límit d'ús
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Nom
         presentation: Presentació
@@ -109,20 +110,20 @@ ca:
         abbr: Abreviatura
         name: Nom
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Descripció
         name: Nom
@@ -157,47 +158,47 @@ ca:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Adreça
@@ -208,40 +209,40 @@ ca:
       spree/credit_card:
         one: Targeta de crèdit
         other: Targetes de crèdit
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Unitat en inventari
         other: Unitats en inventari
       spree/line_item:
         one: Article
         other: Articles
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Comanda
         other: Comandes
       spree/payment:
         one: Pagament
         other: Pagaments
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Producte
         other: Productes
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
         one: Propietat
         other: Propietats
       spree/prototype:
         one: Prototip
         other: Prototips
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Autorització de devolució
         other: Autoritzacions de devolució
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Funció
         other: Funcions
@@ -251,14 +252,14 @@ ca:
       spree/shipping_category:
         one: Categoria d'enviament
         other: Categories de enviament
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: Estat
         other: Estats
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Categoria d'impostos
         other: Categories d'impostos
@@ -271,22 +272,22 @@ ca:
       spree/taxonomy:
         one: Propietat
         other: Propietats
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: Usuari
         other: Usuaris
       spree/variant:
-        one:
-        other:
+        one: 
+        other: 
       spree/zone:
         one: Zona
-        other:
+        other: 
   spree:
     abbreviation: Abreviatura
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Compte
     account_updated: Explica actualitzada!
     action: Acció
@@ -299,15 +300,15 @@ ca:
       list: Llesta
       listing: Llistat
       new: Nova
-      refund:
-      save:
+      refund: 
+      save: 
       update: Actualitzar
     activate: Activate
     active: Actiu
     add: Afegir
     add_action_of_type: Add action of type
     add_country: Afegir País
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Add New Header
     add_new_style: Add New Style
     add_one: Afegeix un
@@ -316,138 +317,138 @@ ca:
     add_product_properties: Afegir propietats de producte
     add_rule_of_type: Afegir regla de tipus
     add_state: Afegir província
-    add_stock:
-    add_stock_management:
+    add_stock: 
+    add_stock_management: 
     add_to_cart: Afegir al carret
-    add_variant:
+    add_variant: 
     additional_item: Cost addicional per element
     address1: Adreça
     address2: Adreça(cont.)
-    adjustable:
+    adjustable: 
     adjustment: Ajust
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: 
+    adjustment_successfully_closed: 
+    adjustment_successfully_opened: 
     adjustment_total: Ajust total
     adjustments: Ajustos
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administració
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: 
+    agree_to_privacy_policy: 
+    agree_to_terms_of_service: 
     all: Tots
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: 
+    all_adjustments_opened: 
     all_departments: Tots els departaments
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
+    all_items_have_been_returned: 
+    allow_ssl_in_development_and_test: 
+    allow_ssl_in_production: 
+    allow_ssl_in_staging: 
+    already_signed_up_for_analytics: 
     alt_text: Text alternatiu
     alternative_phone: Telèfon alternatiu
     amount: Quantia
     analytics_desc_header_1: Spree Analytics
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
     analytics_trackers: Trackers de Google Analytics
-    and:
-    approve:
-    approved_at:
-    approver:
+    and: 
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Està segur?
     are_you_sure_delete: Està segur que vol eliminar aquesta entrada?
-    associated_adjustment_closed:
-    at_symbol: '@'
+    associated_adjustment_closed: 
+    at_symbol: "@"
     authorization_failure: Fallada d'autorització
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Disponible en
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Enrere
     back_end: Part Interna
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Tornar a la tenda
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_users_list: 
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Saldo pendent
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Adreça de facturació
     billing: Facturació
     billing_address: Adreça de facturació
     both: tots dos
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Calculadora
     calculator_settings_warning: Si està canviant el tipus de calculadora, ha de guardar la seva selecció abans d'editar la seva configuració
     cancel: Cancel·lar
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: 
     cannot_create_returns: No pot crear-se la devolució ja que aquest demanat encara no ha estat enviat.
     cannot_perform_operation: No pot realitzar-se l'operació
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: 
     capture: captura
-    capture_events:
+    capture_events: 
     card_code: Codi de la targeta
     card_number: Nombre de targeta
-    card_type:
+    card_type: 
     card_type_is: Tipus de targeta
     cart: Carret
-    cart_subtotal:
+    cart_subtotal: 
     categories: Categories
     category: Categoria
-    charged:
-    check_for_spree_alerts:
+    charged: 
+    check_for_spree_alerts: 
     checkout: Pagar
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: 
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 
+    choose_dashboard_locale: 
+    choose_location: 
     city: Ciutat
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Clonar
     close: Tanca
-    close_all_adjustments:
+    close_all_adjustments: 
     code: Codi
-    company:
+    company: 
     complete: complet
     configuration: Configuració
     configurations: Configuracions
@@ -456,109 +457,109 @@ ca:
     confirm_password: Confirmi la contrasenya
     continue: Continuar
     continue_shopping: Seguir comprant
-    cost_currency:
+    cost_currency: 
     cost_price: Preu del Cost
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
     countries: Països
     country: País
     country_based: País basi
     country_name: Nom
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Cupó
     coupon_code: Codi de cupó
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_already_applied: 
+    coupon_code_applied: 
+    coupon_code_better_exists: 
+    coupon_code_expired: 
+    coupon_code_max_usage: 
+    coupon_code_not_eligible: 
+    coupon_code_not_found: 
+    coupon_code_unknown_error: 
     create: Crear
     create_a_new_account: Crear un nou compte
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: 
+    create_reimbursement: 
+    created_at: 
     credit: Crèdit
     credit_card: Targeta de crèdit
-    credit_cards:
+    credit_cards: 
     credit_owed: Crèdit disponible
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credits: 
+    currency: 
+    currency_decimal_mark: 
+    currency_settings: 
+    currency_symbol_position: 
+    currency_thousands_separator: 
     current: Actual
-    current_promotion_usage:
+    current_promotion_usage: 
     customer: Client
     customer_details: Detalls del client
-    customer_details_updated:
-    customer_return:
-    customer_returns:
+    customer_details_updated: 
+    customer_return: 
+    customer_returns: 
     customer_search: Cerca de clients
-    cut:
-    cvv_response:
+    cut: 
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
     date: Data
-    date_completed:
+    date_completed: 
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 
+      format: 
+      js_format: 
     date_range: Rang de Data
     default: Per omissió
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default_refund_amount: 
+    default_tax: 
+    default_tax_zone: 
     delete: Eliminar
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Enviament
     depth: Profunditat
     description: Descripció
-    destination:
+    destination: 
     destroy: Eliminar
-    details:
+    details: 
     discount_amount: Import del descompte
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Mostrar
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: 
+    doesnt_track_inventory: 
     edit: Editar
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Editant usuari
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Correu Electrònic
     empty: Buit
     empty_cart: Buidar carret
@@ -571,7 +572,8 @@ ca:
       messages:
         could_not_create_taxon: no va poder crear-se la categoria
         no_payment_methods_available: No payment methods are configured for this environment
-        no_shipping_methods_available: No hi ha mètodes d'enviament disponibles per a la localitat seleccionada. Per favor, canviï l'adreça i torni a intentar-ho.
+        no_shipping_methods_available: No hi ha mètodes d'enviament disponibles per a la localitat seleccionada. Per favor, canviï l'adreça i
+          torni a intentar-ho.
     errors_prohibited_this_record_from_being_saved:
       one: 1 error va impedir que no pogués guardar-se el registre
       other: "%{count} errors van impedir que no pogués guardar-se el registre"
@@ -579,31 +581,31 @@ ca:
     events:
       spree:
         cart:
-          add:
+          add: 
         checkout:
-          coupon_code_added:
+          coupon_code_added: 
         content:
-          visited:
+          visited: 
         order:
-          contents_changed:
-        page_view:
+          contents_changed: 
+        page_view: 
         user:
-          signup:
+          signup: 
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Caducitat
     extension: Extensió
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Nom d'arxiu
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: 
+    filter_results: 
     finalize: Finalitzar
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: Cost del primer element
     first_name: Nom
     first_name_begins_with: Nom comença per
@@ -612,7 +614,7 @@ ca:
     flexible_rate: Quantitat variable
     forgot_password: Vas oblidar la teva contrasenya?
     free_shipping: Despeses d'enviament gratuïts
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Sistema Intern
     gateway: mitjà
     gateway_config_unavailable: Passarel·la no disponible per configuració
@@ -625,43 +627,43 @@ ca:
     guest_user_account: Comprar sense registrar-se
     has_no_shipped_units: no té unitats enviades
     height: Altura
-    hide_cents:
+    hide_cents: 
     home: Inici
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: Català
     icon: Icona
-    identifier:
+    identifier: 
     image: Imatge
     images: Imatges
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: 
+    included_price_validation: 
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Empleni el formulari i rebrà per email instruccions sobre com reiniciar el seu password:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Interceptar adreça d'Email
     intercept_email_instructions: Substituir el receptor de l'email amb aquesta adreça.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 
+    invalid_promotion_action: 
+    invalid_promotion_rule: 
     inventory: Inventari
     inventory_adjustment: Ajust d'inventari
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: 
+    inventory_state: 
     is_not_available_to_shipment_address: No es troba disponible per a l'adreça d'enviament
-    iso_name:
+    iso_name: 
     item: article
     item_description: Descripció de l'article
     item_total: Total d'articles
@@ -669,26 +671,26 @@ ca:
       operators:
         gt: major que
         gte: major o igual que
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: Cognoms
     last_name_begins_with: Cognom comença per
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Llesta
     loading: Carregant
     locale_changed: S'ha canviat l'idioma
-    location:
-    lock:
-    log_entries:
+    location: 
+    lock: 
+    log_entries: 
     logged_in_as: Identificat com
     logged_in_succesfully: Connectat amb èxit
     logged_out: S'ha tancat la sessió.
@@ -697,38 +699,38 @@ ca:
     login_failed: No s'ha pogut iniciar la sessió, error d'autenticació.
     login_name: Nom d'usuari
     logout: Tancar sessió
-    logs:
+    logs: 
     look_for_similar_items: Buscar articles similars
     make_refund: Realitzar devolució
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Preu principal
     match_choices:
-      all:
-      none:
+      all: 
+      none: 
     max_items: Màxim d'elements
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Fiqui descripció
     meta_keywords: Fiqui paraules clau
-    meta_title:
+    meta_title: 
     metadata: Metadades
     minimal_amount: Quantitat mínima
     month: Mes
-    more:
-    move_stock_between_locations:
+    more: 
+    move_stock_between_locations: 
     my_account: El meu compte
     my_orders: Les meves comandes
     name: Nom
-    name_on_card:
+    name_on_card: 
     name_or_sku: Nom o codi de producte
     new: Nou
     new_adjustment: nou ajust
-    new_country:
+    new_country: 
     new_customer: Nou client
-    new_customer_return:
+    new_customer_return: 
     new_image: Nova Imatge
     new_option_type: Nou tipus d'opció
     new_order: Nova comanda
@@ -737,20 +739,20 @@ ca:
     new_payment_method: Nova forma de pagament
     new_product: Nou producte
     new_promotion: nova promoció
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Nova propietat
     new_prototype: Nou prototip
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Nova autorització de devolució
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Nova categoria d'enviament
     new_shipping_method: Nova forma d'enviament
     new_state: Nova província
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: 
+    new_stock_movement: 
+    new_stock_transfer: 
     new_tax_category: Nova categoria
     new_tax_rate: Nou tipus impositiu
     new_taxon: Nova Categoria
@@ -760,25 +762,25 @@ ca:
     new_variant: Nova Variant
     new_zone: Nova zona
     next: següent
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: 
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: No s'han trobat productes
-    no_resource_found:
+    no_resource_found: 
     no_results: Sense resultats
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: No s'han afegit noves normes
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
     none: Cap
-    none_selected:
+    none_selected: 
     normal_amount: Quantitat normal
     not: false
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: 
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
       product_cloned: Producte clonat
       product_deleted: Producte esborrat
@@ -786,47 +788,47 @@ ca:
       product_not_deleted: No ha pogut esborrar-se el producte
       variant_deleted: Variant esborrada
       variant_not_deleted: La variant no ha pogut esborrar-se
-    num_orders:
+    num_orders: 
     on_hand: Disponible
     open: Obert
-    open_all_adjustments:
+    open_all_adjustments: 
     option_type: Tipus d'opció
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Tipus d'opció
     option_value: Valor de l'opció
     option_values: Valors de l'opció
-    optional:
+    optional: 
     options: Opcions
     or: o
     or_over_price: "%{price} or over"
     order: Demanat
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Detalls de la comanda
     order_email_resent: Email de comanda reexpedida
-    order_information:
+    order_information: 
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
+        dear_customer: 
+        instructions: 
+        order_summary_canceled: 
         subject: Cancel·lació de comanda
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
+        dear_customer: 
+        instructions: 
+        order_summary: 
         subject: Confirmació de comanda
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        subtotal: 
+        thanks: 
+        total: 
+    order_not_found: 
+    order_number: 
     order_processed_successfully: La seva comanda s'ha processat correctament
-    order_resumed:
+    order_resumed: 
     order_state:
       address: adreça
       awaiting_return: esperant resposta
@@ -834,7 +836,7 @@ ca:
       cart: carret
       complete: completat
       confirm: confirmat
-      considered_risky:
+      considered_risky: 
       delivery: enviament
       payment: pagament
       resumed: continuat
@@ -844,24 +846,24 @@ ca:
     order_total: Total de la comanda
     order_updated: Comanda actualitzada
     orders: Demanats
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Sense estoc
     overview: General
-    package_from:
+    package_from: 
     pagination:
-      next_page:
-      previous_page:
+      next_page: 
+      previous_page: 
       truncate: "…"
     password: Contrasenya
-    paste:
+    paste: 
     path: Ruta
     pay: Pagar
     payment: Pagament
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Informació del pagament
     payment_method: Mètode de pagament
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Mètodes de pagament
     payment_processing_failed: El pagament no ha pogut ser processat, per favor, revisi les dades proporcionades.
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -879,57 +881,57 @@ ca:
       void: buit
     payment_updated: Pagament actualitzat
     payments: Pagaments
-    pending:
-    percent:
-    percent_per_item:
+    pending: 
+    percent: 
+    percent_per_item: 
     permalink: Enllaç permanent
     phone: Telèfon
     place_order: Fer comanda
-    please_define_payment_methods:
+    please_define_payment_methods: 
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Suportat per
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Presentació
     previous: Anterior
-    previous_state_missing:
+    previous_state_missing: 
     price: Preu
-    price_range:
-    price_sack:
+    price_range: 
+    price_sack: 
     process: Processar
     product: Producte
     product_details: Detalls del producte
     product_has_no_description: El producte no té descripció
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: Propietats del producte
     product_rule:
       choose_products: Triï productes
-      label:
+      label: 
       match_all: tots
       match_any: almenys un de
-      match_none:
+      match_none: 
       product_source:
         group: Del grup de productes
         manual: Triar manualment
     products: Productes
     promotion: Promoció
-    promotion_action:
+    promotion_action: 
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: 
+        name: 
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: 
+        name: 
+    promotion_actions: 
     promotion_form:
       match_policies:
         all: Coincideix amb alguna de les següents regles
@@ -943,30 +945,30 @@ ca:
         description: Total de la comanda coincideix amb els següents criteris
         name: Total d'elements
       landing_page:
-        description:
-        name:
+        description: 
+        name: 
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: La comanda inclou els següents productes
         name: Productes
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Disponible només per als següents clients
         name: Client
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
+        description: 
+        name: 
+    promotion_uses: 
+    promotionable: 
     promotions: Promocions
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Propietats
     property: Propietat
     prototype: Prototip
@@ -977,11 +979,11 @@ ca:
     quantity: Quantitat
     quantity_returned: Quantitat retornada
     quantity_shipped: Quantitat enviada
-    quick_search:
+    quick_search: 
     rate: proporció
     reason: Raó
     receive: rebre
-    receive_stock:
+    receive_stock: 
     received: Rebut
     reception_states:
       awaiting: En espera
@@ -995,39 +997,39 @@ ca:
       short_shipped: No inclòs en l'enviament
       unexchanged: Sense canvis
     reception_status: Estat de recepció
-    reference:
+    reference: 
     refund: Retornar
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Registrar com a nou client
     registration: Registre
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Recordar-me en aquest equip
     remove: Eliminar
     rename: Rename
-    report:
+    report: 
     reports: Informes
     resend: Tornar a enviar
     reset_password: Reiniciar la meva contrasenya
@@ -1036,36 +1038,36 @@ ca:
     resumed: Reprès
     return: tornar
     return_authorization: Autorització per a devolució
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Retornar autorització actualitzada
     return_authorizations: Autoritzacions per a devolucions
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Retornar quantitat
     returned: va tornar
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
+    returns: 
+    review: 
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: Crèdit RMA
     rma_number: Nombre RMA
     rma_value: Valor RMA
     roles: Funcions
     rules: Regles
-    safe:
+    safe: 
     sales_total: Total de vendes
     sales_total_description: Total de vendes de totes les comandes
-    sales_totals:
+    sales_totals: 
     save_and_continue: Guardar i continuar
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: 
+    say_no: 
+    say_yes: 
     scope: Scope
     search: Buscar
     search_results: Buscar resultats per '%{keywords}'
@@ -1073,10 +1075,10 @@ ca:
     secure_connection_type: Tipus de connexió segura
     security_settings: Security Settings
     select: Seleccionar
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Seleccionar des de prototip
-    select_stock:
+    select_stock: 
     send_copy_of_all_mails_to: Envia una còpia de tots els correus a
     send_mails_as: Enviar correus com
     server: Servidor
@@ -1084,206 +1086,206 @@ ca:
     settings: Configuració
     ship: enviar
     ship_address: adreça d'enviament
-    ship_total:
+    ship_total: 
     shipment: Enviament
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
+        dear_customer: 
+        instructions: 
+        shipment_summary: 
+        subject: 
+        thanks: 
+        track_information: 
+        track_link: 
     shipment_state: Estat de l'enviament
     shipment_states:
-      backorder:
-      canceled:
+      backorder: 
+      canceled: 
       partial: parcial
       pending: pendent
       ready: llest
       shipped: enviat
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Enviaments
     shipped: Enviat
     shipping: Enviament
     shipping_address: Adreça d'enviament
     shipping_categories: Categories d'enviament
     shipping_category: Categoria d'enviament
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
     shipping_instructions: Instruccions d'enviament
     shipping_method: Mètode d'enviament
     shipping_methods: Mètodes d'enviament
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: 
+    shipping_total: 
     shop_by_taxonomy: Comprar per %{taxonomy}
     shopping_cart: Cistella de compres
     show: Mostrar
     show_active: mostrar actius
     show_deleted: Mostrar esborrats
     show_only_complete_orders: Mostrar només les comandes completades
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: 
+    show_rate_in_label: 
     sku: Codi
-    skus:
-    slug:
+    skus: 
+    slug: 
     source: Font
     special_instructions: Instruccions especials
-    split:
+    split: 
     spree_gateway_error_flash_for_checkout: va haver-hi un problema amb la seva informació de pagament. Per favor, revisi-la i intenti-ho de nou.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Inici
     state: Província
     state_based: Província
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Províncies
-    states_required:
+    states_required: 
     status: Estat
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: 
+    stock_location: 
+    stock_location_info: 
+    stock_locations: 
+    stock_locations_need_a_default_country: 
+    stock_management: 
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
+    stock_transfer: 
+    stock_transfers: 
     stop: Fins a
     store: Tenda
     street_address: Adreça
     street_address_2: Adreça (continuació)
     subtotal: Subtotal
     subtract: Restar
-    success:
+    success: 
     successfully_created: "%{resource} ha estat creat amb èxit"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} ha estat esborrat amb èxit"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: 
     successfully_updated: "%{resource} ha estat actualitzat amb èxit"
-    summary:
+    summary: 
     tax: Imposats
     tax_categories: Categories fiscals
     tax_category: Categoria fiscal
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
     tax_rates: Taxes d'impostos
     taxon: Categoria
     taxon_edit: Editar categoria
-    taxon_placeholder:
+    taxon_placeholder: 
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
-    taxonomies:
-    taxonomy:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
+    taxonomies: 
+    taxonomy: 
     taxonomy_edit: Editar categories
     taxonomy_tree_error: El canvi sol·licitat no ha estat acceptat i l'arbre ha tornat al seu estat anterior. Per favor, intenti-ho de nou.
     taxonomy_tree_instruction: "* Clic dret en un dels nodes per accedir al menu per afegir, eliminar o ordenar nodes"
     taxons: Categories
-    test:
+    test: 
     test_mailer:
       test_email:
-        greeting:
-        message:
-        subject:
+        greeting: 
+        message: 
+        subject: 
     test_mode: Manera Prova
     thank_you_for_your_order: Gràcies per la seva comanda
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: 'Han hagut problemes amb els següents camps:'
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Miniatura
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: 
     to_add_variants_you_must_first_define: Per agregar variants, primer ha de definir
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Seguiment
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
     tree: Arbre
     type: Tipus
     type_to_search: Tipus a buscar
     unable_to_connect_to_gateway: No ha estat possible connectar-se a la passarel·la.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
-    unlock:
+    unlock: 
     unrecognized_card_type: Tipus de targeta desconegut
-    unshippable_items:
+    unshippable_items: 
     update: Actualitzar
     updating: Actualitzant
     usage_limit: Límit d'ús
-    use_app_default:
+    use_app_default: 
     use_billing_address: Usar l'adreça de facturació
     use_new_cc: Usar una targeta diferent
-    use_s3:
+    use_s3: 
     user: Usuari
     user_rule:
       choose_users: Triar usuaris
     users: Usuaris
     validation:
       cannot_be_less_than_shipped_units: no pot ser menys que el nombre d'unitats enviades.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
-      is_too_large: "és massa gran -- no hi ha suficients productes disponibles per a aquesta quantitat"
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 
+      is_too_large: és massa gran -- no hi ha suficients productes disponibles per a aquesta quantitat
       must_be_int: ha de ser un sencer
       must_be_non_negative: ha de ser un valor no negatiu
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: valor
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: 
     variants: Variants
     version: Versió
     void: Buit
@@ -1294,7 +1296,7 @@ ca:
     year: Any
     you_have_no_orders_yet: Encara no té cap comanda.
     your_cart_is_empty: La seva cistella està buida
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: 
     zip: Codi postal
     zipcode: Codi Postal
     zone: Zona

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,3 +1,4 @@
+---
 cs:
   activerecord:
     attributes:
@@ -28,7 +29,7 @@ cs:
         cc_type: Typ
         month: Měsíc
         name: Jméno
-        number: "Číslo"
+        number: Číslo
         verification_value: Verifikační hodnota
         year: Rok
       spree/inventory_unit:
@@ -48,7 +49,7 @@ cs:
         email: Email zákazníka
         ip_address: IP Adresa
         item_total: Položky celkem
-        number: "Číslo"
+        number: Číslo
         payment_state: Stav platby
         shipment_state: Stav zásilky
         special_instructions: Speciální instrukce
@@ -71,7 +72,7 @@ cs:
         state: Země
         zipcode: PSČ
       spree/payment:
-        amount: "Částka"
+        amount: Částka
       spree/payment_method:
         name: Název
       spree/product:
@@ -148,7 +149,7 @@ cs:
         price: Cena
         sku: SKU
         weight: Hmotnost
-        width: "Šířka"
+        width: Šířka
       spree/zone:
         description: Popis
         name: Název
@@ -211,17 +212,17 @@ cs:
         few: Kreditní karty
         one: Kreditní karta
         other: Kreditních karet
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         few: Inventární jednotky
         one: Inventární jednotka
         other: Inventárních jednotek
       spree/line_item:
-        few: "Řádkové položky"
-        one: "Řádková položka"
-        other: "Řádkových položek"
-      spree/option_type:
-      spree/option_value:
+        few: Řádkové položky
+        one: Řádková položka
+        other: Řádkových položek
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         few: Objednávky
         one: Objednávka
@@ -230,29 +231,29 @@ cs:
         few: Platby
         one: Platba
         other: Plateb
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         few: Výrobky
         one: Výrobek
         other: Výrobků
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
         few: Vlastnosti
         one: Vlastnost
         other: Vlastností
       spree/prototype:
-        few: "Šablony"
-        one: "Šablona"
-        other: "Šablon"
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+        few: Šablony
+        one: Šablona
+        other: Šablon
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         few: Návraty oprávnění
         one: Návrat oprávnění
         other: Návratů oprávnění
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         few: Role
         one: Role
@@ -265,15 +266,15 @@ cs:
         few: Kategorie dodání
         one: Kategorie dodání
         other: Kategorií dodání
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         few: Státy
         one: Stát
         other: Států
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         few: Kategorie daně
         one: Kategorie daně
@@ -290,7 +291,7 @@ cs:
         few: Sekce
         one: Sekce
         other: Sekcí
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         few: Uživatelé
         one: Uživatel
@@ -309,8 +310,8 @@ cs:
     acceptance_errors: Chyby přijetí
     acceptance_status: Stav přijetí
     accepted: Přijato
-    account: "Účet"
-    account_updated: "Účet aktualizován"
+    account: Účet
+    account_updated: Účet aktualizován
     action: Akce
     actions:
       cancel: Zrušit
@@ -329,7 +330,7 @@ cs:
     add: Přidat
     add_action_of_type: Přidat typ akce
     add_country: Přidat zemi
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Přidat nové záhlaví
     add_new_style: Přidat nový styl
     add_one: Přidat
@@ -347,7 +348,7 @@ cs:
     address2: Adresa (pokrač.)
     adjustable: Přizpůsobitelné
     adjustment: Přizpůsobení
-    adjustment_amount: "Částka"
+    adjustment_amount: Částka
     adjustment_successfully_closed: Nastavení bylo úspěšně uzavřeno!
     adjustment_successfully_opened: Nastavení bylo úspěšně otevřeno!
     adjustment_total: Celkové přizpůsobení
@@ -359,8 +360,8 @@ cs:
         orders: Objednávky
         overview: Přehled
         products: Produkty
-        promotions: Akce
         promotion_categories: Kategorie akcí
+        promotions: Akce
         properties: Vlastnosti
         prototypes: Prototypy
         reports: Výkazy
@@ -384,7 +385,7 @@ cs:
     all_adjustments_closed: Nastavení byla úspěšně uzavřena!
     all_adjustments_opened: Nastavení byla úspěšně otevřena!
     all_departments: Všechna oddělení
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Povolit užívání SSL ve vývojovém a testovacím režimu
     allow_ssl_in_production: Povolit užívání SSL v produkčním režimu
     allow_ssl_in_staging: Povolit užívání SSL ve staging režimu
@@ -406,7 +407,7 @@ cs:
     are_you_sure: Jste si jisti?
     are_you_sure_delete: Jste si jisti, že chcete vymazat tento záznam?
     associated_adjustment_closed: Přidružené nastavení je uzavřeno a nebude přepočítáno. Chcete jej otevřít?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Chyba autorizace
     authorized: autorizováno
     auto_capture: Automatické zachycení
@@ -445,18 +446,18 @@ cs:
     capture: Strhnout
     capture_events: Zachytit události
     card_code: Bezpečnostní číslo karty
-    card_number: "Číslo karty"
+    card_number: Číslo karty
     card_type: Typ karty
     card_type_is: Typ karty je
     cart: Košík
-    cart_subtotal:
+    cart_subtotal: 
     categories: Kategorie
     category: Kategorie
     charged: Účtováno
     check_for_spree_alerts: Zkontrolovat Spree upozornění
     checkout: K pokladně
     choose_a_customer: Vyberte zákazníka
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Vyberte měnu
     choose_dashboard_locale: Vyberte lokalizaci
     choose_location: Vyberte místo
@@ -481,7 +482,7 @@ cs:
     cost_currency: Cena měny
     cost_price: Nákupní cena
     could_not_connect_to_jirafe: Nelze se připojit k Jirafe k synchronizaci dat. Akce bude automaticky opakována později.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: Došlo k problému při ukládání tohoto pohybu skladových zásob. Zkuste to prosím znovu.
     count_on_hand: Počet zboží k dispozici
     countries: Země
@@ -524,13 +525,13 @@ cs:
       one: 'Aktuální využití: %{count}'
       other: 'Aktuální využití: %{count}'
     customer: Zákazník
-    customer_details: "Údaje zákazníka"
-    customer_details_updated: "Údaje zákazníka byly aktualizovány"
+    customer_details: Údaje zákazníka
+    customer_details_updated: Údaje zákazníka byly aktualizovány
     customer_return: Vratka zákazníka
     customer_returns: Vratky zákazníka
     customer_search: Vyhledávání zákazníků
     cut: Vyjmout
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: App ID
@@ -566,7 +567,7 @@ cs:
     display_currency: Zobrazit symbol měny
     doesnt_track_inventory: Nepoužívá sledování skladu
     edit: Upravit
-    editing_resource: 'Editovat %{resource}'
+    editing_resource: Editovat %{resource}
     editing_rma_reason: Editovat důvod reklamace
     editing_user: Můj účet
     eligibility_errors:
@@ -595,7 +596,7 @@ cs:
     errors:
       messages:
         could_not_create_taxon: Nelze vytvořit kategorii
-        no_payment_methods_available: "Žádné platební metody nelze konfigurovat v tomto prostředí"
+        no_payment_methods_available: Žádné platební metody nelze konfigurovat v tomto prostředí
         no_shipping_methods_available: Pro zvolené cílové místo není k dispozici žádný způsob dodání, změňte prosím adresu a zkuste to znovu.
     errors_prohibited_this_record_from_being_saved:
       few: "%{count} chyby zabraňují uložení"
@@ -616,11 +617,15 @@ cs:
         user:
           signup: Registrace uživatele
     exceptions:
-      count_on_hand_setter: Nelze nastavit count_on_hand manuálně, protože je automaticky nastaven callback recalculate_count_on_hand. Prosím, použijte raději `update_column(:count_on_hand, value)`.
+      count_on_hand_setter: >-
+        Nelze nastavit count_on_hand manuálně, protože je automaticky nastaven callback recalculate_count_on_hand. Prosím, použijte raději `update_column(:count_on_hand,
+        value)`.
     exchange_for: Vyměnit za
     excl: vynech.
     existing_shipments: Existující zásilky
-    expedited_exchanges_warning: "Jakákoliv vybraná výměna bude zákazníkovi odeslána ihned po uložení. Zákazníkovi bude účtována plná hodnota položky pokud nevrátí původní položku do %{days_window} dnů."
+    expedited_exchanges_warning: >-
+      Jakákoliv vybraná výměna bude zákazníkovi odeslána ihned po uložení. Zákazníkovi bude účtována plná hodnota položky pokud nevrátí původní
+      položku do %{days_window} dnů.
     expiration: Expirace
     extension: Rozměr
     failed_payment_attempts: Chybných pokusů o platbu
@@ -657,13 +662,13 @@ cs:
       available_locales: Dostupné lokalizace
       language: Jazyk
       localization_settings: Nastavení lokalizace
-      this_file_language: "Čeština (CS)"
+      this_file_language: Čeština (CS)
     icon: Ikona
     identifier: Identifikátor
     image: Obrázek
     images: Obrázky
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
     inactive: Neaktivní
     incl: obsah.
     included_in_price: Zahrnuto v ceně
@@ -748,7 +753,7 @@ cs:
     my_account: Můj účet
     my_orders: Mé objednávky
     name: Název
-    name_on_card:
+    name_on_card: 
     name_or_sku: Název nebo SKU (zadejte alespoň první 4 písmena z názvu výrobku)
     new: Nový
     new_adjustment: Nová úprava
@@ -791,13 +796,13 @@ cs:
     no_pending_payments: Žádné čekající platby
     no_products_found: Nebyly nalezeny žádné výrobky
     no_resource_found: Nebyly nalezeny žádné zdroje
-    no_results: "Žádné výsledky"
+    no_results: Žádné výsledky
     no_returns_found: Nebyly nalezeny žádné refundace.
-    no_rules_added: "Žádné přidané pravidla"
+    no_rules_added: Žádné přidané pravidla
     no_shipping_method_selected: Nebyl vybrán způsob dopravy
     no_state_changes: Žádné změny stavu
     no_tracking_present: Sledování zásilky není dostupné
-    none: "Žádný"
+    none: Žádný
     none_selected: Nic vybráno
     normal_amount: Normální množství
     not: ne
@@ -817,7 +822,7 @@ cs:
     open: Otevřít
     open_all_adjustments: Otevřít všechna přizpůsobení
     option_type: Typ volby
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Typy voleb
     option_value: Hodnota volby
     option_values: Hodnoty voleb
@@ -839,23 +844,23 @@ cs:
         instructions: Vaše objednávka byla zrušena. Uschovejte si prosím tyto informace o zrušení k vaší evidenci.
         order_summary_canceled: Shrnutí objednávky [Zrušeno]
         subject: Zrušení objednávky
-        subtotal: ! 'Mezisoučet:'
-        total: ! 'Celkem:'
+        subtotal: 'Mezisoučet:'
+        total: 'Celkem:'
       confirm_email:
         dear_customer: Vážený zákazníku,\n
         instructions: Zkontrolujte si a uschovejte si prosím následující údaje objednávky k vaší evidenci.
         order_summary: Přehled objednávek
         subject: Potvrzení objednávky
-        subtotal: ! 'Mezisoučet:'
+        subtotal: 'Mezisoučet:'
         thanks: Děkujeme za Váš nákup.
-        total: ! 'Celkem:'
+        total: 'Celkem:'
     order_not_found: Nemůžeme nalézt Vaši objednávku. Zkuste prosím akci provést později.
     order_number: Objednávka %{number}
     order_processed_successfully: Vaše objednávka byla úspěšně zpracována
     order_resumed: Objednávka obnovena
     order_state:
       address: Adresa
-      awaiting_return: "Čeká na návrat"
+      awaiting_return: Čeká na návrat
       canceled: Zrušeno
       cart: Košik
       complete: Dokončení
@@ -900,7 +905,7 @@ cs:
       credit_owed: Dluží kredit
       failed: Selhalo
       paid: Zaplaceno
-      pending: "Čekající na vyřízení"
+      pending: Čekající na vyřízení
       processing: Zpracováváno
       void: Neplatná
     payment_updated: Platba upravena
@@ -920,7 +925,7 @@ cs:
     preferred_reimbursement_type: Preferovaný způsob náhrady
     presentation: Prezentace
     previous: Předchozí
-    previous_state_missing: "n/a"
+    previous_state_missing: n/a
     price: Cena
     price_range: Cenové rozpětí
     price_sack: Ceny balíku
@@ -995,8 +1000,8 @@ cs:
     propagate_all_variants: Nabízet všechny varianty
     properties: Vlastnosti
     property: Vlastnost
-    prototype: "Šablona"
-    prototypes: "Šablony"
+    prototype: Šablona
+    prototypes: Šablony
     provider: Provider
     provider_settings_warning: Pokud měníte poskytovatele, je nutné uložit nové nastavení a teprve potom upravit nastavení uživatele
     qty: Množství
@@ -1023,15 +1028,15 @@ cs:
     reimbursement: Náhrada
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send: ! 'Máte %{days} na vrácení jakéhokoliv zboží, které má být vyměněno.'
+        days_to_send: Máte %{days} na vrácení jakéhokoliv zboží, které má být vyměněno.
         dear_customer: Vážený zákazníku
         exchange_summary: Přehled výměn
         for: pro
         instructions: Vaše výměny byly zpracovány.
         refund_summary: Přehled refundací
         subject: Notifikace o výměně
-        total_refunded:  ! 'Celkem refundováno: %{total}'
-    reimbursement_perform_failed: "Náhrada nemůže být provedena.  Chyba: %{error}"
+        total_refunded: 'Celkem refundováno: %{total}'
+    reimbursement_perform_failed: 'Náhrada nemůže být provedena.  Chyba: %{error}'
     reimbursement_status: Stav náhrady
     reimbursement_type: Typ náhrady
     reimbursement_type_override: Přepsání typu náhrady
@@ -1059,7 +1064,7 @@ cs:
     return_item_rma_ineligible: Položka vyžaduje vrácení zboží (RMA)
     return_item_time_period_ineligible: Položka je mimo povolený interval pro vrácení zboží (RMA)
     return_items: Vracené položky
-    return_items_cannot_be_associated_with_multiple_orders:
+    return_items_cannot_be_associated_with_multiple_orders: 
     return_number: Číslo vrácení
     return_quantity: Množství položek pro vrácení zboží (RMA)
     returned: Vráceno
@@ -1069,7 +1074,7 @@ cs:
     risk_analysis: Analýza rizika
     risky: Rizikový
     rma_credit: RMA kredity
-    rma_number: "Číslo vrácení zboží (RMA)"
+    rma_number: Číslo vrácení zboží (RMA)
     rma_value: Hodnota vrácení zboží (RMA)
     roles: Role
     rules: Pravidla
@@ -1116,8 +1121,8 @@ cs:
     shipment_states:
       backorder: V externím skladu
       canceled: Zrušena
-      partial: "Částečná"
-      pending: "Čekající na vyřízení"
+      partial: Částečná
+      pending: Čekající na vyřízení
       ready: Připravit
       shipped: Dodáno
     shipment_transfer_error: Chyba převodu variant.
@@ -1144,8 +1149,8 @@ cs:
     show_only_complete_orders: Zobrazit pouze dokončené objednávky
     show_only_considered_risky: Zobrazit pouze rizikové
     show_rate_in_label: Zobrazit sazby v popisku
-    sku: "Číslo zboží (SKU)"
-    skus: "Čísla zboží (SKU)"
+    sku: Číslo zboží (SKU)
+    skus: Čísla zboží (SKU)
     slug: Slug
     source: Zdroj
     special_instructions: Zvláštní instrukce
@@ -1206,12 +1211,12 @@ cs:
     stop: Konec
     store: Obchod
     street_address: Ulice
-    street_address_2: "Číslo ulice"
+    street_address_2: Číslo ulice
     subtotal: Mezisoučet
     subtract: Odečet
     success: Úspěch
     successfully_created: "%{resource} byl úspěšně vytvořen!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} byl úspěšně odstraněn!"
     successfully_signed_up_for_analytics: Registrace do Spree Analytics proběhla úspěšně.
     successfully_updated: "%{resource} byl úspěšně aktualizován!"
@@ -1252,7 +1257,7 @@ cs:
     tiered_flat_rate: Kategorizovaná pevná sazba
     tiered_percent: Kategorizovaná procentuální sazba
     tiers: Kategorie
-    time: "Čas"
+    time: Čas
     to_add_variants_you_must_first_define: Pro přidání variant je musíte nejprve nadefinovat.
     total: Celkem
     total_per_item: Celkem za položku
@@ -1261,7 +1266,7 @@ cs:
     total_sales: Celkem tržba
     track_inventory: Sledovat zásoby
     tracking: Sledování
-    tracking_number: "Číslo pro sledování"
+    tracking_number: Číslo pro sledování
     tracking_url: URL pro sledování
     tracking_url_placeholder: 'URL pro doručovací služby, např: http://quickship.com/package?num=:tracking'
     transaction_id: ID transakce
@@ -1290,7 +1295,7 @@ cs:
     users: Uživatelé
     validation:
       cannot_be_less_than_shipped_units: Nesmí být menší než číslo poslaných jednotek.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: přesahuje dostupné skladové zásoby. Ujistěte se, že pro položky objednávky je požadované množství.
       is_too_large: je příliš mnoho -- stávající skladové zásoby nepokryjí požadované množství!
       must_be_int: musí být celé číslo
@@ -1305,7 +1310,7 @@ cs:
     weight: Váha
     what_is_a_cvv: Co to je (CVV) kód kreditní karty?
     what_is_this: Co je to?
-    width: "Šířka"
+    width: Šířka
     year: Rok
     you_have_no_orders_yet: Zatím nemate žádnou objednávku
     your_cart_is_empty: Váš nákupní košík je prázdný

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1,3 +1,4 @@
+---
 da:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ da:
         state: Delstat
         zipcode: Postnummer
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,13 +25,13 @@ da:
         name: Navn
         numcode: ISO-kode
       spree/credit_card:
-        base:
+        base: 
         cc_type: Type
         month: Måned
-        name:
+        name: 
         number: Nummer
         verification_value: CVV-kode
-        year: "År"
+        year: År
       spree/inventory_unit:
         state: Delstat
       spree/line_item:
@@ -95,7 +96,7 @@ da:
         starts_at: Starter
         usage_limit: Brugsbegrænsning
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Navn
         presentation: Præsentation
@@ -109,13 +110,13 @@ da:
         abbr: Forkortelse
         name: Navn
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
         cart_tax_country_iso: Standard afgiftsland i indkøbskurven
         code: Kode
@@ -159,47 +160,47 @@ da:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Adresse
@@ -210,22 +211,22 @@ da:
       spree/credit_card:
         one: Betalingskort
         other: Betalingskort
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
       spree/line_item:
         one: Ordrelinje
         other: Ordrelinjer
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Ordre
         other: Ordrer
       spree/payment:
         one: Betaling
         other: Betalinger
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Produkt
         other: Produkter
@@ -237,13 +238,13 @@ da:
       spree/prototype:
         one: Prototype
         other: Prototyper
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Return Authorization
         other: Return Authorizations
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Rolle
         other: Roller
@@ -253,13 +254,13 @@ da:
       spree/shipping_category:
         one: Leveringskategori
         other: Leveringskategorier
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: Delstat
         other: Delstater
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
       spree/stock_transfer: Lagerflytning
       spree/tax_category:
         one: Afgiftskategori
@@ -273,7 +274,7 @@ da:
       spree/taxonomy:
         one: Taksonomi
         other: Taksonomier
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: Bruger
         other: Brugere
@@ -285,10 +286,10 @@ da:
         other: Zoner
   spree:
     abbreviation: Forkortelse
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Konto
     account_updated: Konto opdateret!
     action: Handling
@@ -302,7 +303,7 @@ da:
       list: Liste
       listing: Liste
       new: Ny
-      refund:
+      refund: 
       remove: Slet
       save: Gem
       split: Opdel
@@ -325,19 +326,19 @@ da:
     add_stock: Tilføj til lager
     add_stock_management: Tilføj lagerstyring
     add_taxon: Opret Takson
-    add_variant_properties: Opret variantegenskaber
     add_to_cart: Tilføj til indkøbskurv
     add_variant: Tilføj variant
+    add_variant_properties: Opret variantegenskaber
     added: Oprettet
     additional_item: Yderligere produktpris
     address1: Adresse
     address2: Adresse (fortsat)
-    adjustable:
+    adjustable: 
     adjustment: Justering
     adjustment_amount: Beløb
     adjustment_labels:
       tax_rates:
-        sales_tax_with_rate: '%{name}: %{amount}'
+        sales_tax_with_rate: "%{name}: %{amount}"
     adjustment_successfully_closed: Justeringer lukket
     adjustment_successfully_opened: Justeringer åbnet
     adjustment_total: Samlet justering
@@ -353,9 +354,9 @@ da:
         edit:
           edit_price: Rediger priser
         index:
-          new_price: Ny pris
           amount_greater_than: Beløb større end
           amount_less_than: Beløb mindre end
+          new_price: Ny pris
       promotions:
         form:
           expires_at_placeholder: Udløbsdato
@@ -376,8 +377,8 @@ da:
         overview: Oversigt
         payments: Betalingsmåder
         products: Produkter
-        promotions: Kampagner
         promotion_categories: Kampagnekategorier
+        promotions: Kampagner
         properties: Egenskaber
         prototypes: Prototyper
         reports: Rapporter
@@ -398,15 +399,15 @@ da:
         items_purchased: Købte produkter
         order_history: Ordrehistorik
         order_num: Ordrenr.
-        orders:
+        orders: 
         store_credit: kredit
-        user_information:
+        user_information: 
       users:
         user_page_actions:
           create_order: Opret ordre
     admin_login: Administrator login
     administration: Administration
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Godkend vores privatlivs-betingelser
     agree_to_terms_of_service: Godkend vores handelsbetingelser
     all: Alle
@@ -415,7 +416,7 @@ da:
     all_adjustments_opened: Alle justeringer åbne
     all_adjustments_unfinalized: Ingen justeringer er låst
     all_departments: Alle afdelinger
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Tillad SSL i 'development mode'
     allow_ssl_in_production: Tillad SSL i produktion
     allow_ssl_in_staging: Tillad SSL i 'staging mode'
@@ -443,10 +444,10 @@ da:
     are_you_sure: Er du sikker?
     are_you_sure_delete: Er du sikker på at du vil slette denne post?
     associated_adjustment_closed: Den tilhørende justering er lukket, og vil ikke blive genberegnet. Vil du åben den?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Autorisation fejlede
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Tilgængelig
     average_order_value: Gennemsnitligt ordrebeløb
     avs_response: AVS svar
@@ -454,38 +455,38 @@ da:
     back_end: Administrationsgrænseflade
     back_to_images_list: Tilbage til billedliste
     back_to_payment: Tilbage til betaling
-    back_to_resource_list: 'Tilbage til %{resource}'
-    back_to_rma_reason_list:
+    back_to_resource_list: Tilbage til %{resource}
+    back_to_rma_reason_list: 
     back_to_stock_transfers_list: Tilbage til Lagerflytninger
     back_to_store: Gå tilbage til butikken
     back_to_taxonomies_list: Tilbage til Taksonomier
     back_to_users_list: Tilbage til brugerlisten
     backorderable: Ventelist mulig
-    backorderable_default:
+    backorderable_default: 
     backorderable_header: Kan bestilles til restordre
     backordered: I restordre
-    backorders_allowed:
+    backorders_allowed: 
     balance_due: Forfalden saldo
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Faktureringsadresse
     billing: Fakturering
     billing_address: Faktureringsadresse
     both: Begge
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Beregner
     calculator_settings_warning: Hvis du ændrer beregnertypen, må du først gemme inden du kan ændre beregnerindstillingerne
     cancel: annuller
     cancel_inventory: Annuller lagerbeholdning
     canceled_at: Annulleret d.
     canceler: Annulleret af
-    cannot_create_customer_returns:
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: Du kan ikke skabe en betaling for en ordre uden valgt betalingsmetode
     cannot_create_returns: Kan ikke returnere ordren, eftersom den endnu ikke er leveret.
     cannot_perform_operation: Kan ikke udføre den ønskede operation
     cannot_set_shipping_method_without_address: Kan ikke vælge leveringsmetode før adresseinformation er oplyst.
     capture: hæv beløb (capture)
-    capture_events:
+    capture_events: 
     card_code: Kortkode
     card_number: Kortnummer
     card_type: Korttype
@@ -494,7 +495,7 @@ da:
     cart_subtotal: Subtotal
     categories: Kategorier
     category: Kategori
-    charged:
+    charged: 
     check_for_spree_alerts: Check for Spree sikkerhedsopdateringer
     checkout: Til kassen
     choose_a_customer: Vælg kunde
@@ -503,10 +504,10 @@ da:
     choose_dashboard_locale: Vælg sprog i kontrolpanel
     choose_location: Vælg lokalitet
     city: By
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Dupliker
     close: Luk
     close_all_adjustments: Luk alle justeringer
@@ -518,14 +519,14 @@ da:
     configurations: Konfigurationer
     confirm: Bekræft
     confirm_delete: Bekræft sletning
-    confirm_password: Bekræft adgangskode
     confirm_order: Bekræft ordre
+    confirm_password: Bekræft adgangskode
     continue: Fortsæt
     continue_shopping: Fortsæt indkøb
     cost_currency: Kostvaluta
     cost_price: Kostpris
     could_not_connect_to_jirafe: Kunne ikke forbinde til Jirafe. Det vil blive forsøgt automatisk senere.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: Der var et problem med at gemme lagerbevægelsen. Prøv igen.
     count_on_hand: Antal tilgængelig
     countries: Lande
@@ -533,10 +534,10 @@ da:
     country_based: Landbaseret
     country_name: Navn
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Rabat
     coupon_code: Rabatkode
     coupon_code_already_applied: Rabatkoden er allerede anvendt på denne ordre
@@ -546,19 +547,19 @@ da:
     coupon_code_max_usage: Rabatkoden har nået maksimum brug
     coupon_code_not_eligible: Denne rabatkode kan ikke anvendes på denne ordre
     coupon_code_not_found: Rabatkoden eksisterer ikke. Prøv venligst igen.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Opret
     create_a_new_account: Opret en ny konto
     create_new_order: Opret ny ordre
     create_one: opret en
-    create_reimbursement:
+    create_reimbursement: 
     created_at: Oprettet den
     created_by: Oprettet af
     credit: Kredit
     credit_card: Kreditkort
     credit_cards: Kreditkort
     credit_owed: Skyldig kredit
-    credits:
+    credits: 
     currency: Valuta
     currency_decimal_mark: Valuta decimaltegn
     currency_settings: Indstillinger for valuta
@@ -569,8 +570,8 @@ da:
     customer: Kunde
     customer_details: Kunde detaljer
     customer_details_updated: Kundedetaljer opdateret
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Søg på kunde
     cut: Klip
     cvv_response: CVV resultat
@@ -587,16 +588,16 @@ da:
     date: Dato
     date_completed: Dato gennemført
     date_picker:
-      first_day:
+      first_day: 
       format: "%d/%m/%Y"
       js_format: dd/mm/yy
     date_range: Datointerval
     default: Standard
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Standardmoms
     default_tax_zone: Standardmomszone
     delete: Slet
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Levering
     depth: Dybde
     description: Beskrivelse
@@ -607,27 +608,27 @@ da:
     dismiss_banner: Nej Tak. Jeg er ikke interesseret. Vis ikke denne meddelelse igen.
     display: Visning
     display_currency: Vis valuta
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Rediger
-    editing_resource: 'Redigering af %{resource}'
-    editing_rma_reason:
+    editing_resource: Redigering af %{resource}
+    editing_rma_reason: 
     editing_shipping_category: Rediger forsendelseskategori
     editing_user: Redigering af bruger
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: E-mail
     empty: Tom
     empty_cart: Tøm indkøbskurv
@@ -659,12 +660,14 @@ da:
         user:
           signup: Tilmeld dig
     exceptions:
-      count_on_hand_setter: "Antal tilgængelig kan ikke sættes manuelt. Det sættes automatisk af recalculate_count_on_hand callback. Brug `update_column(:count_on_hand, value)` istedet."
-    exchange_for:
-    excl:
+      count_on_hand_setter: >-
+        Antal tilgængelig kan ikke sættes manuelt. Det sættes automatisk af recalculate_count_on_hand callback. Brug `update_column(:count_on_hand,
+        value)` istedet.
+    exchange_for: 
+    excl: 
     existing_shipments: Eksisterende forsendelser
     expected: Forventet
-    expedited_exchanges_warning:
+    expedited_exchanges_warning: 
     expiration: Udløbsdato
     extension: Udvidelse
     failed_payment_attempts: Fejlslagne betalingsforsøg
@@ -674,7 +677,7 @@ da:
     finalize: Afslut
     finalize_all_adjustments: Lås alle justeringer
     finalized: Afsluttet
-    find_a_taxon:
+    find_a_taxon: 
     first_item: Første vares pris
     first_name: Fornavn
     first_name_begins_with: Fornavn begynder med
@@ -683,7 +686,7 @@ da:
     flexible_rate: Flexible pris
     forgot_password: Glemt adgangskode
     free_shipping: Gratis levering
-    free_shipping_amount:
+    free_shipping_amount: 
     from: Fra
     front_end: Kunde interface
     gateway: Betalingsleverandør
@@ -702,29 +705,31 @@ da:
     height: Højde
     helpers:
       products:
-        price_diff_add_html: "Pris forskel: %{amount_html}"
-        price_diff_subtract_html: "Pris forskel: -%{amount_html}"
+        price_diff_add_html: 'Pris forskel: %{amount_html}'
+        price_diff_subtract_html: 'Pris forskel: -%{amount_html}'
     hidden: Skjult
     hide_cents: Skjul øre
     hints:
       spree/price:
-        country: "Dette afgører hvilke lande prisen bruges i.<br> Default: Alle lande"
-        master_variant: "Changing master variant prices will not change variant prices below, but will be used to populate all new variants"
-        options: "These options are used to create variants in the variants table. They can be changed in the variants tab"
+        country: 'Dette afgører hvilke lande prisen bruges i.<br> Default: Alle lande'
+        master_variant: Changing master variant prices will not change variant prices below, but will be used to populate all new variants
+        options: These options are used to create variants in the variants table. They can be changed in the variants tab
       spree/product:
-        promotionable: "Kan der køres kampanger på dette produkt.<br>Default: Checked"
-        shipping_category: "Hvilken type fragt kræver dette produkt.<br> Default: Default"
-        tax_category: "Hvilke afgifter lægges på dette produkt.<br> Default: None"
+        promotionable: 'Kan der køres kampanger på dette produkt.<br>Default: Checked'
+        shipping_category: 'Hvilken type fragt kræver dette produkt.<br> Default: Default'
+        tax_category: 'Hvilke afgifter lægges på dette produkt.<br> Default: None'
       spree/promotion:
-        starts_at: "Fra hvornår gælder en kampagne. <br> Hvis feltet er tomt gælder kampagnen med det samme."
-        expires_at: "Hvornår udløber kampagnen. <br> Hvis feltet er tomt udløber kampagnen aldrig."
+        expires_at: Hvornår udløber kampagnen. <br> Hvis feltet er tomt udløber kampagnen aldrig.
+        starts_at: Fra hvornår gælder en kampagne. <br> Hvis feltet er tomt gælder kampagnen med det samme.
       spree/store:
-        cart_tax_country_iso: "Dette afgører hvilket land der beregnes afgifter i på indkøbskurven (ordre som endnu ikke har en adresse).<br> Default: Ingen."
+        cart_tax_country_iso: 'Dette afgører hvilket land der beregnes afgifter i på indkøbskurven (ordre som endnu ikke har en adresse).<br>
+          Default: Ingen.'
       spree/variant:
-        tax_category: "Dette afgører hvilken slags afgift denne variant bliver pålagt.<br> Default: Bruger afgiftskategorien for produktet."
-        deleted: "Slettet variant"
-        deleted_explanation: "Denne variant slettes den %{date}."
-        deleted_explanation_with_replacement: "Denne variant blev slettet den %{date}. Den er siden hen blevet erstattet af en anden med det samme SKU."
+        deleted: Slettet variant
+        deleted_explanation: Denne variant slettes den %{date}.
+        deleted_explanation_with_replacement: Denne variant blev slettet den %{date}. Den er siden hen blevet erstattet af en anden med det samme
+          SKU.
+        tax_category: 'Dette afgører hvilken slags afgift denne variant bliver pålagt.<br> Default: Bruger afgiftskategorien for produktet.'
     home: Forside
     i18n:
       available_locales: Tilgængelige sprog
@@ -737,33 +742,33 @@ da:
       this_file_language: Danish
       translations: Oversættelser
     icon: Ikon
-    identifier:
+    identifier: 
     image: Billed
     images: Billeder
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
     incl: inkl.
     included_in_price: Inkluderet i prisen
     included_price_validation: kan ikke vælges med mindre du har sat en standard skatte-zone
-    incomplete:
-    info_number_of_skus_not_shown: "Der er yderligere %{count} varenumre"
-    info_product_has_multiple_skus: "Produktet har %{count} varenumre"
+    incomplete: 
+    info_number_of_skus_not_shown: Der er yderligere %{count} varenumre
+    info_product_has_multiple_skus: Produktet har %{count} varenumre
     instructions_to_reset_password: 'Udfyld formen nedenfor og vi vil sende dig instruktionerne til at nulstille din adgangskode:'
     insufficient_stock: Der er ikke nok på lager, kun %{on_hand} tilbage
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Opsnap e-mail-adresse
     intercept_email_instructions: Overskriv e-mail-modtagerens adresse med denne adresse.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Ugyldig betalingsformidler
     invalid_promotion_action: Ugyldig rabat handling.
     invalid_promotion_rule: Ugyldig rabat regel.
     inventory: Beholdning
     inventory_adjustment: Beholdningsjustering
     inventory_error_flash_for_insufficient_quantity: En vare i din kurv er ikke længere på lager.
-    inventory_state:
+    inventory_state: 
     inventory_states:
       on_hand: På lager
     is_not_available_to_shipment_address: er ikke tilgængelig for leveringsadressen
@@ -778,9 +783,9 @@ da:
         lt: mindre end
         lte: mindre end eller lig med
     items_cannot_be_shipped: Vi kan ikke beregne leveringsomkostningerne for de valgte varer og leveringsadresse
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe Statistik
     landing_page_rule:
       path: Path
@@ -794,7 +799,7 @@ da:
     locale_changed: Sproget er ændret
     location: Sted
     lock: Lås
-    log_entries:
+    log_entries: 
     logged_in_as: Logget ind som
     logged_in_succesfully: Du er nu logget ind
     logged_out: Du er nu logget ud.
@@ -806,11 +811,11 @@ da:
     logs: Logs
     look_for_similar_items: Lignende varer
     make_refund: Foretage tilbagebetaling
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
     manage_stock: Lagerstyrring
     manage_variants: Rediger varianter
-    manual_intervention_required:
+    manual_intervention_required: 
     master_price: Hovedpris
     master_variant: Hovedprodukt
     match_choices:
@@ -818,10 +823,10 @@ da:
       none: None
     max_items: Maksimalt antal varer
     member_since: Kunde siden
-    memo:
+    memo: 
     meta_description: Metabeskrivelse
     meta_keywords: Metanøgleord
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Minimalt beløb
     month: Måned
@@ -837,7 +842,7 @@ da:
     new_adjustment_reason: Ny justeringsårsag
     new_country: Nyt land
     new_customer: Ny kunde
-    new_customer_return:
+    new_customer_return: 
     new_image: Nyt billede
     new_option_type: Ny alternative udgave
     new_order: Ny ordre
@@ -846,10 +851,10 @@ da:
     new_payment_method: Ny betalingsmetode
     new_product: Nyt produkt
     new_promotion: Ny kampagne
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Ny egenskab
     new_prototype: Ny prototype
-    new_refund:
+    new_refund: 
     new_refund_reason: Opret Tilbagebetalingsårsag
     new_return_authorization: Ny returnerings autorisation
     new_rma_reason: Opret Returvare årsag
@@ -872,26 +877,26 @@ da:
     new_zone: Ny zone
     next: Næste
     no_actions_added: Ingen handlinger tilføjet
-    no_option_values_on_product_html: 'Ingen varianter fundet. Opret %{link}.'
+    no_option_values_on_product_html: Ingen varianter fundet. Opret %{link}.
     no_payment_found: Ingen betaling fundet
     no_pending_payments: Ingen afventende betalinger
     no_products_found: Ingen varer fundet
-    no_resource: 'Ingen %{resource}'
-    no_resource_found:
+    no_resource: Ingen %{resource}
+    no_resource_found: 
     no_results: Ingen resultater
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: Ingen regler tilføjet
     no_shipping_method_selected: Ingen forsendelsesmåde er valgt
-    no_state_changes:
+    no_state_changes: 
     no_tracking_present: Ingen track & trace oplysninger.
     none: Ingen
-    none_selected:
+    none_selected: 
     normal_amount: Normalt beløb
     not: ikke
     not_available: N/A
     not_enough_stock: Ikke nok på lager til at gennemføre denne lagerflytning.
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
       product_cloned: Produktet er blevet duplikeret
       product_deleted: Produktet er blevet slettet
@@ -902,8 +907,8 @@ da:
     num_orders: Antal ordrer
     number: Antal
     on_hand: På lager
-    open: "Åben"
-    open_all_adjustments: "Åbn alle justeringer"
+    open: Åben
+    open_all_adjustments: Åbn alle justeringer
     option_type: Alternativ udgave
     option_type_placeholder: Vælg en alternativ udgave
     option_types: Alternative udgaver
@@ -915,7 +920,7 @@ da:
     or_over_price: "%{price} or over"
     order: Ordre
     order_adjustments: Ordrejusteringer
-    order_already_updated:
+    order_already_updated: 
     order_approved: Ordre godkendt
     order_canceled: Bestilling annulleret
     order_completed: Bestilling gennemført
@@ -928,23 +933,23 @@ da:
         instructions: Din ordre er blevet annulleret. Gem venligst denne annullering
         order_summary_canceled: Sammendrag af ordre [Annulleret]
         subject: Annullering af ordre
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Kære kunde,\n
         instructions: Gennemlæs og gem venligst følgende orderinformation.
         order_summary: Sammendrag af ordre
         subject: Ordrebekræftelse
-        subtotal:
+        subtotal: 
         thanks: Tak for handelen.
-        total:
+        total: 
     order_not_found: Vi kunne ikke finde din ordre. Prøv venligst sidste handling igen.
-    order_number: "Ordrenummer %{number}"
+    order_number: Ordrenummer %{number}
     order_please_refresh: Opdater venligst bestillingen
     order_processed_successfully: Din ordre er blevet modtaget
     order_ready_for_confirm: Bestillingen er klar til at blive bekræftet
     order_refresh_totals: Opdater totaler
-    order_resumed:
+    order_resumed: 
     order_state:
       address: adresse
       awaiting_return: afventer returnering
@@ -962,7 +967,7 @@ da:
     order_total: Ordre total
     order_updated: Ordre opdateret
     orders: Ordrer
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Ikke på lager
     overview: Oversigt
     package_from: pakke fra
@@ -975,11 +980,11 @@ da:
     path: Sti
     pay: betal
     payment: Betaling
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Betalingsinformation
     payment_method: Betalingsmetode
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Betalingsmetoder
     payment_processing_failed: Betalingen kunne ikke gennemføres. Hver venlig at checke de detaljer du har indtastet.
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -997,8 +1002,8 @@ da:
       void: annulleret
     payment_updated: Betaling er opdater
     payments: Betalinger
-    payments_failed_count: '%{count} fejlslagne betalingsforsøg'
-    pending:
+    payments_failed_count: "%{count} fejlslagne betalingsforsøg"
+    pending: 
     percent: Procent
     percent_per_item: Percent Per Item
     permalink: Permalink
@@ -1007,13 +1012,13 @@ da:
     please_define_payment_methods: Vær venlig at opret nogle betalingsmuligheder først.
     populate_get_error: Der gik noget galt. Forsøg at tilføje artiklen igen.
     powered_by: Leveret af
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: præsentation
     previous: Foregående
-    previous_state_missing:
+    previous_state_missing: 
     price: Pris
     price_range: Prisklasse
     price_sack: Prisgruppe
@@ -1025,10 +1030,10 @@ da:
     product_properties: Vareegenskaber
     product_rule:
       choose_products: Vælg varer
-      label:
+      label: 
       match_all: alle
       match_any: mindst en
-      match_none:
+      match_none: 
       product_source:
         group: Fra varegruppe
         manual: Vælg manuelt
@@ -1040,14 +1045,14 @@ da:
         description: Creates a promotion credit adjustment on the order
         name: Create adjustment
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Populates the cart with the specified quantity of variant
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Handlinger
     promotion_form:
       match_policies:
@@ -1065,27 +1070,27 @@ da:
         description: Kunde skal have besøgt the angivne side
         name: Landingsside
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Ordrer inkluderer angivne vare(r)
         name: Vare(r)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Kun tilgængelig for de angivne bruger
         name: Bruger
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Kampagner
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Egenskaber
     property: Egenskab
     prototype: Prototype
@@ -1096,43 +1101,43 @@ da:
     quantity: Antal
     quantity_returned: Antal returneret
     quantity_shipped: Antal leveret
-    quick_search:
+    quick_search: 
     rate: Sats
     ready_to_ship: Klar til levering
     reason: Anledning
     receive: Modtage
     receive_stock: Modtag varer
     received: Modtaget
-    reception_status:
+    reception_status: 
     reference: Reference
     refund: Tilbagebetal
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Registrer som nu bruger
     registration: Registrering
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Husk mig
     remove: Fjern
     rename: Omdøb
@@ -1145,19 +1150,19 @@ da:
     resumed: Genoptaget
     return: vend tilbage
     return_authorization: Retur-godkendelse
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Retur-godkendelse opdateret
     return_authorizations: Retur-godkendelser
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Retur-antal
     returned: Returneret
-    returns:
+    returns: 
     review: Review
     risk: Risiko
     risk_analysis: Risikoanalyse
@@ -1177,13 +1182,13 @@ da:
     say_yes: Ja
     scope: Område
     search: Søg
-    search_results: "Søgeresultater for '%{keywords}'"
+    search_results: Søgeresultater for '%{keywords}'
     searching: Søger
     secure_connection_type: Sikker forbindelsestype
     security_settings: Sikkerhedsindstillinger
     select: Vælg
     select_a_reason: Vælg en årsag
-    select_a_return_authorization_reason:
+    select_a_return_authorization_reason: 
     select_a_stock_location: Vælg en lager lokalitet
     select_from_prototype: Vægl fra prototype
     select_stock: Vælg
@@ -1216,15 +1221,15 @@ da:
       pending: afventende
       ready: klar
       shipped: leveret
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Leveringer
     shipped: Leveret
     shipping: Levering
     shipping_address: Leveringsadresse
     shipping_categories: Leveringskategori
     shipping_category: Leveringskategori
-    shipping_flat_rate_per_item:
+    shipping_flat_rate_per_item: 
     shipping_flat_rate_per_order: Fastpris
     shipping_flexible_rate: Variabel fragtpris
     shipping_instructions: Leveringsinstruktioner
@@ -1233,64 +1238,64 @@ da:
     shipping_price_sack: Prissænkning
     shipping_rate:
       display_price:
-        display_price_with_explanations: '%{price} %{explanations}'
+        display_price_with_explanations: "%{price} %{explanations}"
     shipping_rate_tax:
       label:
-        sales_tax: 'plus %{tax_rate_name} %{amount}'
+        sales_tax: plus %{tax_rate_name} %{amount}
     shipping_total: Forsendelse ialt
-    shop_by_taxonomy: '%{taxonomy}'
+    shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: Indkøbskurv
     show: Vis
     show_active: Vis aktive
     show_deleted: Vis slettede
     show_only_complete_orders: Vis kun afsluttede ordrer
-    show_only_considered_risky:
+    show_only_considered_risky: 
     show_only_open_transfers: Vis kun udestående overførsler
     show_rate_in_label: Vis sats i label
     sku: Varenummer
     skus: Varenumre
-    slug:
+    slug: 
     source: Kilde
     special_instructions: Specielle instrukser
     split: Del
     spree_gateway_error_flash_for_checkout: Der var et problem med din betalingsinformation. Check dine informationer og prøv igen.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Start
     state: Delstat
     state_based: Delstatsbaseret
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Delstater
     states_required: Stat/region kræves
     status: Status
@@ -1298,9 +1303,9 @@ da:
     stock_location: Lagersted
     stock_location_info: Information om lagersted
     stock_locations: Lagersteder
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Lagerstyring
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: 
     stock_movements: Lagerbevægelser
     stock_movements_for_stock_location: Lagerbevægelser for %{stock_location_name}
     stock_successfully_transferred: Varerne er blevet flyttet mellem lagerstederne.
@@ -1324,26 +1329,26 @@ da:
     subtract: Fratræk
     success: Gennemført
     successfully_created: "%{resource} er blevet oprettet!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} er blevet slettet!"
     successfully_signed_up_for_analytics: Du er nu koblet på Spree Analytics
     successfully_updated: "%{resource} er blevet opdateret!"
-    summary:
+    summary: 
     tax: Afgift
     tax_categories: Afgiftskategorier
     tax_category: Afgiftskategori
-    tax_code:
-    tax_included:
+    tax_code: 
+    tax_included: 
     tax_rate_amount_explanation: Moms tastes som decimaltal. (25% tastes som 0.25)
     tax_rates: afgiftssatser
     taxon: Taksonomisk gruppe
     taxon_edit: Rediger taksonomisk gruppe
     taxon_placeholder: Tilføj taksonomisk gruppe
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taksonomier
     taxonomy: Taxonomy
     taxonomy_edit: Rediger taksonomi
@@ -1358,27 +1363,27 @@ da:
         subject: Testmail
     test_mode: Testtilstand
     thank_you_for_your_order: Tak for din bestilling. Udskriv venligst denne bekræftelsesside til opbevaring.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: Der var problemer med følgende felter
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Tid
     to: Til
     to_add_variants_you_must_first_define: For at tilføje varianter, må du først definere
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
     total_sales: Salg ialt
-    track_inventory:
+    track_inventory: 
     tracking: Sporing
     tracking_number: Track & trace nummer
     tracking_url: Track & trace url
     tracking_url_placeholder: fx. http://www.postdanmark.dk/da/Sider/TrackTrace.aspx?search=:tracking
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Flyt fra
     transfer_stock: Flyt varer
     transfer_to_location: Flyt til
@@ -1386,7 +1391,7 @@ da:
     type: Type
     type_to_search: Skriv for at søge
     unable_to_connect_to_gateway: Ude af stand til at forbinde til betalingsleverandør.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
     unfinalize_all_adjustments: Lås alle justeringer op
     unlock: Lås op
@@ -1405,12 +1410,12 @@ da:
     users: Brugere
     validation:
       cannot_be_less_than_shipped_units: kan ikke være mindre end antallet af leverede enheder.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: Overskrider tilgængelig beholdning. Du bør sikre dig varer har et gyldigt antal
       is_too_large: er for stor – der er ikke nok på lager!
       must_be_int: skal være et heltal
       must_be_non_negative: skal være et positivt tal
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Værdi
     variant: Variant
     variant_placeholder: Vælg en variant
@@ -1425,7 +1430,7 @@ da:
     what_is_a_cvv: Hvad er en sikkerhedskode (CVC)?
     what_is_this: Hvad er dette?
     width: Bredde
-    year: "År"
+    year: År
     you_have_no_orders_yet: Du har endnu ingen ordre.
     your_cart_is_empty: Din indkøbskurv er tom
     your_order_is_empty_add_product: Din ordre er tom.

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -1,409 +1,410 @@
+---
 de-CH:
   activerecord:
     attributes:
       spree/address:
-        address1:
-        address2:
-        city:
-        country:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        address2: 
+        city: 
+        country: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
-        iso:
-        iso3:
-        iso_name:
-        name:
-        numcode:
+        iso: 
+        iso3: 
+        iso_name: 
+        name: 
+        numcode: 
       spree/credit_card:
-        base:
-        cc_type:
-        month:
-        name:
-        number:
-        verification_value:
-        year:
+        base: 
+        cc_type: 
+        month: 
+        name: 
+        number: 
+        verification_value: 
+        year: 
       spree/inventory_unit:
-        state:
+        state: 
       spree/line_item:
-        price:
-        quantity:
+        price: 
+        quantity: 
       spree/option_type:
-        name:
-        presentation:
+        name: 
+        presentation: 
       spree/order:
-        checkout_complete:
-        completed_at:
+        checkout_complete: 
+        completed_at: 
         considered_risky: Riskant
-        coupon_code:
-        created_at:
-        email:
-        ip_address:
-        item_total:
-        number:
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
-        total:
+        coupon_code: 
+        created_at: 
+        email: 
+        ip_address: 
+        item_total: 
+        number: 
+        payment_state: 
+        shipment_state: 
+        special_instructions: 
+        state: 
+        total: 
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/payment:
-        amount:
+        amount: 
       spree/payment_method:
-        name:
+        name: 
       spree/product:
-        available_on:
-        cost_currency:
-        cost_price:
-        description:
-        master_price:
-        name:
-        on_hand:
-        shipping_category:
-        tax_category:
+        available_on: 
+        cost_currency: 
+        cost_price: 
+        description: 
+        master_price: 
+        name: 
+        on_hand: 
+        shipping_category: 
+        tax_category: 
       spree/promotion:
-        advertise:
-        code:
-        description:
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        advertise: 
+        code: 
+        description: 
+        event_name: 
+        expires_at: 
+        name: 
+        path: 
+        starts_at: 
+        usage_limit: 
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
-        name:
-        presentation:
+        name: 
+        presentation: 
       spree/prototype:
-        name:
+        name: 
       spree/return_authorization:
-        amount:
+        amount: 
       spree/role:
-        name:
+        name: 
       spree/state:
-        abbr:
-        name:
+        abbr: 
+        name: 
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
-        description:
-        name:
+        description: 
+        name: 
       spree/tax_rate:
-        amount:
-        included_in_price:
-        show_rate_in_label:
+        amount: 
+        included_in_price: 
+        show_rate_in_label: 
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: 
+        permalink: 
+        position: 
       spree/taxonomy:
-        name:
+        name: 
       spree/user:
-        email:
-        password:
-        password_confirmation:
+        email: 
+        password: 
+        password_confirmation: 
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_currency: 
+        cost_price: 
+        depth: 
+        height: 
+        price: 
+        sku: 
+        weight: 
+        width: 
       spree/zone:
-        description:
-        name:
+        description: 
+        name: 
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
-      spree/address:
-      spree/country:
-      spree/credit_card:
-      spree/customer_return:
-      spree/inventory_unit:
-      spree/line_item:
-      spree/option_type:
-      spree/option_value:
-      spree/order:
-      spree/payment:
-      spree/payment_method:
-      spree/product:
-      spree/promotion:
-      spree/promotion_category:
-      spree/property:
-      spree/prototype:
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
-      spree/return_authorization:
-      spree/return_authorization_reason:
-      spree/role:
-      spree/shipment:
-      spree/shipping_category:
-      spree/shipping_method:
-      spree/state:
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
-      spree/tax_category:
-      spree/tax_rate:
-      spree/taxon:
-      spree/taxonomy:
-      spree/tracker:
-      spree/user:
-      spree/variant:
-      spree/zone:
+      spree/address: 
+      spree/country: 
+      spree/credit_card: 
+      spree/customer_return: 
+      spree/inventory_unit: 
+      spree/line_item: 
+      spree/option_type: 
+      spree/option_value: 
+      spree/order: 
+      spree/payment: 
+      spree/payment_method: 
+      spree/product: 
+      spree/promotion: 
+      spree/promotion_category: 
+      spree/property: 
+      spree/prototype: 
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
+      spree/return_authorization: 
+      spree/return_authorization_reason: 
+      spree/role: 
+      spree/shipment: 
+      spree/shipping_category: 
+      spree/shipping_method: 
+      spree/state: 
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
+      spree/tax_category: 
+      spree/tax_rate: 
+      spree/taxon: 
+      spree/taxonomy: 
+      spree/tracker: 
+      spree/user: 
+      spree/variant: 
+      spree/zone: 
   spree:
     abbreviation: Abkürzung
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Konto
     account_updated: Konto aktualisiert!
     action: Aktion
     actions:
       cancel: Abbrechen
-      continue:
+      continue: 
       create: Erstellen
       destroy: Löschen
-      edit:
+      edit: 
       list: Auflisten
       listing: Liste
       new: Neu
-      refund:
-      save:
+      refund: 
+      save: 
       update: Aktualisieren
     activate: Activate
     active: Aktiv
     add: Hinzufügen
     add_action_of_type: Add action of type
     add_country: Land hinzufügen
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: 
     add_option_value: Option Wert hinzufügen
     add_product: Produkt hinzufügen
     add_product_properties: Produkteigenschaft hinzufügen
     add_rule_of_type: Add rule of type
     add_state: Kanton hinzufügen
-    add_stock:
-    add_stock_management:
+    add_stock: 
+    add_stock_management: 
     add_to_cart: In den Warenkorb
-    add_variant:
+    add_variant: 
     additional_item: Additional Item Cost
-    address1:
-    address2:
-    adjustable:
+    address1: 
+    address2: 
+    adjustable: 
     adjustment: Anpassung
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: 
+    adjustment_successfully_closed: 
+    adjustment_successfully_opened: 
     adjustment_total: Adjustment Total
     adjustments: Preis-Anpassungen
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Verwaltung
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: 
+    agree_to_privacy_policy: 
+    agree_to_terms_of_service: 
     all: Alles
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: 
+    all_adjustments_opened: 
     all_departments: Alle Bereiche
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
-    already_signed_up_for_analytics:
+    already_signed_up_for_analytics: 
     alt_text: Alternative Text
     alternative_phone: Alternative Telefonnummer
     amount: Summe
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
-    analytics_trackers:
-    and:
-    approve:
-    approved_at:
-    approver:
+    analytics_desc_header_1: 
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
+    analytics_trackers: 
+    and: 
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Sind Sie sicher
     are_you_sure_delete: Sind sie sicher, dass Sie diesen Eintrag löschen möchten?
-    associated_adjustment_closed:
-    at_symbol: '@'
+    associated_adjustment_closed: 
+    at_symbol: "@"
     authorization_failure: Anmeldung fehlgeschlagen
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Verfügbar ab
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Zurück
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Zurück zum Shop
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_users_list: 
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Total ausstehend
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Rechnungsadresse
-    billing:
+    billing: 
     billing_address: Rechnungsadresse
-    both:
-    calculated_reimbursements:
+    both: 
+    calculated_reimbursements: 
     calculator: Rechner
     calculator_settings_warning: Wenn Sie den Rechner-Typ ändern, müssen Sie erst speichern, bevor Sie die Rechner-Einstellungen bearbeiten können
     cancel: verwerfen
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has not shipped yet.
     cannot_perform_operation: Cannot perform requested operation
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: 
     capture: stornieren
-    capture_events:
+    capture_events: 
     card_code: Kartenprüfnummer
     card_number: Kartennummer
-    card_type:
+    card_type: 
     card_type_is: Kartentyp ist
     cart: Warenkorb
-    cart_subtotal:
+    cart_subtotal: 
     categories: Kategorien
     category: Kategorie
-    charged:
-    check_for_spree_alerts:
+    charged: 
+    check_for_spree_alerts: 
     checkout: Zur Kasse
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: 
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 
+    choose_dashboard_locale: 
+    choose_location: 
     city: Stadt
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Klonen
-    close:
-    close_all_adjustments:
-    code:
-    company:
+    close: 
+    close_all_adjustments: 
+    code: 
+    company: 
     complete: komplett
     configuration: Konfiguration
     configurations: Konfigurationen
@@ -412,375 +413,375 @@ de-CH:
     confirm_password: Passwort bestätigen
     continue: Weitermachen
     continue_shopping: Weiter Einkaufen
-    cost_currency:
+    cost_currency: 
     cost_price: Einkaufspreis
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
+    countries: 
     country: Land
     country_based: Länderbasiert
-    country_name:
+    country_name: 
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon:
-    coupon_code:
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
+    coupon: 
+    coupon_code: 
+    coupon_code_already_applied: 
+    coupon_code_applied: 
+    coupon_code_better_exists: 
+    coupon_code_expired: 
+    coupon_code_max_usage: 
+    coupon_code_not_eligible: 
+    coupon_code_not_found: 
+    coupon_code_unknown_error: 
     create: Erstellen
     create_a_new_account: Neues Konto erstellen
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: 
+    create_reimbursement: 
+    created_at: 
     credit: Credit
     credit_card: Kreditkarte
     credit_cards: Credit Cards
     credit_owed: Credit Owed
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credits: 
+    currency: 
+    currency_decimal_mark: 
+    currency_settings: 
+    currency_symbol_position: 
+    currency_thousands_separator: 
     current: Stand
-    current_promotion_usage:
+    current_promotion_usage: 
     customer: Kunde
     customer_details: Kundenangaben
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Kundensuche
-    cut:
-    cvv_response:
+    cut: 
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
-    date_completed:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: 
+    date_completed: 
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 
+      format: 
+      js_format: 
     date_range: Datum (von/bis)
-    default:
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default: 
+    default_refund_amount: 
+    default_tax: 
+    default_tax_zone: 
     delete: Löschen
-    deleted_variants_present:
-    delivery:
+    deleted_variants_present: 
+    delivery: 
     depth: Tiefe
     description: Beschreibung
-    destination:
+    destination: 
     destroy: Entfernen
-    details:
-    discount_amount:
-    dismiss_banner:
+    details: 
+    discount_amount: 
+    dismiss_banner: 
     display: Anzeigen
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: 
+    doesnt_track_inventory: 
     edit: Bearbeiten
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Benutzer bearbeiten
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email:
-    empty:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
+    email: 
+    empty: 
     empty_cart: Warenkorb leeren
     enable_mail_delivery: Mailversand einschalten
-    end:
+    end: 
     ending_in: Ending in
     environment: Umgebung
     error: Fehler
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available:
-        no_shipping_methods_available:
-    errors_prohibited_this_record_from_being_saved:
+        could_not_create_taxon: 
+        no_payment_methods_available: 
+        no_shipping_methods_available: 
+    errors_prohibited_this_record_from_being_saved: 
     event: Ereignis
     events:
       spree:
         cart:
-          add:
+          add: 
         checkout:
-          coupon_code_added:
+          coupon_code_added: 
         content:
-          visited:
+          visited: 
         order:
-          contents_changed:
-        page_view:
+          contents_changed: 
+        page_view: 
         user:
-          signup:
+          signup: 
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Gültigkeitsdauer
     extension: Erweiterung
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Dateiname
-    fill_in_customer_info:
-    filter_results:
-    finalize:
-    finalized:
-    find_a_taxon:
-    first_item:
+    fill_in_customer_info: 
+    filter_results: 
+    finalize: 
+    finalized: 
+    find_a_taxon: 
+    first_item: 
     first_name: Vorname
     first_name_begins_with: Vorname beginnt mit
-    flat_percent:
-    flat_rate_per_order:
-    flexible_rate:
+    flat_percent: 
+    flat_rate_per_order: 
+    flexible_rate: 
     forgot_password: Passwort vergessen?
-    free_shipping:
-    free_shipping_amount:
-    front_end:
-    gateway:
-    gateway_config_unavailable:
+    free_shipping: 
+    free_shipping_amount: 
+    front_end: 
+    gateway: 
+    gateway_config_unavailable: 
     gateway_error: Gateway-Fehler
-    general:
+    general: 
     general_settings: Allgemeine Einstellungen
-    google_analytics:
-    google_analytics_id:
+    google_analytics: 
+    google_analytics_id: 
     guest_checkout: Gast-Einkauf
     guest_user_account: Ohne Registrierung bestellen
-    has_no_shipped_units:
+    has_no_shipped_units: 
     height: Höhe
-    hide_cents:
-    home:
+    hide_cents: 
+    home: 
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: Deutsch (Schweiz)
-    icon:
-    identifier:
+    icon: 
+    identifier: 
     image: Bild
     images: Bilder
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password:
-    insufficient_stock:
-    insufficient_stock_lines_present:
-    intercept_email_address:
-    intercept_email_instructions:
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: 
+    included_price_validation: 
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
+    instructions_to_reset_password: 
+    insufficient_stock: 
+    insufficient_stock_lines_present: 
+    intercept_email_address: 
+    intercept_email_instructions: 
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 
+    invalid_promotion_action: 
+    invalid_promotion_rule: 
     inventory: Lager
     inventory_adjustment: Lager-Anpassung
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
-    is_not_available_to_shipment_address:
-    iso_name:
+    inventory_error_flash_for_insufficient_quantity: 
+    inventory_state: 
+    is_not_available_to_shipment_address: 
+    iso_name: 
     item: Artikel
     item_description: Artikelbeschreibung
     item_total: Artikel Gesamt
     item_total_rule:
       operators:
-        gt:
-        gte:
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        gt: 
+        gte: 
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
+    jirafe: 
     landing_page_rule:
-      path:
+      path: 
     last_name: Nachname
     last_name_begins_with: Nachname beginnt mit
-    learn_more:
-    lifetime_stats:
-    line_item_adjustments:
+    learn_more: 
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Liste
     loading: Lade
     locale_changed: Sprache geändert
-    location:
-    lock:
-    log_entries:
+    location: 
+    lock: 
+    log_entries: 
     logged_in_as: Angemeldet als
     logged_in_succesfully: Erfolgreich angemeldet
     logged_out: Sie sind nun ausgeloggt.
-    login:
+    login: 
     login_as_existing: Als bestehender Kunde einloggen
     login_failed: Login-Authentifizierung fehlgeschlagen.
     login_name: Benutzer
     logout: Abmelden
-    logs:
-    look_for_similar_items: "Ähnliche Artikel"
-    make_refund:
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    logs: 
+    look_for_similar_items: Ähnliche Artikel
+    make_refund: 
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Grundpreis
     match_choices:
-      all:
-      none:
-    max_items:
-    member_since:
-    memo:
+      all: 
+      none: 
+    max_items: 
+    member_since: 
+    memo: 
     meta_description: Meta-Beschreibung
     meta_keywords: Meta-Schlüsselwörter
-    meta_title:
+    meta_title: 
     metadata: Metadaten
-    minimal_amount:
+    minimal_amount: 
     month: Monat
-    more:
-    move_stock_between_locations:
+    more: 
+    move_stock_between_locations: 
     my_account: Mein Konto
     my_orders: Meine Bestellungen
     name: Name
-    name_on_card:
+    name_on_card: 
     name_or_sku: Name oder Lagerhaltungsnummer
     new: Neu
     new_adjustment: Neue Preis-Anpassung
-    new_country:
+    new_country: 
     new_customer: Neuer Kunde
-    new_customer_return:
+    new_customer_return: 
     new_image: Neues Bild
     new_option_type: Neue Option
     new_order: Neue Bestellung
-    new_order_completed:
+    new_order_completed: 
     new_payment: Neue Bezahlung
     new_payment_method: New Payment Method
     new_product: Neues Produkt
     new_promotion: Neue Promotion
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Neue Eigenschaft
     new_prototype: Neuer Prototyp
-    new_refund:
-    new_refund_reason:
-    new_return_authorization:
-    new_rma_reason:
-    new_shipment_at_location:
+    new_refund: 
+    new_refund_reason: 
+    new_return_authorization: 
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Neue Versandkategorie
     new_shipping_method: Neue Versandmethode
     new_state: Neuer Kanton
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: 
+    new_stock_movement: 
+    new_stock_transfer: 
     new_tax_category: Neue Steuer-Kategorie
     new_tax_rate: Neuer Steuersatz
-    new_taxon:
+    new_taxon: 
     new_taxonomy: Neue Taxonomie
-    new_tracker:
+    new_tracker: 
     new_user: Neuer Benutzer
     new_variant: Neue Variante
     new_zone: Neue Zone
     next: weiter
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: 
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: Keine Produkte gefunden
-    no_resource_found:
-    no_results:
-    no_returns_found:
-    no_rules_added:
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_resource_found: 
+    no_results: 
+    no_returns_found: 
+    no_rules_added: 
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
     none: kein
-    none_selected:
-    normal_amount:
-    not:
-    not_available:
-    not_enough_stock:
-    not_found:
-    note:
+    none_selected: 
+    normal_amount: 
+    not: 
+    not_available: 
+    not_enough_stock: 
+    not_found: 
+    note: 
     notice_messages:
-      product_cloned:
-      product_deleted:
-      product_not_cloned:
-      product_not_deleted:
-      variant_deleted:
-      variant_not_deleted:
-    num_orders:
+      product_cloned: 
+      product_deleted: 
+      product_not_cloned: 
+      product_not_deleted: 
+      variant_deleted: 
+      variant_not_deleted: 
+    num_orders: 
     on_hand: Auf Lager
-    open:
-    open_all_adjustments:
-    option_type:
-    option_type_placeholder:
+    open: 
+    open_all_adjustments: 
+    option_type: 
+    option_type_placeholder: 
     option_types: Optionen
-    option_value:
+    option_value: 
     option_values: Optionswalues
-    optional:
+    optional: 
     options: Optionen
     or: oder
     or_over_price: "%{price} or over"
     order: Bestellung
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_adjustments: 
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Details der Bestellung
     order_email_resent: Bestellbestätigung erneut versendet
-    order_information:
+    order_information: 
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: 
+        instructions: 
+        order_summary_canceled: 
+        subject: 
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: 
+        instructions: 
+        order_summary: 
+        subject: 
+        subtotal: 
+        thanks: 
+        total: 
+    order_not_found: 
+    order_number: 
     order_processed_successfully: Ihre Bestellung wurde erfolgreich bearbeitet
-    order_resumed:
+    order_resumed: 
     order_state:
       address: Adresse
       awaiting_return: awaiting return
@@ -788,7 +789,7 @@ de-CH:
       cart: Warenkorb
       complete: Abgeschlossen
       confirm: Bestätigt
-      considered_risky:
+      considered_risky: 
       delivery: Versendet
       payment: Bezahlt
       resumed: resumed
@@ -798,248 +799,248 @@ de-CH:
     order_total: Gesamtsumme
     order_updated: Bestellung aktualisiert
     orders: Bestellungen
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Ausverkauft
-    overview: "Übersicht"
-    package_from:
+    overview: Übersicht
+    package_from: 
     pagination:
-      next_page:
-      previous_page:
+      next_page: 
+      previous_page: 
       truncate: "…"
     password: Passwort
     paste: Paste
     path: Pfad
     pay: zahlen
     payment: Zahlung
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Zahlungsinformationen
     payment_method: Zahlungsmethode
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Zahlungsmethoden
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
+    payment_processing_failed: 
+    payment_processor_choose_banner_text: 
     payment_processor_choose_link: our payments page
     payment_state: Bezahlstatus
     payment_states:
       balance_due: fällig
-      checkout:
-      completed:
+      checkout: 
+      completed: 
       credit_owed: credit owed
       failed: failed
       paid: bezahlt
       pending: ausstehend
       processing: processing
       void: void
-    payment_updated:
+    payment_updated: 
     payments: Zahlungen
-    pending:
-    percent:
-    percent_per_item:
-    permalink:
-    phone:
+    pending: 
+    percent: 
+    percent_per_item: 
+    permalink: 
+    phone: 
     place_order: Bestellung ausführen
-    please_define_payment_methods:
-    populate_get_error:
-    powered_by:
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    please_define_payment_methods: 
+    populate_get_error: 
+    powered_by: 
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Anzeige
     previous: zurück
-    previous_state_missing:
+    previous_state_missing: 
     price: Preis
-    price_range:
-    price_sack:
+    price_range: 
+    price_sack: 
     process: Abschicken
     product: Produkt
     product_details: Produkt-Details
     product_has_no_description: Produkt hat keine Beschreibung
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: Produkt-Eigenschaften
     product_rule:
-      choose_products:
-      label:
-      match_all:
-      match_any:
-      match_none:
+      choose_products: 
+      label: 
+      match_all: 
+      match_any: 
+      match_none: 
       product_source:
-        group:
-        manual:
+        group: 
+        manual: 
     products: Produkte
-    promotion:
-    promotion_action:
+    promotion: 
+    promotion_action: 
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: 
+        name: 
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: 
+        name: 
+    promotion_actions: 
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: 
+        any: 
+    promotion_rule: 
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: 
+        name: 
       item_total:
-        description:
-        name:
+        description: 
+        name: 
       landing_page:
-        description:
-        name:
+        description: 
+        name: 
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description:
-        name:
+        description: 
+        name: 
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
-        description:
-        name:
+        description: 
+        name: 
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
+        description: 
+        name: 
+    promotion_uses: 
+    promotionable: 
     promotions: Promotionen
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Eigenschaften
     property: Eigenschaft
     prototype: Prototype
     prototypes: Prototypen
-    provider:
-    provider_settings_warning:
+    provider: 
+    provider_settings_warning: 
     qty: Anzahl
-    quantity:
-    quantity_returned:
-    quantity_shipped:
-    quick_search:
-    rate:
-    reason:
-    receive:
-    receive_stock:
-    received:
-    reception_status:
-    reference:
-    refund:
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    quantity: 
+    quantity_returned: 
+    quantity_shipped: 
+    quick_search: 
+    rate: 
+    reason: 
+    receive: 
+    receive_stock: 
+    received: 
+    reception_status: 
+    reference: 
+    refund: 
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Als Neukunde registrieren
     registration: Registrierung
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Auf diesem Computer speichern
     remove: Entfernen
     rename: Rename
-    report:
+    report: 
     reports: Berichte
     resend: Neu versenden
     reset_password: Mein Passwort zurücksetzen
     response_code: Rückgabewert
     resume: Fortsetzen
     resumed: Fortgesetzt
-    return:
-    return_authorization:
-    return_authorization_reasons:
-    return_authorization_updated:
-    return_authorizations:
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity:
-    returned:
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit:
-    rma_number:
-    rma_value:
+    return: 
+    return_authorization: 
+    return_authorization_reasons: 
+    return_authorization_updated: 
+    return_authorizations: 
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
+    return_quantity: 
+    returned: 
+    returns: 
+    review: 
+    risk: 
+    risk_analysis: 
+    risky: 
+    rma_credit: 
+    rma_number: 
+    rma_value: 
     roles: Rollen
-    rules:
-    safe:
+    rules: 
+    safe: 
     sales_total: Umsatz Gesamt
-    sales_total_description:
-    sales_totals:
+    sales_total_description: 
+    sales_totals: 
     save_and_continue: Speichern und fortsetzen
-    save_my_address:
-    say_no:
-    say_yes:
-    scope:
+    save_my_address: 
+    say_no: 
+    say_yes: 
+    scope: 
     search: Suchen
-    search_results:
-    searching:
-    secure_connection_type:
-    security_settings:
+    search_results: 
+    searching: 
+    secure_connection_type: 
+    security_settings: 
     select: Auswählen
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Vom Prototypen auswählen
-    select_stock:
+    select_stock: 
     send_copy_of_all_mails_to: Schicke eine Kopie aller E-Mails an
     send_mails_as: Schicke E-Mail als
-    server:
+    server: 
     server_error: Der Server hat einen Fehler gemeldet
     settings: Einstellungen
     ship: verschicken
     ship_address: Lieferadresse
-    ship_total:
+    ship_total: 
     shipment: Lieferung
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
+        dear_customer: 
+        instructions: 
+        shipment_summary: 
+        subject: 
+        thanks: 
+        track_information: 
+        track_link: 
     shipment_state: Versandstatus
     shipment_states:
       backorder: Lieferrückstand
@@ -1048,188 +1049,189 @@ de-CH:
       pending: bevorstehend
       ready: Bereit
       shipped: Versendet
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Versand
     shipped: Ausgeliefert
     shipping: Lieferung
     shipping_address: Lieferadresse
     shipping_categories: Versandkategorien
     shipping_category: Versandkategorie
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
-    shipping_instructions:
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
+    shipping_instructions: 
     shipping_method: Versandart
     shipping_methods: Versandarten
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: 
+    shipping_total: 
     shop_by_taxonomy: "%{taxonomy} einkaufen"
     shopping_cart: Warenkorb
     show: Zeigen
-    show_active:
+    show_active: 
     show_deleted: Gelöschte anzeigen
     show_only_complete_orders: Nur komplette Bestellungen anzeigen
     show_only_considered_risky: Nur riskante Bestellungen anzeigen
-    show_rate_in_label:
+    show_rate_in_label: 
     sku: Lagerhaltungsnummer
-    skus:
-    slug:
-    source:
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+    skus: 
+    slug: 
+    source: 
+    special_instructions: 
+    split: 
+    spree_gateway_error_flash_for_checkout: 
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Von
     state: Kanton
     state_based: Basierend auf Kanton
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Kantone
-    states_required:
-    status:
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    states_required: 
+    status: 
+    stock: 
+    stock_location: 
+    stock_location_info: 
+    stock_locations: 
+    stock_locations_need_a_default_country: 
+    stock_management: 
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
+    stock_transfer: 
+    stock_transfers: 
     stop: Bis
     store: Laden
     street_address: Strasse
     street_address_2: Strasse (Feld 2)
     subtotal: Zwischensumme
     subtract: Subtrahieren
-    success:
-    successfully_created:
-    successfully_refunded:
-    successfully_removed:
-    successfully_signed_up_for_analytics:
-    successfully_updated:
-    summary:
+    success: 
+    successfully_created: 
+    successfully_refunded: 
+    successfully_removed: 
+    successfully_signed_up_for_analytics: 
+    successfully_updated: 
+    summary: 
     tax: MwSt.
     tax_categories: Steuerkategorien
     tax_category: Steuerkategorie
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
     tax_rates: Steuersätze
     taxon: Taxonomie
     taxon_edit: Taxonomie bearbeiten
-    taxon_placeholder:
+    taxon_placeholder: 
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taxonomien
-    taxonomy:
+    taxonomy: 
     taxonomy_edit: Taxonomie bearbeiten
-    taxonomy_tree_error: Die angeforderte Änderung wurde nicht akzeptiert, und der Baum wurde in seinen vorherigen Zustand versetzt, bitte noch einmal versuchen!
+    taxonomy_tree_error: Die angeforderte Änderung wurde nicht akzeptiert, und der Baum wurde in seinen vorherigen Zustand versetzt, bitte noch
+      einmal versuchen!
     taxonomy_tree_instruction: "* Rechtsklick auf ein Kind im Baum öffnet das Menü zum Hinzufügen, Löschen oder Sortieren."
     taxons: Klassifizierungen
     test: Test
     test_mailer:
       test_email:
-        greeting:
-        message:
-        subject:
+        greeting: 
+        message: 
+        subject: 
     test_mode: Test-Modus
     thank_you_for_your_order: Vielen Dank für ihre Bestellung
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields:
-    this_order_has_already_received_a_refund:
+    there_are_no_items_for_this_order: 
+    there_were_problems_with_the_following_fields: 
+    this_order_has_already_received_a_refund: 
     thumbnail: Miniaturansicht
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: 
     to_add_variants_you_must_first_define: Um Varianten hinzuzufügen, müssen Sie sie erst definieren.
     total: Gesamt
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Tracking
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
     tree: Baum
     type: Typ
-    type_to_search:
-    unable_to_connect_to_gateway:
-    unable_to_create_reimbursements:
-    under_price:
-    unlock:
-    unrecognized_card_type:
-    unshippable_items:
+    type_to_search: 
+    unable_to_connect_to_gateway: 
+    unable_to_create_reimbursements: 
+    under_price: 
+    unlock: 
+    unrecognized_card_type: 
+    unshippable_items: 
     update: Speichern
     updating: Aktualisiere
     usage_limit: Nutzungsbeschränkung
-    use_app_default:
+    use_app_default: 
     use_billing_address: Rechnungsadresse verwenden
-    use_new_cc:
-    use_s3:
+    use_new_cc: 
+    use_s3: 
     user: Benutzer
     user_rule:
-      choose_users:
+      choose_users: 
     users: Benutzer
     validation:
-      cannot_be_less_than_shipped_units:
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
-      is_too_large:
-      must_be_int:
-      must_be_non_negative:
-      unpaid_amount_not_zero:
+      cannot_be_less_than_shipped_units: 
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 
+      is_too_large: 
+      must_be_int: 
+      must_be_non_negative: 
+      unpaid_amount_not_zero: 
     value: Wert
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: 
     variants: Varianten
-    version:
-    void:
+    version: 
+    void: 
     weight: Gewicht
     what_is_a_cvv: Was ist die (CVV) Kreditkartenprüfnummer?
     what_is_this: Was ist das?
@@ -1237,8 +1239,8 @@ de-CH:
     year: Jahr
     you_have_no_orders_yet: Sie haben noch keine Bestellungen.
     your_cart_is_empty: Ihr Warenkorb ist leer
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: 
     zip: PLZ
-    zipcode:
+    zipcode: 
     zone: Zone
     zones: Zonen

--- a/config/locales/en-AU.yml
+++ b/config/locales/en-AU.yml
@@ -1,3 +1,4 @@
+---
 en-AU:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ en-AU:
         state: State
         zipcode: Postcode
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +25,10 @@ en-AU:
         name: Name
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: 
         cc_type: Type
         month: Month
-        name:
+        name: 
         number: Number
         verification_value: Verification Value
         year: Year
@@ -42,8 +43,8 @@ en-AU:
       spree/order:
         checkout_complete: Checkout Complete
         completed_at: Completed At
-        considered_risky:
-        coupon_code:
+        considered_risky: 
+        coupon_code: 
         created_at: Order Date
         email: Customer E-Mail
         ip_address: IP Address
@@ -71,12 +72,12 @@ en-AU:
         state: Shipping address state
         zipcode: Shipping address postcode
       spree/payment:
-        amount:
+        amount: 
       spree/payment_method:
         name: Name
       spree/product:
         available_on: Available On
-        cost_currency:
+        cost_currency: 
         cost_price: Cost Price
         description: Description
         master_price: Master Price
@@ -95,7 +96,7 @@ en-AU:
         starts_at: Starts At
         usage_limit: Usage Limit
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Name
         presentation: Presentation
@@ -109,20 +110,20 @@ en-AU:
         abbr: Abbreviation
         name: Name
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Description
         name: Name
@@ -141,7 +142,7 @@ en-AU:
         password: Password
         password_confirmation: Password Confirmation
       spree/variant:
-        cost_currency:
+        cost_currency: 
         cost_price: Cost Price
         depth: Depth
         height: Height
@@ -157,47 +158,47 @@ en-AU:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Address
@@ -208,40 +209,40 @@ en-AU:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
       spree/line_item:
         one: Line Item
         other: Line Items
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Order
         other: Orders
       spree/payment:
         one: Payment
         other: Payments
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Product
         other: Products
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
         one: Property
         other: Properties
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Return Authorization
         other: Return Authorizations
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Roles
         other: Roles
@@ -251,14 +252,14 @@ en-AU:
       spree/shipping_category:
         one: Shipping Category
         other: Shipping Categories
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: State
         other: States
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Tax Category
         other: Tax Categories
@@ -271,7 +272,7 @@ en-AU:
       spree/taxonomy:
         one: Taxonomy
         other: Taxonomies
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: User
         other: Users
@@ -283,171 +284,171 @@ en-AU:
         other: Zones
   spree:
     abbreviation: Abbreviation
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Account
     account_updated: Account updated!
     action: Action
     actions:
       cancel: Cancel
-      continue:
+      continue: 
       create: Create
       destroy: Destroy
-      edit:
+      edit: 
       list: List
       listing: Listing
       new: New
-      refund:
-      save:
+      refund: 
+      save: 
       update: Update
     activate: Activate
     active: Active
     add: Add
     add_action_of_type: Add action of type
     add_country: Add Country
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: 
     add_option_value: Add Option Value
     add_product: Add Product
     add_product_properties: Add Product Properties
     add_rule_of_type: Add rule of type
     add_state: Add State
-    add_stock:
-    add_stock_management:
+    add_stock: 
+    add_stock_management: 
     add_to_cart: Add To Basket
-    add_variant:
+    add_variant: 
     additional_item: Additional Item Cost
-    address1:
-    address2:
-    adjustable:
+    address1: 
+    address2: 
+    adjustable: 
     adjustment: Adjustment
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: 
+    adjustment_successfully_closed: 
+    adjustment_successfully_opened: 
     adjustment_total: Adjustment Total
     adjustments: Adjustments
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administration
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: 
+    agree_to_privacy_policy: 
+    agree_to_terms_of_service: 
     all: All
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: 
+    all_adjustments_opened: 
     all_departments: All departments
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
-    already_signed_up_for_analytics:
+    already_signed_up_for_analytics: 
     alt_text: Alternative Text
     alternative_phone: Alternative Phone
     amount: Amount
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: 
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
     analytics_trackers: Analytics Trackers
     and: and
-    approve:
-    approved_at:
-    approver:
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Are you sure?
     are_you_sure_delete: Are you sure you want to delete this record?
-    associated_adjustment_closed:
-    at_symbol: '@'
+    associated_adjustment_closed: 
+    at_symbol: "@"
     authorization_failure: Authorisation Failure
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Available On
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Back
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Go Back To Store
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_users_list: 
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Balance Due
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Bill Address
     billing: Billing
     billing_address: Billing Address
     both: Both
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has not shipped yet.
     cannot_perform_operation: Cannot perform requested operation
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: 
     capture: capture
-    capture_events:
+    capture_events: 
     card_code: Card Code
     card_number: Card Number
-    card_type:
+    card_type: 
     card_type_is: Card type is
     cart: Basket
-    cart_subtotal:
+    cart_subtotal: 
     categories: Categories
     category: Category
-    charged:
-    check_for_spree_alerts:
+    charged: 
+    check_for_spree_alerts: 
     checkout: Checkout
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: 
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 
+    choose_dashboard_locale: 
+    choose_location: 
     city: Suburb / City
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Clone
-    close:
-    close_all_adjustments:
+    close: 
+    close_all_adjustments: 
     code: Code
-    company:
+    company: 
     complete: complete
     configuration: Configuration
     configurations: Configurations
@@ -456,114 +457,114 @@ en-AU:
     confirm_password: Password Confirmation
     continue: Continue
     continue_shopping: Continue shopping
-    cost_currency:
+    cost_currency: 
     cost_price: Cost Price
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
+    countries: 
     country: Country
     country_based: Country Based
-    country_name:
+    country_name: 
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Coupon
     coupon_code: Coupon code
-    coupon_code_already_applied:
+    coupon_code_already_applied: 
     coupon_code_applied: The coupon code was successfully applied to your order.
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_better_exists: 
+    coupon_code_expired: 
+    coupon_code_max_usage: 
+    coupon_code_not_eligible: 
+    coupon_code_not_found: 
+    coupon_code_unknown_error: 
     create: Create
     create_a_new_account: Create a new account
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: 
+    create_reimbursement: 
+    created_at: 
     credit: Credit
     credit_card: Credit Card
     credit_cards: Credit Cards
     credit_owed: Credit Owed
-    credits:
+    credits: 
     currency: Currency
-    currency_decimal_mark:
+    currency_decimal_mark: 
     currency_settings: Currency Settings
     currency_symbol_position: Put currency symbol before or after dollar amount?
-    currency_thousands_separator:
+    currency_thousands_separator: 
     current: Current
-    current_promotion_usage:
+    current_promotion_usage: 
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Customer Search
     cut: Cut
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: 
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 
+      format: 
+      js_format: 
     date_range: Date Range
     default: Default
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Delivery
     depth: Depth
     description: Description
-    destination:
+    destination: 
     destroy: Destroy
-    details:
+    details: 
     discount_amount: Discount Amount
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Edit
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Editing User
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Email
     empty: Empty
     empty_cart: Empty Basket
     enable_mail_delivery: Enable Mail Delivery
-    end:
+    end: 
     ending_in: Ending in
     environment: Environment
     error: error
@@ -590,20 +591,20 @@ en-AU:
         user:
           signup: User signup
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Expiration
     extension: Extension
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Filename
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: 
+    filter_results: 
     finalize: Finalise
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: First Item Cost
     first_name: First Name
     first_name_begins_with: First Name Begins With
@@ -612,7 +613,7 @@ en-AU:
     flexible_rate: Flexible Rate
     forgot_password: Forgot Password
     free_shipping: Free Shipping
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -625,43 +626,43 @@ en-AU:
     guest_user_account: Checkout as a Guest
     has_no_shipped_units: has no shipped units
     height: Height
-    hide_cents:
+    hide_cents: 
     home: Home
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: English (Australia)
     icon: Icon
-    identifier:
+    identifier: 
     image: Image
     images: Images
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Fill out the form below and instructions to reset your password will be emailed to you:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 
+    invalid_promotion_action: 
+    invalid_promotion_rule: 
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: 
+    inventory_state: 
     is_not_available_to_shipment_address: is not available to shipment address
-    iso_name:
+    iso_name: 
     item: Item
     item_description: Item Description
     item_total: Item Total
@@ -669,26 +670,26 @@ en-AU:
       operators:
         gt: greater than
         gte: greater than or equal to
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
+    jirafe: 
     landing_page_rule:
       path: Path
     last_name: Last Name
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: List
     loading: Loading
     locale_changed: Locale Changed
-    location:
-    lock:
-    log_entries:
+    location: 
+    lock: 
+    log_entries: 
     logged_in_as: Logged in as
     logged_in_succesfully: Logged in successfully
     logged_out: You have been logged out.
@@ -697,38 +698,38 @@ en-AU:
     login_failed: Login authentication failed.
     login_name: Login
     logout: Logout
-    logs:
+    logs: 
     look_for_similar_items: Look for similar items
     make_refund: Make refund
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Master Price
     match_choices:
       all: All
       none: None
     max_items: Max Items
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Meta Description
     meta_keywords: Meta Keywords
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Minimal Amount
     month: Month
     more: More
-    move_stock_between_locations:
+    move_stock_between_locations: 
     my_account: My Account
     my_orders: My Orders
     name: Name
-    name_on_card:
+    name_on_card: 
     name_or_sku: Name or SKU
     new: New
     new_adjustment: New Adjustment
-    new_country:
+    new_country: 
     new_customer: New Customer
-    new_customer_return:
+    new_customer_return: 
     new_image: New Image
     new_option_type: New Option Type
     new_order: New Order
@@ -737,20 +738,20 @@ en-AU:
     new_payment_method: New Payment Method
     new_product: New Product
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: 
     new_property: New Property
     new_prototype: New Prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: New Return Authorisation
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: New Shipping Category
     new_shipping_method: New Shipping Method
     new_state: New State
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: 
+    new_stock_movement: 
+    new_stock_transfer: 
     new_tax_category: New Tax Category
     new_tax_rate: New Tax Rate
     new_taxon: New Taxon
@@ -760,25 +761,25 @@ en-AU:
     new_variant: New Variant
     new_zone: New Zone
     next: Next
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: 
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: No products found
-    no_resource_found:
+    no_resource_found: 
     no_results: No results
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: No rules added
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
     none: None
-    none_selected:
+    none_selected: 
     normal_amount: Normal Amount
     not: not
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: 
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted
@@ -786,47 +787,47 @@ en-AU:
       product_not_deleted: Product could not be deleted
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
-    num_orders:
+    num_orders: 
     on_hand: On Hand
-    open:
-    open_all_adjustments:
+    open: 
+    open_all_adjustments: 
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Option Types
     option_value: Option Value
     option_values: Option Values
-    optional:
+    optional: 
     options: Options
     or: or
     or_over_price: "%{price} or over"
     order: Order
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Order Details
     order_email_resent: Order Email Resent
-    order_information:
+    order_information: 
     order_mailer:
       cancel_email:
         dear_customer: Dear Customer,\n
         instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
         subject: Cancellation of Order
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Dear Customer,\n
         instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
         subject: Order Confirmation
-        subtotal:
+        subtotal: 
         thanks: Thank you for your business.
-        total:
-    order_not_found:
+        total: 
+    order_not_found: 
     order_number: Order %{number}
     order_processed_successfully: Your order has been processed successfully
-    order_resumed:
+    order_resumed: 
     order_state:
       address: address
       awaiting_return: awaiting return
@@ -834,7 +835,7 @@ en-AU:
       cart: cart
       complete: complete
       confirm: confirm
-      considered_risky:
+      considered_risky: 
       delivery: delivery
       payment: payment
       resumed: resumed
@@ -844,10 +845,10 @@ en-AU:
     order_total: Order Total
     order_updated: Order Updated
     orders: Orders
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Out of Stock
     overview: Overview
-    package_from:
+    package_from: 
     pagination:
       next_page: next page »
       previous_page: "« previous page"
@@ -857,11 +858,11 @@ en-AU:
     path: Path
     pay: pay
     payment: Payment
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Payment Information
     payment_method: Payment Method
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Payment Methods
     payment_processing_failed: Payment could not be processed, please check the details you entered
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -879,8 +880,8 @@ en-AU:
       void: void
     payment_updated: Payment Updated
     payments: Payments
-    pending:
-    percent:
+    pending: 
+    percent: 
     percent_per_item: Percent Per Item
     permalink: Permalink
     phone: Phone
@@ -888,13 +889,13 @@ en-AU:
     please_define_payment_methods: Please define some payment methods first.
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Presentation
     previous: Previous
-    previous_state_missing:
+    previous_state_missing: 
     price: Price
     price_range: Price Range
     price_sack: Price Sack
@@ -902,14 +903,14 @@ en-AU:
     product: Product
     product_details: Product Details
     product_has_no_description: Product has not description
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: Product Properties
     product_rule:
       choose_products: Choose products
-      label:
+      label: 
       match_all: all
       match_any: at least one
-      match_none:
+      match_none: 
       product_source:
         group: From product group
         manual: Manually choose
@@ -921,14 +922,14 @@ en-AU:
         description: Creates a promotion credit adjustment on the order
         name: Create adjustment
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Populates the cart with the specified quantity of variant
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Actions
     promotion_form:
       match_policies:
@@ -946,27 +947,27 @@ en-AU:
         description: Customer must have visited the specified page
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Order includes specified product(s)
         name: Product(s)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Available only to the specified users
         name: User
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promotions
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Properties
     property: Property
     prototype: Prototype
@@ -974,49 +975,49 @@ en-AU:
     provider: Provider
     provider_settings_warning: If you are changing the provider type, you must save first before you can edit the provider settings
     qty: Qty
-    quantity:
+    quantity: 
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
-    quick_search:
+    quick_search: 
     rate: Rate
     reason: Reason
     receive: receive
-    receive_stock:
+    receive_stock: 
     received: Received
-    reception_status:
-    reference:
+    reception_status: 
+    reference: 
     refund: Refund
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Register as a New User
     registration: Registration
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Remember me
     remove: Remove
     rename: Rename
-    report:
+    report: 
     reports: Reports
     resend: Resend
     reset_password: Reset my password
@@ -1025,34 +1026,34 @@ en-AU:
     resumed: Resumed
     return: return
     return_authorization: Return Authorisation
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Return authorisation updated
     return_authorizations: Return Authorisations
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Return Quantity
     returned: Returned
-    returns:
+    returns: 
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
     roles: Roles
     rules: Rules
-    safe:
+    safe: 
     sales_total: Sales Total
     sales_total_description: Sales Total For All Orders
-    sales_totals:
+    sales_totals: 
     save_and_continue: Save and Continue
-    save_my_address:
+    save_my_address: 
     say_no: false
     say_yes: true
     scope: Scope
@@ -1062,10 +1063,10 @@ en-AU:
     secure_connection_type: Secure Connection Type
     security_settings: Security Settings
     select: Select
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Select From Prototype
-    select_stock:
+    select_stock: 
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
     server: Server
@@ -1073,10 +1074,10 @@ en-AU:
     settings: Settings
     ship: ship
     ship_address: Ship Address
-    ship_total:
+    ship_total: 
     shipment: Shipment
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1085,126 +1086,126 @@ en-AU:
         subject: Shipment Notification
         thanks: Thank you for your business.
         track_information: 'Tracking Information: %{tracking}'
-        track_link:
+        track_link: 
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: 
       partial: partial
       pending: pending
       ready: ready
       shipped: shipped
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Shipments
     shipped: Shipped
     shipping: Delivery
     shipping_address: Delivery Address
     shipping_categories: Shipping Categories
     shipping_category: Shipping Category
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
     shipping_instructions: Delivery Instructions
     shipping_method: Delivery Method
     shipping_methods: Delivery Methods
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: 
+    shipping_total: 
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Basket
     show: Show
     show_active: Show Active
     show_deleted: Show Deleted
     show_only_complete_orders: Only show complete orders
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: 
+    show_rate_in_label: 
     sku: SKU
-    skus:
-    slug:
-    source:
+    skus: 
+    slug: 
+    source: 
     special_instructions: Special Instructions
-    split:
+    split: 
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Start
     state: State
     state_based: State Based
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: States
-    states_required:
+    states_required: 
     status: Status
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: 
+    stock_location: 
+    stock_location_info: 
+    stock_locations: 
+    stock_locations_need_a_default_country: 
+    stock_management: 
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
+    stock_transfer: 
+    stock_transfers: 
     stop: Stop
     store: Store
     street_address: Street Address
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal
     subtract: Subtract
-    success:
+    success: 
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} has been successfully removed!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: 
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: 
     tax: Tax
     tax_categories: Tax Categories
     tax_category: Tax Category
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
     tax_rates: Tax Rates
     taxon: Taxon
     taxon_edit: Edit Taxon
-    taxon_placeholder:
+    taxon_placeholder: 
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy
@@ -1219,42 +1220,42 @@ en-AU:
         subject: Testmail
     test_mode: Test Mode
     thank_you_for_your_order: Thank you for your business.  Please print out a copy of this confirmation page for your records.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: 
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Tracking
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
     tree: Tree
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
-    unlock:
+    unlock: 
     unrecognized_card_type: Unrecognised card type
-    unshippable_items:
+    unshippable_items: 
     update: Update
     updating: Updating
     usage_limit: Usage Limit
-    use_app_default:
+    use_app_default: 
     use_billing_address: Use Billing Address
     use_new_cc: Use a new card
     use_s3: Use Amazon S3 For Images
@@ -1264,15 +1265,15 @@ en-AU:
     users: Users
     validation:
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: must be an integer
       must_be_non_negative: must be a non-negative value
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Value
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: 
     variants: Variants
     version: Version
     void: Void
@@ -1283,7 +1284,7 @@ en-AU:
     year: Year
     you_have_no_orders_yet: You have no orders yet.
     your_cart_is_empty: Your basket is empty
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: 
     zip: Postcode
     zipcode: Postcode
     zone: Zone

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1,3 +1,4 @@
+---
 en-GB:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ en-GB:
         state: County
         zipcode: Post Code
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +25,10 @@ en-GB:
         name: Name
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: 
         cc_type: Type
         month: Month
-        name:
+        name: 
         number: Number
         verification_value: Verification Value
         year: Year
@@ -42,7 +43,7 @@ en-GB:
       spree/order:
         checkout_complete: Checkout Complete
         completed_at: Completed At
-        considered_risky:
+        considered_risky: 
         coupon_code: Coupon Code
         created_at: Order Date
         email: Customer E-Mail
@@ -95,7 +96,7 @@ en-GB:
         starts_at: Starts At
         usage_limit: Usage Limit
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Name
         presentation: Presentation
@@ -109,20 +110,20 @@ en-GB:
         abbr: Abbreviation
         name: Name
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Description
         name: Name
@@ -157,47 +158,47 @@ en-GB:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: Card has expired
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Address
@@ -208,40 +209,40 @@ en-GB:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
       spree/line_item:
         one: Line Item
         other: Line Items
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Order
         other: Orders
       spree/payment:
         one: Payment
         other: Payments
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Product
         other: Products
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
         one: Property
         other: Properties
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Return Authorisation
         other: Return Authorisations
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Roles
         other: Roles
@@ -251,14 +252,14 @@ en-GB:
       spree/shipping_category:
         one: Shipping Category
         other: Shipping Categories
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: County
         other: Counties
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Tax Category
         other: Tax Categories
@@ -271,7 +272,7 @@ en-GB:
       spree/taxonomy:
         one: Taxonomy
         other: Taxonomies
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: User
         other: Users
@@ -282,13 +283,11 @@ en-GB:
         one: Zone
         other: Zones
   spree:
-    filter: Filter
-    quick_search: Quick Search . . .
     abbreviation: Abbreviation
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Account
     account_updated: Account updated!
     action: Action
@@ -301,7 +300,7 @@ en-GB:
       list: List
       listing: Listing
       new: New
-      refund:
+      refund: 
       save: Save
       update: Update
     activate: Activate
@@ -309,7 +308,7 @@ en-GB:
     add: Add
     add_action_of_type: Add action of type
     add_country: Add Country
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Add New Header
     add_new_style: Add New Style
     add_one: Add One
@@ -325,7 +324,7 @@ en-GB:
     additional_item: Additional Item Cost
     address1: Address
     address2: Address (contd.)
-    adjustable:
+    adjustable: 
     adjustment: Adjustment
     adjustment_amount: Amount
     adjustment_successfully_closed: Adjustment has been successfully closed!
@@ -335,36 +334,36 @@ en-GB:
     admin:
       tab:
         configuration: Configuration
-        option_types:
+        option_types: 
         orders: Orders
         overview: Overview
         products: Products
+        promotion_categories: 
         promotions: Promotions
-        promotion_categories:
-        properties:
-        prototypes:
+        properties: 
+        prototypes: 
         reports: Reports
-        taxonomies:
-        taxons:
+        taxonomies: 
+        taxons: 
         users: Users
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administration
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Agree to Privacy Policy
     agree_to_terms_of_service: Agree to Terms of Service
     all: All
     all_adjustments_closed: All adjustments successfully closed!
     all_adjustments_opened: All adjustments successfully opened!
     all_departments: All departments
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
@@ -380,71 +379,71 @@ en-GB:
     analytics_desc_list_4: It's completely free!
     analytics_trackers: Analytics Trackers
     and: and
-    approve:
-    approved_at:
-    approver:
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Are you sure
     are_you_sure_delete: Are you sure you want to delete this record?
     associated_adjustment_closed: The associated adjustment is closed, and will not be recalculated. Do you want to open it?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Authorisation Failure
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Available On
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Back
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Go Back To Store
     back_to_users_list: Back To Users List
     backorderable: Backorderable
-    backorderable_default:
-    backordered:
+    backorderable_default: 
+    backordered: 
     backorders_allowed: backorders allowed
     balance_due: Balance Due
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Bill Address
     billing: Billing
     billing_address: Billing Address
     both: Both
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has not shipped yet.
     cannot_perform_operation: Cannot perform requested operation
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided.
     capture: capture
-    capture_events:
+    capture_events: 
     card_code: Card Code
     card_number: Card Number
-    card_type:
+    card_type: 
     card_type_is: Card type is
     cart: Basket
-    cart_subtotal:
+    cart_subtotal: 
     categories: Categories
     category: Category
-    charged:
+    charged: 
     check_for_spree_alerts: Check for Spree alerts
     checkout: Checkout
     choose_a_customer: Choose a customer
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Choose Currency
     choose_dashboard_locale: Choose Dashboard Locale
-    choose_location:
+    choose_location: 
     city: Town / City
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Clone
     close: Close
     close_all_adjustments: Close All Adjustments
@@ -461,7 +460,7 @@ en-GB:
     cost_currency: Cost Currency
     cost_price: Cost Price
     could_not_connect_to_jirafe: Could not connect to Jirafe to sync data. This will be automatically retried later.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: There was a problem saving this stock movement. Please try again.
     count_on_hand: Count On Hand
     countries: Countries
@@ -469,10 +468,10 @@ en-GB:
     country_based: Country Based
     country_name: Name
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Coupon
     coupon_code: Coupon code
     coupon_code_already_applied: The coupon code has already been applied to this order
@@ -482,17 +481,17 @@ en-GB:
     coupon_code_max_usage: Coupon code usage limit exceeded
     coupon_code_not_eligible: This coupon code is not eligible for this order
     coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Create
     create_a_new_account: Create a new account
-    create_new_order:
-    create_reimbursement:
+    create_new_order: 
+    create_reimbursement: 
     created_at: Created At
     credit: Credit
     credit_card: Credit Card
     credit_cards: Credit Cards
     credit_owed: Credit Owed
-    credits:
+    credits: 
     currency: Currency
     currency_decimal_mark: Currency decimal mark
     currency_settings: Currency Settings
@@ -503,11 +502,11 @@ en-GB:
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Customer Search
     cut: Cut
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: App ID
@@ -526,41 +525,41 @@ en-GB:
       js_format: yy/mm/dd
     date_range: Date Range
     default: Default
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Delivery
     depth: Depth
     description: Description
     destination: Destination
     destroy: Destroy
-    details:
+    details: 
     discount_amount: Discount Amount
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Edit
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Editing User
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Email
     empty: Empty
     empty_cart: Empty Basket
@@ -592,20 +591,23 @@ en-GB:
         user:
           signup: User signup
     exceptions:
-      count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand, value)` instead.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: >-
+        Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand,
+        value)` instead.
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Expiration
     extension: Extension
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Filename
     fill_in_customer_info: Please fill in customer info
+    filter: Filter
     filter_results: Filter Results
     finalize: Finalise
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: First Item Cost
     first_name: First Name
     first_name_begins_with: First Name Begins With
@@ -614,7 +616,7 @@ en-GB:
     flexible_rate: Flexible Rate
     forgot_password: Forgot Password
     free_shipping: Free Shipping
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -635,33 +637,33 @@ en-GB:
       localization_settings: Localisation Settings
       this_file_language: English (UK)
     icon: Icon
-    identifier:
+    identifier: 
     image: Image
     images: Images
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Fill out the form below and instructions to reset your password will be emailed to you:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Internal Name
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Invalid payment provider.
     invalid_promotion_action: Invalid promotion action.
     invalid_promotion_rule: Invalid promotion rule.
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: is not available to shipment address
     iso_name: Iso Name
     item: Item
@@ -671,26 +673,26 @@ en-GB:
       operators:
         gt: greater than
         gte: greater than or equal to
-        lt:
-        lte:
+        lt: 
+        lte: 
     items_cannot_be_shipped: We are unable to ship the selected items to your shipping address. Please choose another shipping address.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: Last Name
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: List
     loading: Loading
     locale_changed: Locale Changed
     location: Location
     lock: Lock
-    log_entries:
+    log_entries: 
     logged_in_as: Logged in as
     logged_in_succesfully: Logged in successfully
     logged_out: You have been logged out.
@@ -699,23 +701,23 @@ en-GB:
     login_failed: Login authentication failed.
     login_name: Login
     logout: Logout
-    logs:
+    logs: 
     look_for_similar_items: Look for similar items
     make_refund: Make refund
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Master Price
     match_choices:
       all: All
       none: None
     max_items: Max Items
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Meta Description
     meta_keywords: Meta Keywords
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Minimal Amount
     month: Month
@@ -724,13 +726,13 @@ en-GB:
     my_account: My Account
     my_orders: My Orders
     name: Name
-    name_on_card:
+    name_on_card: 
     name_or_sku: Name or SKU
     new: New
     new_adjustment: New Adjustment
-    new_country:
+    new_country: 
     new_customer: New Customer
-    new_customer_return:
+    new_customer_return: 
     new_image: New Image
     new_option_type: New Option Type
     new_order: New Order
@@ -739,14 +741,14 @@ en-GB:
     new_payment_method: New Payment Method
     new_product: New Product
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: 
     new_property: New Property
     new_prototype: New Prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: New Return Authorisation
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: New Shipping Category
     new_shipping_method: New Shipping Method
     new_state: New State
@@ -763,24 +765,24 @@ en-GB:
     new_zone: New Zone
     next: Next
     no_actions_added: No actions added
-    no_payment_found:
+    no_payment_found: 
     no_pending_payments: No pending payments
     no_products_found: No products found
-    no_resource_found:
+    no_resource_found: 
     no_results: No results
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: No rules added
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: No tracking details provided.
     none: None
-    none_selected:
+    none_selected: 
     normal_amount: Normal Amount
     not: not
     not_available: N/A
     not_enough_stock: There is not enough inventory at the source location to complete this transfer.
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted
@@ -788,7 +790,7 @@ en-GB:
       product_not_deleted: Product could not be deleted
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
-    num_orders:
+    num_orders: 
     on_hand: On Hand
     open: Open
     open_all_adjustments: Open All Adjustments
@@ -803,9 +805,9 @@ en-GB:
     or_over_price: "%{price} or over"
     order: Order
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Order Details
     order_email_resent: Order Email Resent
     order_information: Order Information
@@ -815,20 +817,20 @@ en-GB:
         instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
         subject: Cancellation of Order
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Dear Customer,\n
         instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
         subject: Order Confirmation
-        subtotal:
+        subtotal: 
         thanks: Thank you for your business.
-        total:
+        total: 
     order_not_found: We couldn't find your order. Please try that action again.
     order_number: Order %{number}
     order_processed_successfully: Your order has been processed successfully
-    order_resumed:
+    order_resumed: 
     order_state:
       address: address
       awaiting_return: awaiting return
@@ -836,7 +838,7 @@ en-GB:
       cart: cart
       complete: complete
       confirm: confirm
-      considered_risky:
+      considered_risky: 
       delivery: delivery
       payment: payment
       resumed: resumed
@@ -846,7 +848,7 @@ en-GB:
     order_total: Order Total
     order_updated: Order Updated
     orders: Orders
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Out of Stock
     overview: Overview
     package_from: package from
@@ -859,11 +861,11 @@ en-GB:
     path: Path
     pay: pay
     payment: Payment
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Payment Information
     payment_method: Payment Method
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Payment Methods
     payment_processing_failed: Payment could not be processed, please check the details you entered
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -881,7 +883,7 @@ en-GB:
       void: void
     payment_updated: Payment Updated
     payments: Payments
-    pending:
+    pending: 
     percent: Percent
     percent_per_item: Percent Per Item
     permalink: Permalink
@@ -890,13 +892,13 @@ en-GB:
     please_define_payment_methods: Please define some payment methods first.
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Presentation
     previous: Previous
-    previous_state_missing:
+    previous_state_missing: 
     price: Price
     price_range: Price Range
     price_sack: Price Sack
@@ -908,10 +910,10 @@ en-GB:
     product_properties: Product Properties
     product_rule:
       choose_products: Choose products
-      label:
+      label: 
       match_all: all
       match_any: at least one
-      match_none:
+      match_none: 
       product_source:
         group: From product group
         manual: Manually choose
@@ -923,14 +925,14 @@ en-GB:
         description: Creates a promotion credit adjustment on the order
         name: Create adjustment
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Populates the cart with the specified quantity of variant
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Actions
     promotion_form:
       match_policies:
@@ -948,27 +950,27 @@ en-GB:
         description: Customer must have visited the specified page
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Order includes specified product(s)
         name: Product(s)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Available only to the specified users
         name: User
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promotions
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Properties
     property: Property
     prototype: Prototype
@@ -979,46 +981,46 @@ en-GB:
     quantity: Quantity
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
-    quick_search:
+    quick_search: 
     rate: Rate
     reason: Reason
     receive: receive
     receive_stock: Receive Stock
     received: Received
-    reception_status:
+    reception_status: 
     reference: Reference
     refund: Refund
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Register as a New User
     registration: Registration
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Remember me
     remove: Remove
     rename: Rename
-    report:
+    report: 
     reports: Reports
     resend: Resend
     reset_password: Reset my password
@@ -1027,34 +1029,34 @@ en-GB:
     resumed: Resumed
     return: return
     return_authorization: Return Authorisation
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Return authorisation updated
     return_authorizations: Return Authorisations
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Return Quantity
     returned: Returned
-    returns:
+    returns: 
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
     roles: Roles
     rules: Rules
-    safe:
+    safe: 
     sales_total: Sales Total
     sales_total_description: Sales Total For All Orders
     sales_totals: Sales Totals
     save_and_continue: Save and Continue
-    save_my_address:
+    save_my_address: 
     say_no: false
     say_yes: true
     scope: Scope
@@ -1064,8 +1066,8 @@ en-GB:
     secure_connection_type: Secure Connection Type
     security_settings: Security Settings
     select: Select
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Select From Prototype
     select_stock: Select stock
     send_copy_of_all_mails_to: Send Copy of All Mails To
@@ -1077,8 +1079,8 @@ en-GB:
     ship_address: Ship Address
     ship_total: Ship Total
     shipment: Shipment
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1091,13 +1093,13 @@ en-GB:
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: 
       partial: partial
       pending: pending
       ready: ready
       shipped: shipped
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Shipments
     shipped: Shipped
     shipping: Delivery
@@ -1111,67 +1113,67 @@ en-GB:
     shipping_method: Delivery Method
     shipping_methods: Delivery Methods
     shipping_price_sack: Price sack
-    shipping_total:
+    shipping_total: 
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Basket
     show: Show
     show_active: Show Active
     show_deleted: Show Deleted
     show_only_complete_orders: Only show complete orders
-    show_only_considered_risky:
+    show_only_considered_risky: 
     show_rate_in_label: Show rate in label
     sku: SKU
-    skus:
-    slug:
+    skus: 
+    slug: 
     source: Source
     special_instructions: Special Instructions
     split: Split
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Start
     state: County
     state_based: State Based
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Counties
     states_required: County Required
     status: Status
-    stock:
+    stock: 
     stock_location: Stock Location
     stock_location_info: Stock location info
     stock_locations: Stock Locations
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Stock Management
     stock_management_requires_a_stock_location: Please create a stock location in order to manage stock.
     stock_movements: Stock Movements
@@ -1185,28 +1187,28 @@ en-GB:
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal
     subtract: Subtract
-    success:
+    success: 
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} has been successfully removed!"
     successfully_signed_up_for_analytics: Successfully signed up for Spree Analytics
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: 
     tax: Tax
     tax_categories: Tax Categories
     tax_category: Tax Category
-    tax_code:
-    tax_included:
+    tax_code: 
+    tax_included: 
     tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)
     tax_rates: Tax Rates
     taxon: Taxon
     taxon_edit: Edit Taxon
     taxon_placeholder: Add a Taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy
@@ -1223,24 +1225,24 @@ en-GB:
     thank_you_for_your_order: Thank you for your business.  Please print out a copy of this confirmation page for your records.
     there_are_no_items_for_this_order: There are no items for this order. Please add an item to the order to continue.
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Time
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Tracking
     tracking_number: Tracking Number
     tracking_url: Tracking URL
     tracking_url_placeholder: e.g. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Transfer From
     transfer_stock: Transfer Stock
     transfer_to_location: Transfer To
@@ -1248,7 +1250,7 @@ en-GB:
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
     unlock: Unlock
     unrecognized_card_type: Unrecognised card type
@@ -1256,7 +1258,7 @@ en-GB:
     update: Update
     updating: Updating
     usage_limit: Usage Limit
-    use_app_default:
+    use_app_default: 
     use_billing_address: Use Billing Address
     use_new_cc: Use a new card
     use_s3: Use Amazon S3 For Images
@@ -1266,12 +1268,12 @@ en-GB:
     users: Users
     validation:
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: exceeds available stock. Please ensure line items have a valid quantity.
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: must be an integer
       must_be_non_negative: must be a non-negative value
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Value
     variant: Variant
     variant_placeholder: Choose a variant

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -1,3 +1,4 @@
+---
 en-IN:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ en-IN:
         state: State
         zipcode: Zip Code
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +25,10 @@ en-IN:
         name: Name
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: 
         cc_type: Type
         month: Month
-        name:
+        name: 
         number: Number
         verification_value: Verification Value
         year: Year
@@ -42,8 +43,8 @@ en-IN:
       spree/order:
         checkout_complete: Checkout Complete
         completed_at: Completed At
-        considered_risky:
-        coupon_code:
+        considered_risky: 
+        coupon_code: 
         created_at: Order Date
         email: Customer E-Mail
         ip_address: IP Address
@@ -95,7 +96,7 @@ en-IN:
         starts_at: Starts At
         usage_limit: Usage Limit
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Name
         presentation: Presentation
@@ -109,20 +110,20 @@ en-IN:
         abbr: Abbreviation
         name: Name
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Description
         name: Name
@@ -157,47 +158,47 @@ en-IN:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Address
@@ -208,40 +209,40 @@ en-IN:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
       spree/line_item:
         one: Line Item
         other: Line Items
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Order
         other: Orders
       spree/payment:
         one: Payment
         other: Payments
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Product
         other: Products
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
         one: Property
         other: Properties
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Return Authorization
         other: Return Authorizations
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Roles
         other: Roles
@@ -251,14 +252,14 @@ en-IN:
       spree/shipping_category:
         one: Shipping Category
         other: Shipping Categories
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: State
         other: States
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Tax Category
         other: Tax Categories
@@ -271,7 +272,7 @@ en-IN:
       spree/taxonomy:
         one: Taxonomy
         other: Taxonomies
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: User
         other: Users
@@ -283,10 +284,10 @@ en-IN:
         other: Zones
   spree:
     abbreviation: Abbreviation
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Account
     account_updated: Account updated!
     action: Action
@@ -299,7 +300,7 @@ en-IN:
       list: List
       listing: Listing
       new: New
-      refund:
+      refund: 
       save: Save
       update: Update
     activate: Activate
@@ -307,7 +308,7 @@ en-IN:
     add: Add
     add_action_of_type: Add action of type
     add_country: Add Country
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Add New Header
     add_new_style: Add New Style
     add_one: Add One
@@ -323,7 +324,7 @@ en-IN:
     additional_item: Additional Item Cost
     address1: Address
     address2: Address (contd.)
-    adjustable:
+    adjustable: 
     adjustment: Adjustment
     adjustment_amount: Amount
     adjustment_successfully_closed: Adjustment has been successfully closed!
@@ -332,37 +333,37 @@ en-IN:
     adjustments: Adjustments
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administration
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Agree to Privacy Policy
     agree_to_terms_of_service: Agree to Terms of Service
     all: All
     all_adjustments_closed: All adjustments successfully closed!
     all_adjustments_opened: All adjustments successfully opened!
     all_departments: All departments
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
@@ -378,71 +379,71 @@ en-IN:
     analytics_desc_list_4: It's completely free!
     analytics_trackers: Analytics Trackers
     and: and
-    approve:
-    approved_at:
-    approver:
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Are you sure
     are_you_sure_delete: Are you sure you want to delete this record?
     associated_adjustment_closed: The associated adjustment is closed, and will not be recalculated. Do you want to open it?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Authorization Failure
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Available On
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Back
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Go Back To Store
     back_to_users_list: Back To Users List
     backorderable: Backorderable
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Balance Due
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Bill Address
     billing: Billing
     billing_address: Billing Address
     both: Both
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has not shipped yet.
     cannot_perform_operation: Cannot perform requested operation
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided
     capture: capture
-    capture_events:
+    capture_events: 
     card_code: Card Code
     card_number: Card Number
-    card_type:
+    card_type: 
     card_type_is: Card type is
     cart: Basket
-    cart_subtotal:
+    cart_subtotal: 
     categories: Categories
     category: Category
-    charged:
+    charged: 
     check_for_spree_alerts: Check for Spree alerts
     checkout: Checkout
     choose_a_customer: Choose a customer
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Choose Currency
     choose_dashboard_locale: Choose Dashboard Locale
-    choose_location:
+    choose_location: 
     city: Town / City
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Clone
     close: Close
     close_all_adjustments: Close All Adjustments
@@ -459,7 +460,7 @@ en-IN:
     cost_currency: Cost Currency
     cost_price: Cost Price
     could_not_connect_to_jirafe: Could not connect to Jirafe to sync data. This will be automatically retried later.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: There was a problem saving this stock movement. Please try again.
     count_on_hand: Count On Hand
     countries: Countries
@@ -467,10 +468,10 @@ en-IN:
     country_based: Country Based
     country_name: Name
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Coupon
     coupon_code: Coupon code
     coupon_code_already_applied: The coupon code has already been applied to this order
@@ -480,17 +481,17 @@ en-IN:
     coupon_code_max_usage: Coupon code usage limit exceeded
     coupon_code_not_eligible: This coupon code is not eligible for this order
     coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Create
     create_a_new_account: Create a new account
-    create_new_order:
-    create_reimbursement:
+    create_new_order: 
+    create_reimbursement: 
     created_at: Created At
     credit: Credit
     credit_card: Credit Card
     credit_cards: Credit Cards
     credit_owed: Credit Owed
-    credits:
+    credits: 
     currency: Currency
     currency_decimal_mark: Currency decimal mark
     currency_settings: Currency Settings
@@ -501,16 +502,16 @@ en-IN:
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Customer Search
     cut: Cut
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: App ID
         app_token: App Token
-        currently_unavailable:
+        currently_unavailable: 
         explanation: The fields below may already be populated if you chose to register with Jirafe from the admin dashboard.
         header: Jirafe Analytics Settings
         site_id: Site ID
@@ -519,46 +520,46 @@ en-IN:
     date: Date
     date_completed: Date Completed
     date_picker:
-      first_day:
+      first_day: 
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
     date_range: Date Range
     default: Default
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Delivery
     depth: Depth
     description: Description
     destination: Destination
     destroy: Destroy
-    details:
+    details: 
     discount_amount: Discount Amount
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Edit
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Editing User
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Email
     empty: Empty
     empty_cart: Empty Basket
@@ -590,20 +591,22 @@ en-IN:
         user:
           signup: User signup
     exceptions:
-      count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand, value)` instead.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: >-
+        Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand,
+        value)` instead.
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Expiration
     extension: Extension
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Filename
     fill_in_customer_info: Please fill in customer info
     filter_results: Filter Results
     finalize: Finalize
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: First Item Cost
     first_name: First Name
     first_name_begins_with: First Name Begins With
@@ -612,7 +615,7 @@ en-IN:
     flexible_rate: Flexible Rate
     forgot_password: Forgot Password
     free_shipping: Free Shipping
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -628,38 +631,38 @@ en-IN:
     hide_cents: Hide cents
     home: Home
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: English (IN)
     icon: Icon
-    identifier:
+    identifier: 
     image: Image
     images: Images
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Fill out the form below and instructions to reset your password will be emailed to you:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Invalid payment provider.
     invalid_promotion_action: Invalid promotion action.
     invalid_promotion_rule: Invalid promotion rule.
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: is not available to shipment address
     iso_name: ISO Name
     item: Item
@@ -669,26 +672,26 @@ en-IN:
       operators:
         gt: greater than
         gte: greater than or equal to
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: Last Name
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: List
     loading: Loading
     locale_changed: Locale Changed
     location: Location
     lock: Lock
-    log_entries:
+    log_entries: 
     logged_in_as: Logged in as
     logged_in_succesfully: Logged in successfully
     logged_out: You have been logged out.
@@ -697,23 +700,23 @@ en-IN:
     login_failed: Login authentication failed.
     login_name: Login
     logout: Logout
-    logs:
+    logs: 
     look_for_similar_items: Look for similar items
     make_refund: Make refund
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Master Price
     match_choices:
       all: All
       none: None
     max_items: Max Items
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Meta Description
     meta_keywords: Meta Keywords
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Minimal Amount
     month: Month
@@ -722,13 +725,13 @@ en-IN:
     my_account: My Account
     my_orders: My Orders
     name: Name
-    name_on_card:
+    name_on_card: 
     name_or_sku: Name or SKU
     new: New
     new_adjustment: New Adjustment
-    new_country:
+    new_country: 
     new_customer: New Customer
-    new_customer_return:
+    new_customer_return: 
     new_image: New Image
     new_option_type: New Option Type
     new_order: New Order
@@ -737,14 +740,14 @@ en-IN:
     new_payment_method: New Payment Method
     new_product: New Product
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: 
     new_property: New Property
     new_prototype: New Prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: New Return Authorization
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: New Shipping Category
     new_shipping_method: New Shipping Method
     new_state: New State
@@ -761,24 +764,24 @@ en-IN:
     new_zone: New Zone
     next: Next
     no_actions_added: No actions added
-    no_payment_found:
-    no_pending_payments:
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: No products found
-    no_resource_found:
+    no_resource_found: 
     no_results: No results
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: No rules added
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: No tracking details provided.
     none: None
-    none_selected:
+    none_selected: 
     normal_amount: Normal Amount
     not: not
     not_available: N/A
     not_enough_stock: There is not enough inventory at the source location to complete this transfer.
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted
@@ -786,12 +789,12 @@ en-IN:
       product_not_deleted: Product could not be deleted
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
-    num_orders:
+    num_orders: 
     on_hand: On Hand
     open: Open
     open_all_adjustments: Open All Adjustments
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Option Types
     option_value: Option Value
     option_values: Option Values
@@ -801,9 +804,9 @@ en-IN:
     or_over_price: "%{price} or over"
     order: Order
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Order Details
     order_email_resent: Order Email Resent
     order_information: Order Information
@@ -813,20 +816,20 @@ en-IN:
         instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
         subject: Cancellation of Order
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Dear Customer,\n
         instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
         subject: Order Confirmation
-        subtotal:
+        subtotal: 
         thanks: Thank you for your business.
-        total:
+        total: 
     order_not_found: We couldn't find your order. Please try that action again.
-    order_number:
+    order_number: 
     order_processed_successfully: Your order has been processed successfully
-    order_resumed:
+    order_resumed: 
     order_state:
       address: address
       awaiting_return: awaiting return
@@ -834,7 +837,7 @@ en-IN:
       cart: cart
       complete: complete
       confirm: confirm
-      considered_risky:
+      considered_risky: 
       delivery: delivery
       payment: payment
       resumed: resumed
@@ -844,7 +847,7 @@ en-IN:
     order_total: Order Total
     order_updated: Order Updated
     orders: Orders
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Out of Stock
     overview: Overview
     package_from: package from
@@ -857,11 +860,11 @@ en-IN:
     path: Path
     pay: pay
     payment: Payment
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Payment Information
     payment_method: Payment Method
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Payment Methods
     payment_processing_failed: Payment could not be processed, please check the details you entered
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -879,7 +882,7 @@ en-IN:
       void: void
     payment_updated: Payment Updated
     payments: Payments
-    pending:
+    pending: 
     percent: Percent
     percent_per_item: Percent Per Item
     permalink: Permalink
@@ -888,13 +891,13 @@ en-IN:
     please_define_payment_methods: Please define some payment methods first.
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Presentation
     previous: Previous
-    previous_state_missing:
+    previous_state_missing: 
     price: Price
     price_range: Price Range
     price_sack: Price Sack
@@ -906,10 +909,10 @@ en-IN:
     product_properties: Product Properties
     product_rule:
       choose_products: Choose products
-      label:
+      label: 
       match_all: all
       match_any: at least one
-      match_none:
+      match_none: 
       product_source:
         group: From product group
         manual: Manually choose
@@ -921,14 +924,14 @@ en-IN:
         description: Creates a promotion credit adjustment on the order
         name: Create adjustment
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Populates the cart with the specified quantity of variant
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Actions
     promotion_form:
       match_policies:
@@ -946,27 +949,27 @@ en-IN:
         description: Customer must have visited the specified page
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Order includes specified product(s)
         name: Product(s)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Available only to the specified users
         name: User
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promotions
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Properties
     property: Property
     prototype: Prototype
@@ -977,46 +980,46 @@ en-IN:
     quantity: Quantity
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
-    quick_search:
+    quick_search: 
     rate: Rate
     reason: Reason
     receive: receive
     receive_stock: Receive Stock
     received: Received
-    reception_status:
+    reception_status: 
     reference: Reference
     refund: Refund
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Register as a New User
     registration: Registration
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Remember me
     remove: Remove
     rename: Rename
-    report:
+    report: 
     reports: Reports
     resend: Resend
     reset_password: Reset my password
@@ -1025,34 +1028,34 @@ en-IN:
     resumed: Resumed
     return: return
     return_authorization: Return Authorization
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Return authorization updated
     return_authorizations: Return Authorizations
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Return Quantity
     returned: Returned
-    returns:
+    returns: 
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
     roles: Roles
     rules: Rules
-    safe:
+    safe: 
     sales_total: Sales Total
     sales_total_description: Sales Total For All Orders
     sales_totals: Sales Totals
     save_and_continue: Save and Continue
-    save_my_address:
+    save_my_address: 
     say_no: false
     say_yes: true
     scope: Scope
@@ -1062,8 +1065,8 @@ en-IN:
     secure_connection_type: Secure Connection Type
     security_settings: Security Settings
     select: Select
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Select From Prototype
     select_stock: Select stock
     send_copy_of_all_mails_to: Send Copy of All Mails To
@@ -1075,8 +1078,8 @@ en-IN:
     ship_address: Ship Address
     ship_total: Ship Total
     shipment: Shipment
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1089,13 +1092,13 @@ en-IN:
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: 
       partial: partial
       pending: pending
       ready: ready
       shipped: shipped
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Shipments
     shipped: Shipped
     shipping: Delivery
@@ -1109,69 +1112,69 @@ en-IN:
     shipping_method: Delivery Method
     shipping_methods: Delivery Methods
     shipping_price_sack: Price sack
-    shipping_total:
+    shipping_total: 
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Basket
     show: Show
     show_active: Show Active
     show_deleted: Show Deleted
     show_only_complete_orders: Only show complete orders
-    show_only_considered_risky:
+    show_only_considered_risky: 
     show_rate_in_label: Show rate in label
     sku: SKU
-    skus:
-    slug:
+    skus: 
+    slug: 
     source: Source
     special_instructions: Special Instructions
-    split:
+    split: 
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Start
     state: County
     state_based: State Based
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Counties
     states_required: States Required
     status: Status
-    stock:
+    stock: 
     stock_location: Stock Location
     stock_location_info: Stock location info
     stock_locations: Stock Locations
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Stock Management
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: 
     stock_movements: Stock Movements
     stock_movements_for_stock_location: Stock Movements for %{stock_location_name}
     stock_successfully_transferred: Stock was successfully transferred between locations.
@@ -1183,28 +1186,28 @@ en-IN:
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal
     subtract: Subtract
-    success:
+    success: 
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} has been successfully removed!"
     successfully_signed_up_for_analytics: Successfully signed up for Spree Analytics
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: 
     tax: Tax
     tax_categories: Tax Categories
     tax_category: Tax Category
-    tax_code:
-    tax_included:
+    tax_code: 
+    tax_included: 
     tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)
     tax_rates: Tax Rates
     taxon: Taxon
     taxon_edit: Edit Taxon
     taxon_placeholder: Add a Taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy
@@ -1219,26 +1222,26 @@ en-IN:
         subject: Testmail
     test_mode: Test Mode
     thank_you_for_your_order: Thank you for your business.  Please print out a copy of this confirmation page for your records.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Time
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Tracking
     tracking_number: Tracking Number
     tracking_url: Tracking URL
     tracking_url_placeholder: e.g. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Transfer From
     transfer_stock: Transfer Stock
     transfer_to_location: Transfer To
@@ -1246,7 +1249,7 @@ en-IN:
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
     unlock: Unlock
     unrecognized_card_type: Unrecognized card type
@@ -1254,7 +1257,7 @@ en-IN:
     update: Update
     updating: Updating
     usage_limit: Usage Limit
-    use_app_default:
+    use_app_default: 
     use_billing_address: Use Billing Address
     use_new_cc: Use a new card
     use_s3: Use Amazon S3 For Images
@@ -1264,15 +1267,15 @@ en-IN:
     users: Users
     validation:
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: exceeds available stock. Please ensure line items have a valid quantity.
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: must be an integer
       must_be_non_negative: must be a non-negative value
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Value
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: 
     variants: Variants
     version: Version
     void: Void

--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -1,3 +1,4 @@
+---
 en-NZ:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ en-NZ:
         state: Region
         zipcode: Postcode
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +25,10 @@ en-NZ:
         name: Name
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: 
         cc_type: Type
         month: Month
-        name:
+        name: 
         number: Number
         verification_value: Verification Value
         year: Year
@@ -42,7 +43,7 @@ en-NZ:
       spree/order:
         checkout_complete: Checkout Complete
         completed_at: Completed At
-        considered_risky:
+        considered_risky: 
         coupon_code: Coupon Code
         created_at: Order Date
         email: Customer E-Mail
@@ -95,7 +96,7 @@ en-NZ:
         starts_at: Starts At
         usage_limit: Usage Limit
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Name
         presentation: Presentation
@@ -109,20 +110,20 @@ en-NZ:
         abbr: Abbreviation
         name: Name
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Description
         name: Name
@@ -157,47 +158,47 @@ en-NZ:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: Card has expired
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Address
@@ -208,40 +209,40 @@ en-NZ:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
       spree/line_item:
         one: Line Item
         other: Line Items
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Order
         other: Orders
       spree/payment:
         one: Payment
         other: Payments
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Product
         other: Products
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
         one: Property
         other: Properties
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Return Authorisation
         other: Return Authorisations
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Roles
         other: Roles
@@ -251,14 +252,14 @@ en-NZ:
       spree/shipping_category:
         one: Shipping Category
         other: Shipping Categories
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: State
         other: States
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Tax Category
         other: Tax Categories
@@ -271,7 +272,7 @@ en-NZ:
       spree/taxonomy:
         one: Taxonomy
         other: Taxonomies
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: User
         other: Users
@@ -283,171 +284,171 @@ en-NZ:
         other: Zones
   spree:
     abbreviation: Abbreviation
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Account
     account_updated: Account updated!
     action: Action
     actions:
       cancel: Cancel
-      continue:
+      continue: 
       create: Create
       destroy: Destroy
-      edit:
+      edit: 
       list: List
       listing: Listing
       new: New
-      refund:
-      save:
+      refund: 
+      save: 
       update: Update
     activate: Activate
     active: Active
     add: Add
     add_action_of_type: Add action of type
     add_country: Add Country
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: 
     add_option_value: Add Option Value
     add_product: Add Product
     add_product_properties: Add Product Properties
     add_rule_of_type: Add rule of type
     add_state: Add Region
-    add_stock:
-    add_stock_management:
+    add_stock: 
+    add_stock_management: 
     add_to_cart: Add To Cart
-    add_variant:
+    add_variant: 
     additional_item: Additional Item Cost
-    address1:
-    address2:
-    adjustable:
+    address1: 
+    address2: 
+    adjustable: 
     adjustment: Adjustment
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: 
+    adjustment_successfully_closed: 
+    adjustment_successfully_opened: 
     adjustment_total: Adjustment Total
     adjustments: Adjustments
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administration
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: 
+    agree_to_privacy_policy: 
+    agree_to_terms_of_service: 
     all: All
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: 
+    all_adjustments_opened: 
     all_departments: All departments
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
-    already_signed_up_for_analytics:
+    already_signed_up_for_analytics: 
     alt_text: Alternative Text
     alternative_phone: Alternative Phone
     amount: Amount
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: 
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
     analytics_trackers: Analytics Trackers
     and: and
-    approve:
-    approved_at:
-    approver:
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Are you sure
     are_you_sure_delete: Are you sure you want to delete this record?
-    associated_adjustment_closed:
-    at_symbol: '@'
+    associated_adjustment_closed: 
+    at_symbol: "@"
     authorization_failure: Authorisation Failure
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Available On
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Back
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Go Back To Store
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_users_list: 
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Balance Due
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Bill Address
     billing: Billing
     billing_address: Billing Address
     both: Both
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has no shipped units.
     cannot_perform_operation: Cannot perform requested operation
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: 
     capture: Capture
-    capture_events:
+    capture_events: 
     card_code: Card Code
     card_number: Card Number
-    card_type:
+    card_type: 
     card_type_is: Card type is
     cart: Cart
-    cart_subtotal:
+    cart_subtotal: 
     categories: Categories
     category: Category
-    charged:
-    check_for_spree_alerts:
+    charged: 
+    check_for_spree_alerts: 
     checkout: Checkout
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: 
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 
+    choose_dashboard_locale: 
+    choose_location: 
     city: Town / City
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Clone
-    close:
-    close_all_adjustments:
+    close: 
+    close_all_adjustments: 
     code: Code
-    company:
+    company: 
     complete: complete
     configuration: Configuration
     configurations: Configurations
@@ -456,114 +457,114 @@ en-NZ:
     confirm_password: Password Confirmation
     continue: Continue
     continue_shopping: Continue shopping
-    cost_currency:
+    cost_currency: 
     cost_price: Cost Price
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
+    countries: 
     country: Country
     country_based: Country Based
-    country_name:
+    country_name: 
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Coupon
     coupon_code: Coupon code
-    coupon_code_already_applied:
+    coupon_code_already_applied: 
     coupon_code_applied: The coupon code was successfully applied to your order.
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_better_exists: 
+    coupon_code_expired: 
+    coupon_code_max_usage: 
+    coupon_code_not_eligible: 
+    coupon_code_not_found: 
+    coupon_code_unknown_error: 
     create: Create
     create_a_new_account: Create a new account
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: 
+    create_reimbursement: 
+    created_at: 
     credit: Credit
     credit_card: Credit Card
     credit_cards: Credit Cards
     credit_owed: Credit Owed
-    credits:
+    credits: 
     currency: Currency
-    currency_decimal_mark:
+    currency_decimal_mark: 
     currency_settings: Currency Settings
     currency_symbol_position: Put currency symbol before or after dollar amount?
-    currency_thousands_separator:
+    currency_thousands_separator: 
     current: Current
-    current_promotion_usage:
+    current_promotion_usage: 
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Customer Search
     cut: Cut
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: 
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 
+      format: 
+      js_format: 
     date_range: Date Range
     default: Default
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Delivery
     depth: Depth
     description: Description
-    destination:
+    destination: 
     destroy: Destroy
-    details:
+    details: 
     discount_amount: Discount Amount
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Edit
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Editing User
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Email
     empty: Empty
     empty_cart: Empty Cart
     enable_mail_delivery: Enable Mail Delivery
-    end:
+    end: 
     ending_in: Ending in
     environment: Environment
     error: error
@@ -590,20 +591,20 @@ en-NZ:
         user:
           signup: User signup
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Expiration
     extension: Extension
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Filename
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: 
+    filter_results: 
     finalize: Finalise
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: First Item Cost
     first_name: First Name
     first_name_begins_with: First Name Begins With
@@ -612,7 +613,7 @@ en-NZ:
     flexible_rate: Flexible Rate
     forgot_password: Forgot Password?
     free_shipping: Free Delivery
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -625,43 +626,43 @@ en-NZ:
     guest_user_account: Checkout as a Guest
     has_no_shipped_units: has no shipped units
     height: Height
-    hide_cents:
+    hide_cents: 
     home: Home
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: English (New Zealand)
     icon: Icon
-    identifier:
+    identifier: 
     image: Image
     images: Images
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Fill out the form below and instructions to reset your password will be emailed to you:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 
+    invalid_promotion_action: 
+    invalid_promotion_rule: 
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: 
+    inventory_state: 
     is_not_available_to_shipment_address: is not available to delivery address
-    iso_name:
+    iso_name: 
     item: Item
     item_description: Item Description
     item_total: Item Total
@@ -669,26 +670,26 @@ en-NZ:
       operators:
         gt: greater than
         gte: greater than or equal to
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
+    jirafe: 
     landing_page_rule:
       path: Path
     last_name: Last Name
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: List
     loading: Loading
     locale_changed: Locale Changed
-    location:
-    lock:
-    log_entries:
+    location: 
+    lock: 
+    log_entries: 
     logged_in_as: Logged in as
     logged_in_succesfully: Logged in successfully
     logged_out: You have been logged out.
@@ -697,38 +698,38 @@ en-NZ:
     login_failed: Login authentication failed.
     login_name: Login
     logout: Logout
-    logs:
+    logs: 
     look_for_similar_items: Look for similar items
     make_refund: Make refund
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Master Price
     match_choices:
       all: All
       none: None
     max_items: Max Items
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Meta Description
     meta_keywords: Meta Keywords
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Minimal Amount
     month: Month
     more: More
-    move_stock_between_locations:
+    move_stock_between_locations: 
     my_account: My Account
     my_orders: My Orders
     name: Name
-    name_on_card:
+    name_on_card: 
     name_or_sku: Name or SKU (enter at least first 4 characters of product name)
     new: New
     new_adjustment: New Adjustment
-    new_country:
+    new_country: 
     new_customer: New Customer
-    new_customer_return:
+    new_customer_return: 
     new_image: New Image
     new_option_type: New Option Type
     new_order: New Order
@@ -737,20 +738,20 @@ en-NZ:
     new_payment_method: New Payment Method
     new_product: New Product
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: 
     new_property: New Property
     new_prototype: New Prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: New Return Authorisation
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: New Shipping Category
     new_shipping_method: New Delivery Method
     new_state: New Region
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: 
+    new_stock_movement: 
+    new_stock_transfer: 
     new_tax_category: New Tax Category
     new_tax_rate: New Tax Rate
     new_taxon: New Taxon
@@ -760,25 +761,25 @@ en-NZ:
     new_variant: New Variant
     new_zone: New Zone
     next: Next
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: 
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: No products found
-    no_resource_found:
+    no_resource_found: 
     no_results: No results
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: No rules added
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
     none: None
-    none_selected:
+    none_selected: 
     normal_amount: Normal Amount
     not: not
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: 
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted
@@ -786,47 +787,47 @@ en-NZ:
       product_not_deleted: Product could not be deleted
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
-    num_orders:
+    num_orders: 
     on_hand: On Hand
-    open:
-    open_all_adjustments:
+    open: 
+    open_all_adjustments: 
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Option Types
     option_value: Option Value
     option_values: Option Values
-    optional:
+    optional: 
     options: Options
     or: or
     or_over_price: "%{price} or over"
     order: Order
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Order Details
     order_email_resent: Order Email Resent
-    order_information:
+    order_information: 
     order_mailer:
       cancel_email:
         dear_customer: Dear Customer,\n
         instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
         subject: Cancellation of Order
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Dear Customer,\n
         instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
         subject: Order Confirmation
-        subtotal:
+        subtotal: 
         thanks: Thank you for your business.
-        total:
-    order_not_found:
-    order_number:
+        total: 
+    order_not_found: 
+    order_number: 
     order_processed_successfully: Your order has been processed successfully
-    order_resumed:
+    order_resumed: 
     order_state:
       address: address
       awaiting_return: awaiting return
@@ -834,7 +835,7 @@ en-NZ:
       cart: cart
       complete: complete
       confirm: confirm
-      considered_risky:
+      considered_risky: 
       delivery: delivery
       payment: payment
       resumed: resumed
@@ -844,10 +845,10 @@ en-NZ:
     order_total: Order Total
     order_updated: Order Updated
     orders: Orders
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Out of Stock
     overview: Overview
-    package_from:
+    package_from: 
     pagination:
       next_page: next page »
       previous_page: "« previous page"
@@ -857,11 +858,11 @@ en-NZ:
     path: Path
     pay: pay
     payment: Payment
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Payment Information
     payment_method: Payment Method
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Payment Methods
     payment_processing_failed: Payment could not be processed, please check the details you entered
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -879,8 +880,8 @@ en-NZ:
       void: void
     payment_updated: Payment Updated
     payments: Payments
-    pending:
-    percent:
+    pending: 
+    percent: 
     percent_per_item: Percent Per Item
     permalink: Permalink
     phone: Phone
@@ -888,13 +889,13 @@ en-NZ:
     please_define_payment_methods: Please define some payment methods first.
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Presentation
     previous: Previous
-    previous_state_missing:
+    previous_state_missing: 
     price: Price
     price_range: Price Range
     price_sack: Price Sack
@@ -902,14 +903,14 @@ en-NZ:
     product: Product
     product_details: Product Details
     product_has_no_description: This product has no description
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: Product Properties
     product_rule:
       choose_products: Choose products
-      label:
+      label: 
       match_all: all
       match_any: at least one
-      match_none:
+      match_none: 
       product_source:
         group: From product group
         manual: Manually choose
@@ -921,14 +922,14 @@ en-NZ:
         description: Creates a promotion credit adjustment on the order
         name: Create adjustment
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Populates the cart with the specified variants and quantities
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Actions
     promotion_form:
       match_policies:
@@ -946,27 +947,27 @@ en-NZ:
         description: Customer must have visited the specified page
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Order includes specified product(s)
         name: Product(s)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Available only to the specified users
         name: User
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promotions
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Properties
     property: Property
     prototype: Prototype
@@ -974,49 +975,49 @@ en-NZ:
     provider: Provider
     provider_settings_warning: If you are changing the provider type, you must save first before you can edit the provider settings
     qty: Qty
-    quantity:
+    quantity: 
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
-    quick_search:
+    quick_search: 
     rate: Rate
     reason: Reason
     receive: receive
-    receive_stock:
+    receive_stock: 
     received: Received
-    reception_status:
-    reference:
+    reception_status: 
+    reference: 
     refund: Refund
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Register as a New User
     registration: Registration
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Remember me
     remove: Remove
     rename: Rename
-    report:
+    report: 
     reports: Reports
     resend: Resend
     reset_password: Reset my password
@@ -1025,34 +1026,34 @@ en-NZ:
     resumed: Resumed
     return: return
     return_authorization: Return Authorisation
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Return authorisation updated
     return_authorizations: Return Authorisations
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Return Quantity
     returned: Returned
-    returns:
+    returns: 
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
     roles: Roles
     rules: Rules
-    safe:
+    safe: 
     sales_total: Sales Total
     sales_total_description: Sales Total For All Orders
-    sales_totals:
+    sales_totals: 
     save_and_continue: Save and Continue
-    save_my_address:
+    save_my_address: 
     say_no: false
     say_yes: true
     scope: Scope
@@ -1062,10 +1063,10 @@ en-NZ:
     secure_connection_type: Secure Connection Type
     security_settings: Security Settings
     select: Select
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Select From Prototype
-    select_stock:
+    select_stock: 
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
     server: Server
@@ -1073,10 +1074,10 @@ en-NZ:
     settings: Settings
     ship: ship
     ship_address: Delivery Address
-    ship_total:
+    ship_total: 
     shipment: Shipment
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1085,126 +1086,126 @@ en-NZ:
         subject: Shipment Notification
         thanks: Thank you for your business.
         track_information: 'Tracking Information: %{tracking}'
-        track_link:
+        track_link: 
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: 
       partial: partial
       pending: pending
       ready: ready
       shipped: shipped
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Shipments
     shipped: Shipped
     shipping: Delivery
     shipping_address: Delivery Address
     shipping_categories: Shipping Categories
     shipping_category: Shipping Category
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
     shipping_instructions: Delivery Instructions
     shipping_method: Delivery Method
     shipping_methods: Delivery Methods
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: 
+    shipping_total: 
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Cart
     show: Show
     show_active: Show Active
     show_deleted: Show Deleted
     show_only_complete_orders: Only show complete orders
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: 
+    show_rate_in_label: 
     sku: SKU
-    skus:
-    slug:
-    source:
+    skus: 
+    slug: 
+    source: 
     special_instructions: Special Instructions
-    split:
+    split: 
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Start
     state: Region
     state_based: Region Based
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Regions
-    states_required:
+    states_required: 
     status: Status
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: 
+    stock_location: 
+    stock_location_info: 
+    stock_locations: 
+    stock_locations_need_a_default_country: 
+    stock_management: 
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
+    stock_transfer: 
+    stock_transfers: 
     stop: Stop
     store: Store
     street_address: Street Address
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal
     subtract: Subtract
-    success:
+    success: 
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} has been successfully removed!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: 
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: 
     tax: Tax
     tax_categories: Tax Categories
     tax_category: Tax Category
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
     tax_rates: Tax Rates
     taxon: Taxon
     taxon_edit: Edit Taxon
-    taxon_placeholder:
+    taxon_placeholder: 
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy
@@ -1219,42 +1220,42 @@ en-NZ:
         subject: Testmail
     test_mode: Test Mode
     thank_you_for_your_order: Thank you for your business.  Please print out a copy of this confirmation page for your records.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: 
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Tracking
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
     tree: Tree
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
-    unlock:
+    unlock: 
     unrecognized_card_type: Unrecognised card type
-    unshippable_items:
+    unshippable_items: 
     update: Update
     updating: Updating
     usage_limit: Usage Limit
-    use_app_default:
+    use_app_default: 
     use_billing_address: Use Billing Address
     use_new_cc: Use a new card
     use_s3: Use Amazon S3 For Images
@@ -1264,15 +1265,15 @@ en-NZ:
     users: Users
     validation:
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: must be an integer
       must_be_non_negative: must be a non-negative value
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Value
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: 
     variants: Variants
     version: Version
     void: Void
@@ -1283,8 +1284,8 @@ en-NZ:
     year: Year
     you_have_no_orders_yet: You have no orders yet.
     your_cart_is_empty: Your cart is empty
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: 
     zip: Postcode
-    zipcode:
+    zipcode: 
     zone: Zone
     zones: Zones

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -1,3 +1,4 @@
+---
 es-CL:
   activerecord:
     attributes:
@@ -27,10 +28,10 @@ es-CL:
         base: Base
         cc_type: Tipo
         month: Mes
+        name: Nombre
         number: Número
         verification_value: Código de verificación (CVV)
         year: Año
-        name: Nombre
       spree/inventory_unit:
         state: Estado
       spree/line_item:
@@ -42,6 +43,7 @@ es-CL:
       spree/order:
         checkout_complete: Pedido completo
         completed_at: Completado En
+        considered_risky: Arriesgado
         coupon_code: Código Cupón
         created_at: Fecha del Pedido
         email: E-Mail del Cliente
@@ -53,7 +55,6 @@ es-CL:
         special_instructions: Instrucciones especiales
         state: Estado
         total: Total
-        considered_risky: Arriesgado
       spree/order/bill_address:
         address1: Calle dirección de facturación
         city: Ciudad dirección de facturación
@@ -113,19 +114,19 @@ es-CL:
         name: Nombre
       spree/state_change:
         state_changes: Cambio de estados
-        type: Tipo
         state_from: Estado inicial
         state_to: Estado final
-        user: Usuario
         timestamp: Fecha del cambio
+        type: Tipo
         updated: Actualizado
+        user: Usuario
       spree/store:
-        url: URL
+        mail_from_address: Dirección de email de envío
         meta_description: Meta descripción
         meta_keywords: Meta palabras claves
-        seo_title: Título SEO
         name: Nombre de la Tienda
-        mail_from_address: Dirección de email de envío
+        seo_title: Título SEO
+        url: URL
       spree/tax_category:
         description: Descripción
         name: Nombre
@@ -155,6 +156,52 @@ es-CL:
       spree/zone:
         description: Descripción
         name: Nombre
+    errors:
+      models:
+        spree/calculator/tiered_flat_rate:
+          attributes:
+            base:
+              keys_should_be_positive_number: Tier keys should all be numbers larger than 0
+            preferred_tiers:
+              should_be_hash: should be a hash
+        spree/calculator/tiered_percent:
+          attributes:
+            base:
+              keys_should_be_positive_number: Tier keys should all be numbers larger than 0
+              values_should_be_percent: Tier values should all be percentages between 0% and 100%
+            preferred_tiers:
+              should_be_hash: should be a hash
+        spree/classification:
+          attributes:
+            taxon_id:
+              already_linked: is already linked to this product
+        spree/credit_card:
+          attributes:
+            base:
+              card_expired: Card has expired
+              expiry_invalid: Card expiration is invalid
+        spree/line_item:
+          attributes:
+            currency:
+              must_match_order_currency: Must match order currency
+        spree/refund:
+          attributes:
+            amount:
+              greater_than_allowed: is greater than the allowed amount.
+        spree/reimbursement:
+          attributes:
+            base:
+              return_items_order_id_does_not_match: One or more of the return items specified do not belong to the same order as the reimbursement.
+        spree/return_item:
+          attributes:
+            inventory_unit:
+              other_completed_return_item_exists: "%{inventory_unit_id} has already been taken by return item %{return_item_id}"
+            reimbursement:
+              cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
+        spree/store:
+          attributes:
+            base:
+              cannot_destroy_default_store: Cannot destroy the default Store.
     models:
       spree/address:
         one: Dirección
@@ -237,12 +284,12 @@ es-CL:
       spree/state_change:
         one: Cambio de estado
         other: Cambio de estados
-      spree/stock_movement:
-        one: Movimiento de Stock
-        other: Movimientos de Stock
       spree/stock_location:
         one: Ubicación de Stock
         other: Ubicaciones de Stock
+      spree/stock_movement:
+        one: Movimiento de Stock
+        other: Movimientos de Stock
       spree/stock_transfer:
         one: Transferencia de Stock
         other: Transferencias de Stock
@@ -270,63 +317,15 @@ es-CL:
       spree/zone:
         one: Zona
         other: Zonas
-    errors:
-      models:
-        spree/calculator/tiered_flat_rate:
-          attributes:
-            base:
-              keys_should_be_positive_number: "Tier keys should all be numbers larger than 0"
-            preferred_tiers:
-              should_be_hash: "should be a hash"
-        spree/calculator/tiered_percent:
-          attributes:
-            base:
-              keys_should_be_positive_number: "Tier keys should all be numbers larger than 0"
-              values_should_be_percent: "Tier values should all be percentages between 0% and 100%"
-            preferred_tiers:
-              should_be_hash: "should be a hash"
-        spree/classification:
-          attributes:
-            taxon_id:
-              already_linked: "is already linked to this product"
-        spree/credit_card:
-          attributes:
-            base:
-              card_expired: "Card has expired"
-              expiry_invalid: "Card expiration is invalid"
-        spree/line_item:
-          attributes:
-            currency:
-              must_match_order_currency: "Must match order currency"
-        spree/refund:
-          attributes:
-            amount:
-              greater_than_allowed: is greater than the allowed amount.
-        spree/reimbursement:
-          attributes:
-            base:
-              return_items_order_id_does_not_match: One or more of the return items specified do not belong to the same order as the reimbursement.
-        spree/return_item:
-          attributes:
-            reimbursement:
-              cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
-            inventory_unit:
-              other_completed_return_item_exists: "%{inventory_unit_id} has already been taken by return item %{return_item_id}"
-        spree/store:
-          attributes:
-            base:
-              cannot_destroy_default_store: Cannot destroy the default Store.
-
   number:
     percentage:
       format:
         precision: 1
-
   spree:
     abbreviation: Abreviación
     accept: Aceptar
-    acceptance_status: Estado de aceptación
     acceptance_errors: Errores de aceptación
+    acceptance_status: Estado de aceptación
     accepted: Aceptado
     account: Cuenta
     account_updated: Cuenta actualizada
@@ -369,8 +368,8 @@ es-CL:
     adjustment_amount: Valor
     adjustment_labels:
       tax_rates:
-        including_tax: '%{name}%{amount} (Incluido en el precio)'
-        excluding_tax: '%{name}%{amount}'
+        excluding_tax: "%{name}%{amount}"
+        including_tax: "%{name}%{amount} (Incluido en el precio)"
     adjustment_successfully_closed: El ajuste ha sido cerrado satisfactoriamente
     adjustment_successfully_opened: El ajuste ha sido abierto satisfactoriamente
     adjustment_total: Total del ajuste
@@ -382,8 +381,8 @@ es-CL:
         orders: Pedidos
         overview: Visión general
         products: Productos
+        promotion_categories: 
         promotions: Promociones
-        promotion_categories:
         properties: Atributos
         prototypes: Prototipos
         reports: Informes
@@ -396,7 +395,7 @@ es-CL:
         items: Artículos
         items_purchased: Artículos comprados
         order_history: Historial de pedidos
-        order_num: "Pedido #"
+        order_num: 'Pedido #'
         orders: Pedidos
         user_information: Información del usuario
     administration: Administración
@@ -426,7 +425,7 @@ es-CL:
     are_you_sure: "¿Estás seguro?"
     are_you_sure_delete: "¿Estás seguro de que quieres borrar este registro?"
     associated_adjustment_closed: El ajuste asociado está cerrado y no será recalculado. ¿Quieres abrirlo?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Fallo en la autorización
     authorized: Autorizado
     auto_capture: Captura automática
@@ -435,14 +434,14 @@ es-CL:
     avs_response: AVS Response
     back: Volver
     back_end: Backend
-    backordered: Pedido pendiente
-    back_to_resource_list: 'Volver al listado de %{resource}'
     back_to_payment: Volver al pago
+    back_to_resource_list: Volver al listado de %{resource}
     back_to_rma_reason_list: Volver al listado de razones RMA
     back_to_store: Volver a la Tienda
     back_to_users_list: Volver al Listado de Usuarios
     backorderable: backorderable
     backorderable_default: Backorderable default
+    backordered: Pedido pendiente
     backorders_allowed: Permitida la Devolución
     balance_due: Saldo adeudado
     base_amount: Valor base
@@ -453,12 +452,12 @@ es-CL:
     both: Ambos
     calculated_reimbursements: Los reembolsos calculados
     calculator: Calculador
-    calculator_settings_warning: 'Si cambias el tipo de calculador, debes guardar primero antes de editar las preferencias del calculador'
+    calculator_settings_warning: Si cambias el tipo de calculador, debes guardar primero antes de editar las preferencias del calculador
     cancel: cancelar
-    canceler: Candelado
     canceled_at: Cancelado en
-    cannot_create_payment_without_payment_methods: No puedes crear un pago para un pedido sin antes definir un medio de pago
+    canceler: Candelado
     cannot_create_customer_returns: No se puede crear devoluciones para el cliente ya que este pedido no ha enviado artículos.
+    cannot_create_payment_without_payment_methods: No puedes crear un pago para un pedido sin antes definir un medio de pago
     cannot_create_returns: No puedes crear devoluciones para un pedido que no tiene unidades enviadas.
     cannot_perform_operation: No se pudo realizar la operación solicitada.
     cannot_set_shipping_method_without_address: No se puede establecer el método de envío hasta que no se proporcionen los detalles del cliente.
@@ -470,15 +469,15 @@ es-CL:
     card_type_is: El tipo de tarjeta es
     cart: Carrito
     cart_subtotal:
-      one: 'Subtotal (1 artículo)'
-      other: 'Subtotal (%{count} artículos)'
+      one: Subtotal (1 artículo)
+      other: Subtotal (%{count} artículos)
     categories: Categorías
     category: Categoría
     charged: Cargado
     check_for_spree_alerts: Comprobar alertas
     checkout: Realizar pedido
     choose_a_customer: Seleccione un cliente
-    choose_a_taxon_to_sort_products_for: "Elegir una Clasificación para ordenar productos por"
+    choose_a_taxon_to_sort_products_for: Elegir una Clasificación para ordenar productos por
     choose_currency: Seleccione moneda
     choose_dashboard_locale: Seleccione idioma del Dashboard
     choose_location: Seleccione Ubicación
@@ -531,10 +530,10 @@ es-CL:
     create_reimbursement: Crear reembolso
     created_at: Creado el
     credit: Crédito
-    credits: Créditos
     credit_card: Tarjeta de Crédito
     credit_cards: Tarjetas de Crédito
     credit_owed: Crédito adeudado
+    credits: Créditos
     currency: Moneda
     currency_settings: Parámetros de moneda
     current: Actual
@@ -573,16 +572,16 @@ es-CL:
     deleted_variants_present: Algunos artículos de este pedido ya no están disponibles.
     delivery: Entregar
     depth: Profundidad
-    details: Detalles
     description: Descripción
     destination: Destino
     destroy: Eliminar
+    details: Detalles
     discount_amount: Valor del descuento
     dismiss_banner: No. Gracias! No estoy interesado. no mostrar este mensaje otra vez
     display: Mostrar
     doesnt_track_inventory: No realizar el siguiente de inventario
     edit: Editar
-    editing_resource: 'Editando %{resource}'
+    editing_resource: Editando %{resource}
     editing_rma_reason: Editando razón RMA
     editing_user: Editando Usuario
     eligibility_errors:
@@ -610,7 +609,8 @@ es-CL:
     errors:
       messages:
         could_not_create_taxon: No pude crear la Clasificación
-        no_shipping_methods_available: 'No hay métodos de envió disponibles para la localización seleccionada, por favor cambia tu dirección e inténtalo de nuevo'
+        no_shipping_methods_available: No hay métodos de envió disponibles para la localización seleccionada, por favor cambia tu dirección e
+          inténtalo de nuevo
     errors_prohibited_this_record_from_being_saved:
       one: 1 error impidió que pudiera guardarse el registro
       other: "%{count} errores impidieron que pudiera guardarse el registro"
@@ -629,21 +629,25 @@ es-CL:
         user:
           signup: Registrar Usuario
     exceptions:
-      count_on_hand_setter: "No se pudo establecer count_on_hand manualmente, ya que está establecido automáticamente por la callback recalculate_count_on_hand. Por favor utiliza `update_column(:count_on_hand, value)` en vez de ello."
+      count_on_hand_setter: >-
+        No se pudo establecer count_on_hand manualmente, ya que está establecido automáticamente por la callback recalculate_count_on_hand. Por
+        favor utiliza `update_column(:count_on_hand, value)` en vez de ello.
     exchange_for: Intercambio de
-    expedited_exchanges_warning: "Cualquier cambio especificado serán entregado al cliente. Al cliente se le cargará el importe total del artículo si no devuelve en %{days_window} days_window días."
     excl: excl.
+    existing_shipments: Enví existentes
+    expedited_exchanges_warning: >-
+      Cualquier cambio especificado serán entregado al cliente. Al cliente se le cargará el importe total del artículo si no devuelve en %{days_window}
+      days_window días.
     expiration: Vencimiento
     extension: Extensión
-    existing_shipments: Enví existentes
     failed_payment_attempts: Intentos fallidos de pago
     filename: Nombre de Archivo
     fill_in_customer_info: Por favor rellena información del cliente
     filter: Filtro
     filter_results: Filtrar resultados
     finalize: Finalizar
-    find_a_taxon: Encontrar una Clasificación
     finalized: Finalizado
+    find_a_taxon: Encontrar una Clasificación
     first_item: Primer artículo
     first_name: Nombre
     first_name_begins_with: Nombre comienza por
@@ -673,17 +677,17 @@ es-CL:
     icon: Icono
     image: Imagen
     images: Imágenes
-    implement_eligible_for_return: "Debe implementar #eligible_for_return? para su EligibilityValidator."
-    implement_requires_manual_intervention: "Debe implmentar #requires_manual_intervention? para su EligibilityValidator."
+    implement_eligible_for_return: 'Debe implementar #eligible_for_return? para su EligibilityValidator.'
+    implement_requires_manual_intervention: 'Debe implmentar #requires_manual_intervention? para su EligibilityValidator.'
     inactive: Inactivo
     incl: incl.
     included_in_price: Incluido en el precio
     included_price_validation: No puede ser seleccionado a menos que establezcas una Zona de Impuesto por defecto
     incomplete: Incompleto
-    info_product_has_multiple_skus: "Este producto tiene %{count} variantes:"
     info_number_of_skus_not_shown:
-      one: "y otro"
-      other: "y %{count} otros"
+      one: y otro
+      other: y %{count} otros
+    info_product_has_multiple_skus: 'Este producto tiene %{count} variantes:'
     instructions_to_reset_password: Por favor ingresa tu e-mail en el siguiente formulario
     insufficient_stock: Stock insuficiente, sólo %{on_hand} restante
     insufficient_stock_lines_present: Algunos artículos de este pedido no tienen la cantidad suficiente.
@@ -712,8 +716,8 @@ es-CL:
         lte: Menor o igual que
     items_cannot_be_shipped: No es posible enviar los elementos seleccionados a su dirección de entrega. Por favor indica otra dirección de entrega.
     items_in_rmas: Artículos de devolución autorizados
-    items_to_be_reimbursed: Los productos que se reembolsarán
     items_reimbursed: Artículos Reembolsados
+    items_to_be_reimbursed: Los productos que se reembolsarán
     jirafe: Jirafe
     landing_page_rule:
       path: Ruta
@@ -721,14 +725,13 @@ es-CL:
     last_name_begins_with: Apellido comienza con
     learn_more: Aprender más
     lifetime_stats: Estadísticas de por vida
-    line_item_adjustments: "Line item adjustments"
+    line_item_adjustments: Line item adjustments
     list: Lista
     loading: Cargando
     locale_changed: Idioma cambiado
     location: Localización
     lock: Bloquear
-    log_entries: "Registros de entrada"
-    logs: Registros
+    log_entries: Registros de entrada
     logged_in_as: Identificado como
     logged_in_succesfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
@@ -737,12 +740,13 @@ es-CL:
     login_failed: No se ha podido iniciar la sesión, error de autenticación.
     login_name: E-Mail
     logout: Cerrar sesión
+    logs: Registros
     look_for_similar_items: Buscar artículos similares
     make_refund: Realizar devolución
     make_sure_the_above_reimbursement_amount_is_correct: Asegúrese de que el valor del reembolso de arriba es correcto
     manage_promotion_categories: Administrar las categorías de promoción
-    manual_intervention_required: Requiere intervención manual
     manage_variants: Administrar Variantes
+    manual_intervention_required: Requiere intervención manual
     master_price: Precio principal
     match_choices:
       all: Todos
@@ -765,9 +769,9 @@ es-CL:
     name_or_sku: Nombre o SKU (introducir al menos los 4 primeros caracteres o nombre del producto)
     new: Nuevo
     new_adjustment: Nuevo Ajuste
+    new_country: Nuevo País
     new_customer: Nuevo Cliente
     new_customer_return: Nueva devolución del cliente
-    new_country: Nuevo País
     new_image: Nueva Imagen
     new_option_type: Nuevo Tipo de Opción
     new_order: Nuevo Pedido
@@ -781,12 +785,12 @@ es-CL:
     new_prototype: Nuevo prototipo
     new_refund: Nuevo reembolso
     new_refund_reason: Nueva razón de reembolso
-    new_rma_reason: Nueva razón de RMA
     new_return_authorization: Nueva autorización de devolución
+    new_rma_reason: Nueva razón de RMA
     new_role: Nuevo Rol
+    new_shipment_at_location: Nueva Ubicación de envío
     new_shipping_category: Nueva categoría de envío
     new_shipping_method: Nueva forma de envío
-    new_shipment_at_location: Nueva Ubicación de envío
     new_state: Nuevo estado
     new_stock_location: Nueva localización de stock
     new_stock_movement: Nuevo movimiento de stock
@@ -804,10 +808,10 @@ es-CL:
     no_payment_found: No hay pagos encontrados
     no_pending_payments: No hay pagos pendientes
     no_products_found: No se encontraron productos
-    no_results: Sin resultados
-    no_rules_added: No se añadieron reglas
     no_resource_found: No se encontraron %{resource}
-    no_returns_found:  No se encontraron reembolsos
+    no_results: Sin resultados
+    no_returns_found: No se encontraron reembolsos
+    no_rules_added: No se añadieron reglas
     no_shipping_method_selected: Ningún método de envío seleccionado.
     no_state_changes: Ningún estado cambia todavía.
     no_tracking_present: No se proporcionaron detalles del tracking
@@ -873,9 +877,9 @@ es-CL:
       awaiting_return: esperando devolución
       canceled: cancelada
       cart: carrito
-      considered_risky: Considerado riesgoso
       complete: completado
       confirm: Confirmada
+      considered_risky: Considerado riesgoso
       delivery: Entrega
       payment: Pago
       resumed: reanudado
@@ -901,8 +905,8 @@ es-CL:
     payment_could_not_be_created: El pago no se ha podido crear.
     payment_information: Información del Pago
     payment_method: Medio de Pago
-    payment_methods: Medios de Pago
     payment_method_not_supported: Medio de Pago no soportado, por favo seleccione otro.
+    payment_methods: Medios de Pago
     payment_processing_failed: El pago no pudo ser procesado, por favor comprueba los detalles que has ingresado
     payment_processor_choose_banner_text: Si necesitas ayuda a la hora de escojer un procesador de pago, por favor visita
     payment_processor_choose_link: nuestra pagina de pagos
@@ -919,23 +923,23 @@ es-CL:
       void: anular
     payment_updated: Pago actualizado
     payments: Pagos
+    pending: Pendiente
     percent: Porcentaje
     percent_per_item: Porcentaje por artículo
     permalink: Permalink
-    pending: Pendiente
     phone: Teléfono
     place_order: Realizar Pedido
     please_define_payment_methods: Por favor define algún medio de pago primero
     please_enter_reasonable_quantity: Por favor introduzca una cantidad razonable.
     populate_get_error: Se produjo un error. Por favor intenta añadir el artículo otra vez.
     powered_by: Desarrollado por
-    pre_tax_refund_amount: Pre-Tax Valor devolución
     pre_tax_amount: Pre-Tax Valor
+    pre_tax_refund_amount: Pre-Tax Valor devolución
     pre_tax_total: Pre-Tax Total
     preferred_reimbursement_type: Tipo preferido de Reembolso
     presentation: Presentación
     previous: Anterior
-    previous_state_missing: "n/a"
+    previous_state_missing: n/a
     price: Precio
     price_range: Rango de precios
     price_sack: Precio Sack
@@ -956,7 +960,6 @@ es-CL:
         manual: Escoje manualmente
     products: Productos
     promotion: Promoción
-    promotionable: Promocionable
     promotion_action: Acción de promoción
     promotion_action_types:
       create_adjustment:
@@ -977,7 +980,7 @@ es-CL:
       match_policies:
         all: Cumple todas estas reglas
         any: Cumple cualquiera de estas reglas
-    promotion_label: 'Promoción (%{name})'
+    promotion_label: Promoción (%{name})
     promotion_rule: Regla de promoción
     promotion_rule_types:
       first_order:
@@ -998,17 +1001,18 @@ es-CL:
       product:
         description: El pedido incluye productos específicos
         name: Producto(s)
+      taxon:
+        description: Pedido incluye productos de una clasificación(es) especifica(s)
+        name: Taxón
       user:
         description: Disponible solamente a usuarios específicos
         name: Usuario
       user_logged_in:
         description: Disponible solamente a usuarios registrados
         name: Usuario registrado
-      taxon:
-        description: Pedido incluye productos de una clasificación(es) especifica(s)
-        name: Taxón
-    promotions: Promociones
     promotion_uses: Usos de promoción
+    promotionable: Promocionable
+    promotions: Promociones
     propagate_all_variants: Propagar todas las Variantes
     properties: Propiedades
     property: Propiedad
@@ -1039,7 +1043,17 @@ es-CL:
     reimburse: Reembolsar
     reimbursed: Reembolsado
     reimbursement: Reembolso
-    reimbursement_perform_failed: "El reembolso no pudo realizarse.  Error: %{error}"
+    reimbursement_mailer:
+      reimbursement_email:
+        days_to_send: "'Usted tiene %{days} días para devolver cualquier artículo que esperé cambiar.'"
+        dear_customer: Estimado cliente,
+        exchange_summary: Resumen del Cambio
+        for: para
+        instructions: Su reembolso ha sido procesado.
+        refund_summary: Resumen de Reembolso
+        subject: Notificación de Reembolso
+        total_refunded: "'Total Reembolsado: %{total}'"
+    reimbursement_perform_failed: 'El reembolso no pudo realizarse.  Error: %{error}'
     reimbursement_status: Estado del reembolso
     reimbursement_type: Tipo reembolso
     reimbursement_type_override: Tipo de anulación de reembolso
@@ -1060,7 +1074,7 @@ es-CL:
     resumed: Resumido
     return: Volver
     return_authorization: Autorización para devolución
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Autorización para devolución actualizada
     return_authorizations: Autorizaciones para devolución
     return_item_inventory_unit_ineligible: Return item's inventory unit must be shipped
@@ -1070,16 +1084,6 @@ es-CL:
     return_item_time_period_ineligible: Return item is outside the eligible time period
     return_items: Artículos devueltos
     return_items_cannot_be_associated_with_multiple_orders: Los artículos de vuelta no se pueden asociar con varios pedidos.
-    reimbursement_mailer:
-      reimbursement_email:
-        days_to_send: "'Usted tiene %{days} días para devolver cualquier artículo que esperé cambiar.'"
-        dear_customer: Estimado cliente,
-        exchange_summary: Resumen del Cambio
-        for: para
-        instructions: Su reembolso ha sido procesado.
-        refund_summary: Resumen de Reembolso
-        subject: Notificación de Reembolso
-        total_refunded: "'Total Reembolsado: %{total}'"
     return_number: Número devolución
     return_quantity: Cantidad de devolución
     returned: Devuelto
@@ -1104,7 +1108,7 @@ es-CL:
     say_yes: Si
     scope: Alcance
     search: Buscar
-    search_results: "Resultados para las búsqueda de '%{keywords}'"
+    search_results: Resultados para las búsqueda de '%{keywords}'
     searching: Buscando
     secure_connection_type: Tipo de conexión segura
     security_settings: Configuración de seguridad
@@ -1113,7 +1117,7 @@ es-CL:
     select_a_stock_location: Seleccione una ubicación de stock
     select_from_prototype: Seleccionar desde el prototipo
     select_stock: Seleccionar Stock
-    selected_quantity_not_available: 'El artículo %{item} no está disponible.'
+    selected_quantity_not_available: El artículo %{item} no está disponible.
     send_copy_of_all_mails_to: Enviar copia de todos los emails a
     send_mails_as: Enviar emails como
     server: Servidor
@@ -1123,8 +1127,8 @@ es-CL:
     ship_address: Dirección de envío
     ship_total: Total de envío
     shipment: Envío
-    shipment_adjustments: "Ajustes de envío"
-    shipment_details: "Desde %{stock_location} por %{shipping_method}"
+    shipment_adjustments: Ajustes de envío
+    shipment_details: Desde %{stock_location} por %{shipping_method}
     shipment_mailer:
       shipped_email:
         dear_customer: Estimado Cliente,\n
@@ -1142,8 +1146,8 @@ es-CL:
       pending: Pendiente
       ready: Listo
       shipped: Enviado
-    shipment_transfer_success: 'Transferido con éxito'
-    shipment_transfer_error: 'Hubo un error al transferir'
+    shipment_transfer_error: Hubo un error al transferir
+    shipment_transfer_success: Transferido con éxito
     shipments: Envíos
     shipped: Enviado
     shipping: Envío
@@ -1159,8 +1163,8 @@ es-CL:
     shipping_price_sack: Precio empaque
     shipping_rates:
       display_price:
-        including_tax: "%{price} (incl. %{tax_amount} %{tax_rate_name})"
         excluding_tax: "%{price} (+ %{tax_amount} %{tax_rate_name})"
+        including_tax: "%{price} (incl. %{tax_amount} %{tax_rate_name})"
     shipping_total: Total envío
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrito de compra
@@ -1178,11 +1182,10 @@ es-CL:
     split: Dividir
     spree_gateway_error_flash_for_checkout: Hubo un problema con tu información de pago. Por favor revisa tu información e intentado de nuevo
     ssl:
-      change_protocol: "Por favor cambia a HTTP (en lugar de HTTPS) y vuelve a intentar."
+      change_protocol: Por favor cambia a HTTP (en lugar de HTTPS) y vuelve a intentar.
     start: Empezar
     state: Estado
     state_based: Estado basado
-    states: Estados
     state_machine_states:
       accepted: Aceptado
       address: Dirección
@@ -1190,22 +1193,22 @@ es-CL:
       awaiting: Esperando
       awaiting_return: Esperando devolución
       backordered: Pendiente de entrega
-      cart: Carrito
       canceled: Cancelado
+      cart: Carrito
       checkout: Revisar
-      confirm: Confirmar
+      closed: Cerrado
       complete: Completo
       completed: Completado
-      closed: Cerrado
+      confirm: Confirmar
       delivery: Entrega
       errored: Con errores
       failed: Fracasado
       given_to_customer: Entregado al cliente
       invalid: Inválido
       manual_intervention_required: Requiere intervención manual
+      on_hand: En mano
       open: Abierto
       order: Pedido
-      on_hand: En mano
       payment: Pago
       pending: Pendiente
       processing: Processing
@@ -1215,6 +1218,7 @@ es-CL:
       returned: Devuelto
       shipped: Transportado
       void: Vacío
+    states: Estados
     states_required: Provincias requeridas
     status: Estado
     stock: Stock
@@ -1243,11 +1247,11 @@ es-CL:
     successfully_updated: "%{resource} ha sido actualizado con éxito"
     summary: Resumen
     tax: Impuesto
-    tax_included: "Impuesto (incl.)"
     tax_categories: Categorías de impuestos
     tax_category: Categoría impuesto
     tax_code: Código de impuesto
-    tax_rate_amount_explanation: "Las tarifas de impuestos son numeros decimales (p. ej. si la tarifa de impuesto es del 5%, introducir 0.05)"
+    tax_included: Impuesto (incl.)
+    tax_rate_amount_explanation: Las tarifas de impuestos son numeros decimales (p. ej. si la tarifa de impuesto es del 5%, introducir 0.05)
     tax_rates: Tarifas de impuesto
     taxon: Clasificación
     taxon_edit: Editar Clasificación
@@ -1317,13 +1321,13 @@ es-CL:
       choose_users: Escoje Usuarios
     users: Usuarios
     validation:
-      unpaid_amount_not_zero: "La cantidad no fue totalmente reembolsada. Aún así: % {amount}"
       cannot_be_less_than_shipped_units: no puede ser menor que el número de unidades enviadas.
       cannot_destroy_line_item_as_inventory_units_have_shipped: No se puede eliminar artículo ya que algunas unidades se han enviado.
       exceeds_available_stock: excede el stock disponible. Por favor asegúrate que los artículos tienen un cantidad válida.
       is_too_large: demasiado grande -- el stock disponible no puede cubrir la cantidad solicitada
       must_be_int: debe ser un número entero
       must_be_non_negative: debe ser un valor positivo
+      unpaid_amount_not_zero: 'La cantidad no fue totalmente reembolsada. Aún así: % {amount}'
     value: Valor
     variant: Variante
     variant_placeholder: Escoje una variante
@@ -1345,6 +1349,6 @@ es-CL:
   views:
     pagination:
       first: Primera
-      previous: Anterior
-      next: Siguiente
       last: Última
+      next: Siguiente
+      previous: Anterior

--- a/config/locales/es-EC.yml
+++ b/config/locales/es-EC.yml
@@ -1,3 +1,4 @@
+---
 es-EC:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ es-EC:
         state: Provincia ó Estado
         zipcode: Código Postal
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +25,10 @@ es-EC:
         name: Nombre
         numcode: Código ISO
       spree/credit_card:
-        base:
+        base: 
         cc_type: Tipo
         month: Mes
-        name:
+        name: 
         number: Número
         verification_value: Valor verificación
         year: Año
@@ -42,7 +43,7 @@ es-EC:
       spree/order:
         checkout_complete: Completar Pedido
         completed_at: Completado En
-        considered_risky:
+        considered_risky: 
         coupon_code: Código Cupón
         created_at: Fecha del Pedido
         email: Email del Cliente
@@ -95,7 +96,7 @@ es-EC:
         starts_at: Empieza en
         usage_limit: Limite de Uso
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Nombre
         presentation: Presentación
@@ -109,20 +110,20 @@ es-EC:
         abbr: Abreviatura
         name: Nombre
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Descripción
         name: Nombre
@@ -157,47 +158,47 @@ es-EC:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: La Tarjeta ha expirado
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Dirección.
@@ -208,42 +209,42 @@ es-EC:
       spree/credit_card:
         one: Tarjeta de Crédito.
         other: Tarjetas de Crédito
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Unidad de inventario.
         other: Unidades de inventario
       spree/line_item:
         one: Línea de pedido
         other: Líneas de pedido
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Pedido
         other: Pedidos
       spree/payment:
         one: Pago
         other: Pagos
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Producto
         other: Productos
       spree/promotion:
         one: Promoción
         other: Promociones
-      spree/promotion_category:
+      spree/promotion_category: 
       spree/property:
         one: Propiedad
         other: Propiedades
       spree/prototype:
         one: Prototipo
         other: Propotipos
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Autorización para devolución
         other: Autorizaciones para devolución
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Función
         other: Funciones
@@ -253,14 +254,14 @@ es-EC:
       spree/shipping_category:
         one: Categoría de envío
         other: Categorías de envío
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: Provincia
         other: Provincias
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Categoría fiscal
         other: Categorías fiscales
@@ -273,7 +274,7 @@ es-EC:
       spree/taxonomy:
         one: Categoría
         other: Categorías
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: Usuario
         other: Usuarios
@@ -285,10 +286,10 @@ es-EC:
         other: Zonas
   spree:
     abbreviation: Abreviatura
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Cuenta
     account_updated: Cuenta actualizada
     action: Acción
@@ -301,7 +302,7 @@ es-EC:
       list: Listar
       listing: Listando
       new: Nuevo
-      refund:
+      refund: 
       save: Guardar
       update: Actualizar
     activate: Activar
@@ -309,7 +310,7 @@ es-EC:
     add: Añadir
     add_action_of_type: Añadir acción del tipo
     add_country: Añadir País
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Añadir nueva cabecera
     add_new_style: Añadir nuevo estilo
     add_one: Añadir uno
@@ -325,7 +326,7 @@ es-EC:
     additional_item: Coste de artículo adicional
     address1: Dirección
     address2: Dirección (cont.)
-    adjustable:
+    adjustable: 
     adjustment: Ajuste
     adjustment_amount: Cuantía
     adjustment_successfully_closed: El ajuste ha sido cerrado satisfactoriamente
@@ -335,36 +336,36 @@ es-EC:
     admin:
       tab:
         configuration: Configuración
-        option_types:
+        option_types: 
         orders: Pedidos
         overview: Visión general
         products: Productos
+        promotion_categories: 
         promotions: Promociones
-        promotion_categories:
-        properties:
-        prototypes:
+        properties: 
+        prototypes: 
         reports: Informes
-        taxonomies:
-        taxons:
+        taxonomies: 
+        taxons: 
         users: Usuarios
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administración
-    advertise:
+    advertise: 
     agree_to_privacy_policy: De acuerdo con la politica de privacidad.
     agree_to_terms_of_service: De acuerdo con las condiciones de uso
     all: Todos
     all_adjustments_closed: Todos los ajustes cerrados satisfactoriamente
     all_adjustments_opened: Todos los ajustes abiertos satisfactoriamente
     all_departments: Todos los departamentos
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Permitir SSL en modo desarrollo y pruebas
     allow_ssl_in_production: Permitir SSL en producción
     allow_ssl_in_staging: Permitir SSL en modo staging
@@ -380,71 +381,71 @@ es-EC:
     analytics_desc_list_4: Es completamente gratuito!
     analytics_trackers: Analytics Trackers
     and: y
-    approve:
-    approved_at:
-    approver:
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: "¿Estás seguro?"
     are_you_sure_delete: "¿Estás seguro de que quieres borrar este registro?"
     associated_adjustment_closed: El ajuste asociado está cerrado y no será recalculado. ¿Quieres abrirlo?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Fallo en la autorización
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Disponible
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Volver
     back_end: Parte interna
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Volver a la Tienda
     back_to_users_list: Volver a Listado de Usuarios
     backorderable: Devuelto
-    backorderable_default:
-    backordered:
+    backorderable_default: 
+    backordered: 
     backorders_allowed: Permitida la Devolucion
     balance_due: Saldo adeudado
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Dirección de facturación
     billing: Facturación
     billing_address: Dirección de facturación
     both: Ambos
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Calculador
     calculator_settings_warning: Si cambias el tipo de calculador, debes guardar primero antes de editar las preferencias del calculador
     cancel: Cancelar
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: No puedes crear un pago para un pedido sin antes definir un método de pago
     cannot_create_returns: No puedes crear devoluciones para un pedido que no tiene unidades enviadas
     cannot_perform_operation: No se pudo realizar la operación solicitada
     cannot_set_shipping_method_without_address: No se puede establecer el método de envío hasta que no se proporcionen los detalles del cliente.
     capture: Captura
-    capture_events:
+    capture_events: 
     card_code: Código de tarjeta
     card_number: Número de tarjeta
-    card_type:
+    card_type: 
     card_type_is: Tipo de tarjeta es
     cart: Carrito
-    cart_subtotal:
+    cart_subtotal: 
     categories: Categorías
     category: Categoría
-    charged:
+    charged: 
     check_for_spree_alerts: Comprobar alertas de Spre
     checkout: Realizar pedido
     choose_a_customer: Escoge un cliente
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Escoge moneda
     choose_dashboard_locale: Escoge idioma del Panel de Instrumentos
-    choose_location:
+    choose_location: 
     city: Ciudad
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Clonar
     close: Cerrar
     close_all_adjustments: Cerrar todos los ajustes
@@ -461,7 +462,7 @@ es-EC:
     cost_currency: Moneda de costo
     cost_price: Precio de costo
     could_not_connect_to_jirafe: No se pudo conectar a Jirafe para sincronizar los datos. Se intentará más tarde automáticamente.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: Hubo un problema grabando este movimiento de stock. Por favor inténtalo otra vez.
     count_on_hand: Disponible
     countries: Países
@@ -469,10 +470,10 @@ es-EC:
     country_based: País base
     country_name: Nombre
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Cupón
     coupon_code: Código Cupón
     coupon_code_already_applied: El código del cupón ya ha sido aplicado a este pedido
@@ -482,17 +483,17 @@ es-EC:
     coupon_code_max_usage: Excedido el limite de uso del código del cupón
     coupon_code_not_eligible: Este código de cupón no es elegible para este pedido
     coupon_code_not_found: El código del cupón que has introducido no existe. Inténtalo de nuevo.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Crear
     create_a_new_account: Crear una nueva cuenta
-    create_new_order:
-    create_reimbursement:
+    create_new_order: 
+    create_reimbursement: 
     created_at: Creada
     credit: Crédito
     credit_card: Tarjeta de Crédito
     credit_cards: Tarjetas de Crédito
     credit_owed: Crédito adeudado
-    credits:
+    credits: 
     currency: Moneda
     currency_decimal_mark: Marca decimal de moneda
     currency_settings: Parámetros de moneda
@@ -503,11 +504,11 @@ es-EC:
     customer: Cliente
     customer_details: Detalles del Cliente
     customer_details_updated: Detalles del Cliente actualizado
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Búsqueda del Cliente
     cut: Cortar
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: ID App
@@ -526,41 +527,41 @@ es-EC:
       js_format: dd/mm/yy
     date_range: Rango de fechas
     default: Por defecto
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Tasa por defecto
     default_tax_zone: Zona de tasa por defecto
     delete: Borrar
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Entregar
     depth: Ancho
     description: Descripción
     destination: Destino
     destroy: Eliminar
-    details:
+    details: 
     discount_amount: Cuantía descuento
     dismiss_banner: No. Gracias! No estoy interesado, no mostrar este mensaje otra vez
     display: Mostrar
     display_currency: Moneda a mostrar
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Editar
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Editando Usuario
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Email
     empty: Vacío
     empty_cart: Carrito vacío
@@ -573,7 +574,8 @@ es-EC:
       messages:
         could_not_create_taxon: No pude crear taxon
         no_payment_methods_available: No hay métodos de pago configurados para este entorno
-        no_shipping_methods_available: No hay métodos de envió disponibles para la localización seleccionada, por favor cambia tu dirección e inténtalo de nuevo
+        no_shipping_methods_available: No hay métodos de envió disponibles para la localización seleccionada, por favor cambia tu dirección e
+          inténtalo de nuevo
     errors_prohibited_this_record_from_being_saved:
       one: 1 error impidió que pudiera guardarse el registro
       other: "%{count} errores impidieron que pudiera guardarse el registro"
@@ -592,20 +594,22 @@ es-EC:
         user:
           signup: Dar de alta Usuario
     exceptions:
-      count_on_hand_setter: No se pudo establecer count_on_hand manualmente, ya que está establecido automáticamente por la callback recalculate_count_on_hand. Por favor utiliza `update_column(:count_on_hand, value)` en vez de ello.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: >-
+        No se pudo establecer count_on_hand manualmente, ya que está establecido automáticamente por la callback recalculate_count_on_hand. Por
+        favor utiliza `update_column(:count_on_hand, value)` en vez de ello.
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Vencimiento
     extension: Extensión
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Nombre de Fichero
     fill_in_customer_info: Por favor rellena información del cliente
     filter_results: Filtrar resultados
     finalize: Finalizar
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: Coste del primer artículo
     first_name: Nombre
     first_name_begins_with: Nombre comienza por
@@ -614,7 +618,7 @@ es-EC:
     flexible_rate: Tarifa flexible
     forgot_password: "¿Olvidaste el password?"
     free_shipping: Envío gratuito
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Parte delantera
     gateway: Pasarela
     gateway_config_unavailable: Pasarela no disponible para entorno
@@ -635,33 +639,33 @@ es-EC:
       localization_settings: Ajustes Localización
       this_file_language: Español
     icon: Icono
-    identifier:
+    identifier: 
     image: Imagen
     images: Imágenes
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Incluido en el precio
     included_price_validation: No puede ser seleccionado a menos que establezcas una Zona de Tasa por defecto
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: Por favor introduce tu nombre en el siguiente formulario
     insufficient_stock: Stock disponible insuficiente, sólo %{on_hand} restante
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Interceptar Dirección Email
     intercept_email_instructions: Sobrescribe correo electrónico del destinatario y reemplázalo con esta dirección.
     internal_name: Nombre interno
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Proveedor de pago inválido
     invalid_promotion_action: Acción de promoción inválida
     invalid_promotion_rule: Regla de promoción inválida
     inventory: Inventario
     inventory_adjustment: Ajuste de inventario
     inventory_error_flash_for_insufficient_quantity: Un artículo de tu carrito ha dejado de estar disponible.
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: no está disponible para la dirección de envío
     iso_name: Nombre ISO
     item: Artículo
@@ -671,26 +675,26 @@ es-EC:
       operators:
         gt: Mayor que
         gte: Mayor que o igual a
-        lt:
-        lte:
+        lt: 
+        lte: 
     items_cannot_be_shipped: No es posible enviar los elementos seleccionados a su dirección de entrega. Por favor indica otra dirección de entrega.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Ruta
     last_name: Apellidos
     last_name_begins_with: Apellido comienza con
     learn_more: Aprender más
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Lista
     loading: Carga
     locale_changed: Idioma cambiado
     location: Localización
     lock: Bloquear
-    log_entries:
+    log_entries: 
     logged_in_as: Identificado como
     logged_in_succesfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
@@ -699,23 +703,23 @@ es-EC:
     login_failed: No se ha podido iniciar la sesión, error de autenticación.
     login_name: Validación
     logout: Cerrar sesión
-    logs:
+    logs: 
     look_for_similar_items: Buscar artículos similares
     make_refund: Realizar devolución
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Precio principal
     match_choices:
       all: Todos
       none: Ninguno
     max_items: Máximo Artículos
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Descripción Meta
     meta_keywords: Keywords Meta
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Cuantía mínima
     month: Mes
@@ -724,13 +728,13 @@ es-EC:
     my_account: Mi Cuenta
     my_orders: Mis Pedidos
     name: Nombre
-    name_on_card:
+    name_on_card: 
     name_or_sku: Nombre o SKU (introducir al menos los 4 primeros caracteres o nombre del producto)
     new: Nuevo
     new_adjustment: Nuevo Ajuste
-    new_country:
+    new_country: 
     new_customer: Nuevo Cliente
-    new_customer_return:
+    new_customer_return: 
     new_image: Nueva Imagen
     new_option_type: Nuevo Tipo de Opción
     new_order: Nuevo Pedido
@@ -739,14 +743,14 @@ es-EC:
     new_payment_method: Nueva forma de pago
     new_product: Nuevo producto
     new_promotion: Nueva promoción
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Nueva propiedad
     new_prototype: Nuevo prototipo
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Nueva autorización de devolución
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Nueva categoría de envío
     new_shipping_method: Nueva forma de envío
     new_state: Nueva provincia
@@ -763,24 +767,24 @@ es-EC:
     new_zone: Nueva Zona
     next: Siguiente
     no_actions_added: No acciones añadidas
-    no_payment_found:
+    no_payment_found: 
     no_pending_payments: No hay pagos pendientes
     no_products_found: No se encontraron productos
     no_resource_found: No se encontraron %{resource}
     no_results: sin resultados
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: No se añadieron reglas
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: No se proporcionaron detalles del tracking
     none: Ninguno
-    none_selected:
+    none_selected: 
     normal_amount: Cuantía normal
     not: false
     not_available: No disponible
     not_enough_stock: No hay suficiente inventario en la localización fuente para completar esta transferencia
     not_found: No se encontró %{resource}
-    note:
+    note: 
     notice_messages:
       product_cloned: El producto ha sido clonado
       product_deleted: El producto ha sido borrado
@@ -788,7 +792,7 @@ es-EC:
       product_not_deleted: El producto no pudo ser borrado
       variant_deleted: La Variante ha sido borrada
       variant_not_deleted: La Variante no pudo ser borrada
-    num_orders:
+    num_orders: 
     on_hand: Disponible
     open: Abrir
     open_all_adjustments: Abrir todos los ajustes
@@ -799,13 +803,13 @@ es-EC:
     option_values: Valores de opción
     optional: Opcional
     options: Opciones
-    or: "ó"
+    or: ó
     or_over_price: "%{price} ó más"
     order: Pedido
     order_adjustments: Ajustes de pedido
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Detalles del pedido
     order_email_resent: Email de pedido reenviado
     order_information: Información del pedido
@@ -815,20 +819,20 @@ es-EC:
         instructions: Tu pedido ha sido CANCELADO. Por favor conserva esta información de cancelación para tus registros.
         order_summary_canceled: Resumen de pedido [CANCELADO]
         subject: Cancelación de pedido
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Estimado Cliente,\n
         instructions: Por favor, revisa y conserva la siguiente información del pedido de tus registros.
         order_summary: Resumen del pedido
         subject: Confirmación del pedido
-        subtotal:
+        subtotal: 
         thanks: "¡Gracias por su compra!"
-        total:
+        total: 
     order_not_found: No pudimos encontrar tu pedido. Por favor intenta esta acción de nuevo
-    order_number:
+    order_number: 
     order_processed_successfully: Tu pedido ha sido procesado con éxito
-    order_resumed:
+    order_resumed: 
     order_state:
       address: Dirección
       awaiting_return: Esperando devolución
@@ -836,7 +840,7 @@ es-EC:
       cart: Carrito
       complete: completado
       confirm: Confirmada
-      considered_risky:
+      considered_risky: 
       delivery: Entrega
       payment: Pago
       resumed: reanudado
@@ -846,7 +850,7 @@ es-EC:
     order_total: Total Pedido
     order_updated: Pedido actualizado
     orders: Pedidos
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Fuera de stock
     overview: Visión de conjunto
     package_from: paquete desde
@@ -859,11 +863,11 @@ es-EC:
     path: Ruta
     pay: pagar
     payment: Pago
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Información del Pago
     payment_method: Método de Pago
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Métodos de Pago
     payment_processing_failed: El pago no pudo ser procesado, por favor comprueba los detalles que has introducido
     payment_processor_choose_banner_text: Si necesitas ayuda a la hora de escoger un procesador de pago, por favor visita
@@ -881,7 +885,7 @@ es-EC:
       void: anular
     payment_updated: Pago actualizado
     payments: Pagos
-    pending:
+    pending: 
     percent: Porcentaje
     percent_per_item: Porcentaje por artículo
     permalink: Permalink
@@ -890,13 +894,13 @@ es-EC:
     please_define_payment_methods: Por favor define algún método de pago primero
     populate_get_error: Algo fue mal. Por favor intenta añadir el artículo otra vez.
     powered_by: Desarrollado por
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Presentación
     previous: Previo
-    previous_state_missing:
+    previous_state_missing: 
     price: Precio
     price_range: Rango de precios
     price_sack: Saco de precios
@@ -908,10 +912,10 @@ es-EC:
     product_properties: Propiedades del producto
     product_rule:
       choose_products: Escoge productos
-      label:
+      label: 
       match_all: Todos
       match_any: al menos uno
-      match_none:
+      match_none: 
       product_source:
         group: Desde grupo de producto
         manual: Escoge manualmente
@@ -923,14 +927,14 @@ es-EC:
         description: Crea un ajuste de crédito en la promoción en el pedido
         name: Crear ajuste
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Rellena el carrito con la cuantía especificada de la variante
         name: Crea líneas de artículos
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Acciones
     promotion_form:
       match_policies:
@@ -948,27 +952,27 @@ es-EC:
         description: El ciente debe haber visitado la página especificada
         name: Página de destino
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: El pedido incluye productos específicos
         name: Producto(s)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Disponible solamente a usuarios específicos
         name: Usuario
       user_logged_in:
         description: Disponible solamente a usuarios autorizados
         name: Usuario autorizado
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promociones
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Propiedades
     property: Propiedad
     prototype: Prototipo
@@ -979,46 +983,46 @@ es-EC:
     quantity: Cantidad
     quantity_returned: Cantidad devuelta
     quantity_shipped: Cantidad enviada
-    quick_search:
+    quick_search: 
     rate: Tarifa
     reason: Razón
     receive: recibir
     receive_stock: Recibir Stock
     received: Recibido
-    reception_status:
+    reception_status: 
     reference: Referencia
     refund: Devolución
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Registrar
     registration: Registro
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Recuérdame
     remove: Quitar
     rename: Renombrar
-    report:
+    report: 
     reports: Informes
     resend: Reenviar
     reset_password: Reinicializar password
@@ -1027,34 +1031,34 @@ es-EC:
     resumed: Resumido
     return: Volver
     return_authorization: Autorización para devolución
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Autorización para devolución actualizada
     return_authorizations: Autorizaciones para devolución
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Cantidad de devolución
     returned: Devuelto
-    returns:
+    returns: 
     review: Revisar
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: Crédito RMA
     rma_number: Número RMA
     rma_value: Valor RMA
     roles: Funciones
     rules: Reglas
-    safe:
+    safe: 
     sales_total: Total de ventas
     sales_total_description: Total de ventas de todos los pedidos
     sales_totals: Totales de ventas
     save_and_continue: Guardar y continuar
-    save_my_address:
+    save_my_address: 
     say_no: false
     say_yes: Si
     scope: Alcance
@@ -1064,8 +1068,8 @@ es-EC:
     secure_connection_type: Tipo de conexión segura
     security_settings: Preferencias de seguridad
     select: Seleccionar
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Seleccionar desde el prototipo
     select_stock: Seleccionar Stock
     send_copy_of_all_mails_to: Enviar copia de todos los emails a
@@ -1077,8 +1081,8 @@ es-EC:
     ship_address: Dirección de envío
     ship_total: Total de envío
     shipment: Envío
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Estimado Cliente,\n
@@ -1091,13 +1095,13 @@ es-EC:
     shipment_state: Estado del envío
     shipment_states:
       backorder: Pedido pendiente de existencias
-      canceled:
+      canceled: 
       partial: Parcial
       pending: Pendiente
       ready: Listo
       shipped: Enviado
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Envíos
     shipped: Enviado
     shipping: Envío
@@ -1111,67 +1115,67 @@ es-EC:
     shipping_method: Método de Envío
     shipping_methods: Métodos de Envío
     shipping_price_sack: Saco de Precio
-    shipping_total:
+    shipping_total: 
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrito de la Compra
     show: Mostrar
     show_active: Mostrar Activo
     show_deleted: Mostrar Borrado
     show_only_complete_orders: Mostrar solamente Pedidos completos
-    show_only_considered_risky:
+    show_only_considered_risky: 
     show_rate_in_label: Mostrar tarifa en la etiqueta
     sku: Referencia
-    skus:
-    slug:
+    skus: 
+    slug: 
     source: Fuente
     special_instructions: Instrucciones especiales
     split: Dividir
     spree_gateway_error_flash_for_checkout: Hubo un problema con tu información de pago. Por favor revisa tu información e intentado de nuevo
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Empezar
     state: Provincia
     state_based: Estado basado
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Provincias
     states_required: Provincias requeridas
     status: Estatus
-    stock:
+    stock: 
     stock_location: Localización de stock
     stock_location_info: Info localización de stock
     stock_locations: Localizaciones de Stock
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Gestión de Stock
     stock_management_requires_a_stock_location: Por favor crea una localización de stock para gestionarlo.
     stock_movements: Movimientos del Stock
@@ -1185,28 +1189,29 @@ es-EC:
     street_address_2: Calle (cont.)
     subtotal: Subtotal
     subtract: Restar
-    success:
+    success: 
     successfully_created: "%{resource} ha sido creado con éxito"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} ha sido eliminado con éxito"
     successfully_signed_up_for_analytics: Dado de alta con éxito en Spree Analytics
     successfully_updated: "%{resource} ha sido actualizado con éxito"
-    summary:
+    summary: 
     tax: Tasa
     tax_categories: Categorías fiscales
     tax_category: Categoría Fiscal
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation: Las tasas de impuestos son numeros decimales para ayudar en los calculos, (p. ej. si la tasa de impuesto es del 5%, introducir 0.05)
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: Las tasas de impuestos son numeros decimales para ayudar en los calculos, (p. ej. si la tasa de impuesto es del
+      5%, introducir 0.05)
     tax_rates: Tasas de impuestos
     taxon: Taxon
     taxon_edit: Editar Taxon
     taxon_placeholder: Añadir Taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taxonomías
     taxonomy: Taxonomía
     taxonomy_edit: Editar Taxonomía
@@ -1223,32 +1228,32 @@ es-EC:
     thank_you_for_your_order: Gracias por tu compra. Por favor imprime una copia de esta página de confirmación para tus archivos.
     there_are_no_items_for_this_order: El pedido no contiene artículos. Por favor, añade un artículo al pedido para continuar.
     there_were_problems_with_the_following_fields: Hubo un problema con los siguientes campos
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Hora
     to_add_variants_you_must_first_define: Para añadir variantes, debes definir primero
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Tracking
     tracking_number: Número de Tracking
     tracking_url: URL de Tracking
     tracking_url_placeholder: p. ej. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Transferido desde
     transfer_stock: Transferencia de Stock
     transfer_to_location: Transferido a
-    tree: "Árbol"
+    tree: Árbol
     type: Tipo
     type_to_search: Tipo a buscar
     unable_to_connect_to_gateway: No es posible la conexión a la pasarela
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Bajo %{price}
     unlock: Desbloqueado
     unrecognized_card_type: Tipo de tarjeta no reconocida
@@ -1256,7 +1261,7 @@ es-EC:
     update: Actualizar
     updating: Actualizando
     usage_limit: Límite de Uso
-    use_app_default:
+    use_app_default: 
     use_billing_address: Usa la Dirección de Facturación
     use_new_cc: Usa una nueva tarjeta
     use_s3: Usa Amazon S3 para las Imágenes
@@ -1266,12 +1271,12 @@ es-EC:
     users: Usuarios
     validation:
       cannot_be_less_than_shipped_units: no puede ser menor que el número de unidades enviadas.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: excede el stock disponible. Por favor asegúrate que los artículos tienen un cantidad válida.
       is_too_large: demasiado grande -- el stock disponible no puede cubrir la cantidad solicitada
       must_be_int: debe ser un número entero
       must_be_non_negative: debe ser un valor no negativo
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Valor
     variant: Variante
     variant_placeholder: Escoge una variante

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -1,3 +1,4 @@
+---
 es-MX:
   activerecord:
     attributes:
@@ -22,20 +23,15 @@ es-MX:
         active: Activo
         code: Código
         name: Nombre
-        state: Estado
-      spree/adjustment_reason:
-        active: Activo
-        code: Código
-        name: Nombre
         state: Estatus
       spree/calculator/flat_rate:
         preferred_amount: Cantidad
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/carton:
         tracking: Seguimiento
       spree/country:
@@ -45,13 +41,21 @@ es-MX:
         name: Nombre
         numcode: Código ISO
       spree/credit_card:
-        base:
+        base: 
         cc_type: Tipo
         month: Mes
-        name:
+        name: 
         number: Número
         verification_value: Código de Verificación
         year: Año
+      spree/customer_return:
+        created_at: Fecha y Hora
+        name: Nombre
+        number: Número de devolución
+        pre_tax_total: Total antes de impuestos
+        reimbursement_status: Estado del Reembolso
+        total: Total
+        total_excluding_vat: Total antes de impuestos
       spree/inventory_unit:
         state: Estado
       spree/line_item:
@@ -77,8 +81,8 @@ es-MX:
         created_at: Fecha de pedido
         description: Descripción
         email: E-Mail del cliente
-        ip_address: Dirección IP
         included_tax_total: Impuesto (incl.)
+        ip_address: Dirección IP
         item_total: Total de artículos
         number: Número
         order_number: Número de Orden
@@ -112,24 +116,14 @@ es-MX:
         response_code: ID de la Transacción
         state: Estado
       spree/payment_capture_event:
-        created_at: Fecha y Hora
         amount: Monto
-      spree/payment_method:
-        active: Activo
-        auto_capture: Auto Capture
-        available_to_admin: Available to Admin
-        available_to_users: Available to Users
-        description: Description
-        display_on: Display
-        name: Name
-        preference_source: Preference Source
-        type: Type
+        created_at: Fecha y Hora
       spree/payment_method:
         active: Activo
         auto_capture: Autocaptura
         available_to_admin: Disponible para el Administrador
         available_to_users: Disponible para los Usuarios
-        description: 'Descripción'
+        description: Descripción
         display_on: Mostrar
         name: Nombre
         preference_source: Fuente de preferencia
@@ -142,8 +136,8 @@ es-MX:
         available_on: Disponible en
         cost_currency: Moneda de Costo
         cost_price: Precio de Costo
-        description: Descripción
         depth: Profundidad
+        description: Descripción
         height: Altura
         master_price: Precio Maestro
         meta_description: Meta Description
@@ -158,14 +152,6 @@ es-MX:
         tax_category: Categoría de Impuestos
         weight: Peso
         width: Anchura
-      spree/customer_return:
-        created_at: Fecha y Hora
-        name: Nombre
-        number: Número de devolución
-        pre_tax_total: Total antes de impuestos
-        reimbursement_status: Estado del Reembolso
-        total: Total
-        total_excluding_vat: Total antes de impuestos
       spree/product_property:
         value: Valor
       spree/promotion:
@@ -179,8 +165,8 @@ es-MX:
         starts_at: Comienza
         usage_limit: Límite de Uso
       spree/promotion_category:
-        name: Nombre
         code: Código
+        name: Nombre
       spree/property:
         name: Nombre
         presentation: Presentación
@@ -211,36 +197,11 @@ es-MX:
       spree/return_reason:
         active: Activo
         created_at: Fecha y hora
-        state: Estado
         memo: Memo
         name: Nombre
         number: RMA Número
         state: Estado
       spree/role:
-        name: Nombre
-      spree/state:
-        abbr: Abreviación
-        name: Nombre
-      spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
-      spree/store:
-        available_locales: Idiomas disponibles
-        cart_tax_country_iso: País de impuestos para carros vacíos
-        code: 'Código'
-        default: Por Defecto
-        default_currency: Moneda predeterminada
-        mail_from_address: Correo de dirección
-        meta_description: 'Metadescripción'
-        meta_keywords: Meta Keywords
-        name: Nombre del Sitio
-        seo_title: 'Título del Seo'
-        url: Sitio URL
         name: Nombre
       spree/shipment:
         tracking: Número de Seguimiento
@@ -248,13 +209,24 @@ es-MX:
         name: Nombre
       spree/shipping_method:
         admin_name: Nombre interno
+        available_to_users: Disponible para los usuarios
         carrier: Transportista
         code: Código
         display_on: Mostrar
         name: Nombre
         service_level: Nivel de servicio
         tracking_url: URL de seguimiento
-        available_to_users: Disponible para los usuarios
+      spree/state:
+        abbr: Abreviación
+        name: Nombre
+      spree/state_change:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/stock_location:
         name: Nombre
         state: Estado
@@ -263,39 +235,47 @@ es-MX:
         originated_by: Originado por
         quantity: Cantidad
         variant: Variante
+      spree/store:
+        available_locales: Idiomas disponibles
+        cart_tax_country_iso: País de impuestos para carros vacíos
+        code: Código
+        default: Por Defecto
+        default_currency: Moneda predeterminada
+        mail_from_address: Correo de dirección
+        meta_description: Metadescripción
+        meta_keywords: Meta Keywords
+        name: Nombre
+        seo_title: Título del Seo
+        url: Sitio URL
       spree/tax_category:
         description: Descripción
-        name: Nombre
         is_default: Por Defecto
+        name: Nombre
         tax_code: Código de impuesto
       spree/tax_rate:
         amount: Tasa
-        included_in_price: Incluido en el Precio
-        show_rate_in_label: Mostrar tasa en etiqueta
         expires_at: Fecha de caducidad
-        name: Nombre
-        starts_at: Fecha de inicio
-        amount: Tasa
         included_in_price: Incluido en el Precio
+        name: Nombre
         show_rate_in_label: Mostrar tasa en etiqueta
+        starts_at: Fecha de inicio
         tax_categories: Categorías de Tasa
       spree/taxon:
-        name: Nombre
-        permalink: Enlace permanente
-        position: Posición
         description: Descripción
         icon: Icono
         meta_description: Meta Description
         meta_keywords: Meta Keywords
         meta_title: Meta Title
+        name: Nombre
+        permalink: Enlace permanente
         position: Posición
       spree/taxonomy:
         name: Nombre
       spree/user:
         email: Email
+        lifetime_value: Total gastado
         password: Contraseña
         password_confirmation: Confirmación de Contraseña
-        lifetime_value: Total gastado
         spree_roles: Roles
       spree/variant:
         cost_currency: Moneda de Costo
@@ -316,47 +296,47 @@ es-MX:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: La tarjeta ha expirado.
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Dirección
@@ -424,9 +404,6 @@ es-MX:
       spree/refund_reason:
         one: Razón del Reembolso
         other: Razones del Reembolso
-      spree/return_reason:
-        one: RMA Razón
-        other: RMA Razones
       spree/reimbursement:
         one: Reembolso
         other: Reembolsos
@@ -436,7 +413,10 @@ es-MX:
       spree/return_authorization:
         one: Autorización de Devolución
         other: Autorizaciones de Devolución
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
+      spree/return_reason:
+        one: RMA Razón
+        other: RMA Razones
       spree/role:
         one: Rol
         other: Roles
@@ -452,7 +432,7 @@ es-MX:
       spree/state:
         one: Estado
         other: Estados
-      spree/state_change:
+      spree/state_change: 
       spree/stock:
         one: Inventorio
         other: Inventorios
@@ -465,7 +445,7 @@ es-MX:
       spree/stock_movement:
         one: Movimiento del Inventario
         other: Movimientos del Inventario
-      spree/stock_transfer:
+      spree/stock_transfer: 
       spree/store:
         one: Tienda
         other: Tiendas
@@ -481,30 +461,22 @@ es-MX:
       spree/taxonomy:
         one: Taxonomía
         other: Taxonomías
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: Usuario
         other: Usuarios
       spree/variant:
         one: Variante
         other: Variantes
-      spree/user:
-        one: Usuario
-        other: Usuarios
       spree/zone:
         one: Zona
         other: Zonas
-  time:
-    formats:
-      solidus:
-        long: '%B %d, %Y %-l:%M %p'
-        short: "%b %-d '%y %-l:%M%P"
   spree:
     abbreviation: Abreviatura
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Cuenta
     account_updated: Cuenta actualizada
     action: Acción
@@ -531,7 +503,7 @@ es-MX:
     add: Añadir
     add_action_of_type: Añadir tipo de acción
     add_country: Añadir País
-    add_coupon_code:
+    add_coupon_code: Añadir código de cupón
     add_line_item: Agregar Artículo
     add_new_header: Añadir nuevo encabezado
     add_new_style: Añadir nuevo estilo
@@ -548,7 +520,7 @@ es-MX:
     additional_item: Costo adicional por elemento
     address1: Dirección
     address2: Dirección (continuación)
-    adjustable:
+    adjustable: 
     adjustment: Ajuste
     adjustment_amount: Monto
     adjustment_successfully_closed: Ajustes cerrados exitosamente
@@ -560,6 +532,33 @@ es-MX:
       api:
         key_cleared: Llave borrada
         key_generated: Llave generada
+      prices:
+        any_country: Cualquier País
+        edit:
+          edit_price: Editar Precio
+        index:
+          amount_greater_than: Monto mayor que
+          amount_less_than: Monto menor que
+          new_price: Nuevo Precio
+      promotion_status:
+        active: Activo
+        expired: Expirado
+        inactive: Inactivo
+        not_started: No empezado
+      promotions:
+        actions:
+          calculator_label: Calculado por
+      stock_locations:
+        form:
+          address: Dirección
+          general: General
+          settings: Ajustes
+      store_credits:
+        created_at: Emitido el
+        errors:
+          store_credit_reason_required: Debe seleccionar una razón por la cual se realizó el cambio
+        memo: Memo
+        select_amount_store_credit_reason: Seleccionar la razón por la que se actualiza la cantidad
       tab:
         checkout: Reembolsos y devoluciones
         configuration: Configuración
@@ -569,8 +568,8 @@ es-MX:
         overview: Visión general
         payments: Pagos
         products: Productos
-        promotions: Promociones
         promotion_categories: Categorias de promociones
+        promotions: Promociones
         properties: Propiedades
         prototypes: Prototipos
         reports: Reportes
@@ -586,63 +585,26 @@ es-MX:
         users: Usuarios
         zones: Zonas
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
-      prices:
-        any_country: Cualquier País
-        edit:
-          edit_price: Editar Precio
-        index:
-          amount_greater_than: Monto mayor que
-          amount_less_than: Monto menor que
-          new_price: Nuevo Precio
-      promotions:
-        actions:
-          calculator_label: Calculado por
-      promotion_status:
-        active: Activo
-        expired: Expirado
-        inactive: Inactivo
-        not_started: No empezado
-      store_credits:
-        created_at: Emitido el
-        memo: Memo
-        select_amount_store_credit_reason: Seleccionar la razón por la que se actualiza la cantidad
-        errors:
-          store_credit_reason_required: Debe seleccionar una razón por la cual se realizó el cambio
-      stock_locations:
-        form:
-          address: Dirección
-          general: General
-          settings: Ajustes
-      user:
         edit:
           api_access: Accesp API
           clear_key: Borrar llave
-          confirm_clear_key: ¿Está seguro que quiere borrar esta llave de la API del usuario? Invalidará la llave existente
-          confirm_regenerate_key: ¿Está seguro que quiere regenerar esta llave de la API del usuario? Invalidará la llave existente
+          confirm_clear_key: "¿Está seguro que quiere borrar esta llave de la API del usuario? Invalidará la llave existente"
+          confirm_regenerate_key: "¿Está seguro que quiere regenerar esta llave de la API del usuario? Invalidará la llave existente"
           generate_key: Generar Llave API
           key: Llave
           no_key: Sin llave
           regenerate_key: Llave regenerada
     administration: Administración
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Aceptar política de privacidad.
     agree_to_terms_of_service: Aceptar términos del servicio.
-    add_coupon_code: Añadir código de cupón
     all: Todos
     all_adjustments_closed: "¡Todos los ajustes se han cerrado con éxito!"
-    all_adjustments_opened: Todos los ajustes abiertos exitosamente!
     all_adjustments_finalized: Todos los ajustes finalizados con éxito!
+    all_adjustments_opened: Todos los ajustes abiertos exitosamente!
     all_adjustments_unfinalized: Todos los ajustes exitosamente sin finalizar!
     all_departments: Todos los departamentos
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Permitir que SSL sea usado en modos de prueba y desarrollo
     allow_ssl_in_production: Permitir que SSL sea usado en modo de producción
     allow_ssl_in_staging: Permitir que SSL sea usado en modo de staging
@@ -664,71 +626,70 @@ es-MX:
     are_you_sure: "¿Está seguro?"
     are_you_sure_delete: "¿Está seguro de que quiere eliminar esta entrada?"
     associated_adjustment_closed: El ajuste relacionado está cerrado, y no será recalculado. ¿Deseas abrirlo?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Fallo de autorización
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Disponible en
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Atrás
     back_end: Parte Intera
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Regresar a la tienda
     back_to_users_list: Regresar a la Lista de Usuarios
     backorderable: Disponible para apartado
     backorderable_default: Reordenables por defecto
     backorderable_header: Reordenables
-    backordered:
-    backorders_allowed:
+    backordered: 
+    backorders_allowed: 
     balance_due: Saldo pendiente
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Dirección de facturación
     billing: Facturación
     billing_address: Dirección de facturación
     both: ambos
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Calculadora
     calculator_settings_warning: Si está cambiando el tipo de calculadora, debe guardar su selección antes de editar su configuración
     cancel: Cancelar
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: No puedes crear un pago para una orden que no tiene métodos de pago definidos
     cannot_create_returns: No puede crearse la devolución ya que este pedido aún no ha sido enviado.
     cannot_perform_operation: No puede realizarse la operación requerida
     cannot_set_shipping_method_without_address: No es posible asignar un método de envío hasta tener los detalles del cliente.
     capture: captura
-    capture_events:
+    capture_events: 
     card_code: Código de la tarjeta
     card_number: Número de tarjeta
-    card_type:
+    card_type: 
     card_type_is: Tipo de tarjeta
     cart: Carrito
-    cart_subtotal:
+    cart_subtotal: 
     categories: Categorías
     category: Categoría
     character_limit: Límite de 255 caracteres
-    charged:
+    charged: 
     check_for_spree_alerts: Verificar alertas de Spree
     checkout: Pagar
     choose_a_customer: Elegir cliente
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Elegir Moneda
     choose_dashboard_locale: Escoger Idioma del Panel de Control
-    choose_location:
+    choose_location: 
     choose_promotion_action: Elige acción
     choose_promotion_rule: Elige regla
     choose_reason: Elige una razón
     city: Ciudad
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    create_promotion_code: Crear código de promoción
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Clonar
     close: Cerrar
     close_all_adjustments: Cerrar todos los ajustes
@@ -739,14 +700,14 @@ es-MX:
     configurations: Configuraciones
     confirm: Confirmar
     confirm_delete: Confirmar borrado
-    confirm_password: Confirme la contraseña
     confirm_order: Confirmar Orden
+    confirm_password: Confirme la contraseña
     continue: Continuar
     continue_shopping: Seguir comprando
     cost_currency: Moneda de costo
     cost_price: Precio del Costo
     could_not_connect_to_jirafe: No se pudo conectar con Jirafe para sincronizar datos. Se intentará de nuevo automáticamente más tarde .
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: Hubo un problema guardando este movimiento de existencias. Por favor intente de nuevo.
     count_on_hand: Contar manualmente.
     countries: Países
@@ -754,10 +715,10 @@ es-MX:
     country_based: País base
     country_name: Nombre
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Cupón
     coupon_code: Código de cupón
     coupon_code_already_applied: El código del cupón ya ha sido aplicado en esta orden
@@ -767,18 +728,19 @@ es-MX:
     coupon_code_max_usage: Se ha excedido el límite de uso del código del cupón
     coupon_code_not_eligible: Este código del cupón no puede ser usado para esta orden
     coupon_code_not_found: El código del cupón que introdujiste no existe. Por favor intenta de nuevo
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Crear
     create_a_new_account: Crear una nueva cuenta
-    create_new_order:
+    create_new_order: 
     create_one: Crear Uno
-    create_reimbursement:
+    create_promotion_code: Crear código de promoción
+    create_reimbursement: 
     created_at: Creado en
     credit: Crédito
     credit_card: Tarjeta de crédito
     credit_cards: Tarjetas de crédito
     credit_owed: Crédito disponible
-    credits:
+    credits: 
     currency: Moneda
     currency_decimal_mark: Marca de decimales de moneda
     currency_settings: Configuraciones de moneda
@@ -789,11 +751,11 @@ es-MX:
     customer: Cliente
     customer_details: Detalles del cliente
     customer_details_updated: Detalles del cliente actualizados
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Búsqueda de clientes
     cut: Corte
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: ID de aplicación
@@ -812,45 +774,45 @@ es-MX:
       js_format: dd/mm/yy
     date_range: Rango de Fecha
     default: Por omisión
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Impuesto por defecto
     default_tax_zone: Zona de impuestos por defecto
     delete: Eliminar
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Envío
     depth: Profundidad
     description: Descripción
     destination: Destino
     destroy: Eliminar
-    details:
+    details: 
     discount_amount: Importe del descuento
     discount_rules: Reglas de descuento
     dismiss_banner: No. ¡Gracias!. No estoy interesado, no muestres este mensaje de nuevo
     display: Mostrar
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     download_promotion_codes_list: Descargar lista de códigos
     edit: Editar
-    editing_resource:
-    editing_rma_reason:
-    editing_user: Editando usuario
+    editing_resource: 
+    editing_rma_reason: 
     editing_shipping_category: Editando Categoría de Envío
     editing_shipping_method: Editando Método de Envío
+    editing_user: Editando usuario
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Email
     empty: Vacío
     empty_cart: Vaciar carrito
@@ -863,7 +825,8 @@ es-MX:
       messages:
         could_not_create_taxon: no pudo crearse la categoría
         no_payment_methods_available: No hay métodos de pago configurados para este entorno
-        no_shipping_methods_available: No hay métodos de envío disponibles para la localidad seleccionada. Por favor, cambie la dirección y vuelva a intentarlo.
+        no_shipping_methods_available: No hay métodos de envío disponibles para la localidad seleccionada. Por favor, cambie la dirección y vuelva
+          a intentarlo.
     errors_prohibited_this_record_from_being_saved:
       one: 1 error impidió que no pudiera guardarse el registro
       other: "%{count} errores impidieron que no pudiera guardarse el registro"
@@ -882,22 +845,24 @@ es-MX:
         user:
           signup: User signup
     exceptions:
-      count_on_hand_setter: No se puede usar count_on_hand manualmente, debido a que se activa automáticamente por el callback recalculate_count_hand. Por favor utilice 'update_column(:count_on_hand, value)'
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: >-
+        No se puede usar count_on_hand manualmente, debido a que se activa automáticamente por el callback recalculate_count_hand. Por favor utilice
+        'update_column(:count_on_hand, value)'
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Caducidad
     extension: Extensión
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Nombre de archivo
     fill_in_customer_info: Por favor complete la información del cliente
     filter: Filtrar
     filter_results: Filtrar resultados
     finalize: Finalizar
     finalize_all_adjustments: Finalizar todos los ajustes
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: Costo del primer elemento
     first_name: Nombre
     first_name_begins_with: Nombre comienza por
@@ -906,7 +871,7 @@ es-MX:
     flexible_rate: Cantidad variable
     forgot_password: "¿Olvidaste tu contraseña?"
     free_shipping: Gastos de envío gratuitos
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Sistema Interno
     gateway: Pasarela
     gateway_config_unavailable: Pasarela no disponible por configuración
@@ -922,35 +887,53 @@ es-MX:
     hide_cents: Ocultar centavos
     hints:
       spree/price:
-        country: "Esto determina en qué país es válido el precio.<br/>Por defecto: Cualquier País"
-        master_variant: "Al cambiar el precio de la variante master no cambiará los precios del resto de las variantes de este producto, pero se utilizará como referencia en las variantes de nueva creación"
-        options: "Estas opciones se utilizan para crear variantes en la tabla de variantes y se pueden cambiar en la pestaña de variantes"
+        country: 'Esto determina en qué país es válido el precio.<br/>Por defecto: Cualquier País'
+        master_variant: >-
+          Al cambiar el precio de la variante master no cambiará los precios del resto de las variantes de este producto, pero se utilizará como
+          referencia en las variantes de nueva creación
+        options: Estas opciones se utilizan para crear variantes en la tabla de variantes y se pueden cambiar en la pestaña de variantes
       spree/product:
-        available_on: "Esto establece la fecha de disponibilidad para el producto. Si este valor no se establece, o se establece en una fecha en el futuro, entonces el producto no está en la tienda."
-        promotionable: "Esto determina si las promociones pueden aplicarse a este producto.<br/>Predeterminado: Revisado"
-        shipping_category: "Esto determina qué tipo de envío requiere este producto.<br/> Predeterminado: Default"
-        tax_category: "Esto determina qué clase de impuestos se aplica a este producto.<br/> Predeterminado: Ninguno"
+        available_on: >-
+          Esto establece la fecha de disponibilidad para el producto. Si este valor no se establece, o se establece en una fecha en el futuro,
+          entonces el producto no está en la tienda.
+        promotionable: 'Esto determina si las promociones pueden aplicarse a este producto.<br/>Predeterminado: Revisado'
+        shipping_category: 'Esto determina qué tipo de envío requiere este producto.<br/> Predeterminado: Default'
+        tax_category: 'Esto determina qué clase de impuestos se aplica a este producto.<br/> Predeterminado: Ninguno'
       spree/promotion:
-        starts_at: "Determina cuando la promoción se puede aplicar a pedidos. <br/> Si no se especifica ningún valor, la promoción estará inmediatamente disponible."
-        expires_at: "Esto determina cuándo expira la promoción. <br/> Si no se especifica ningún valor, la promoción nunca expira."
+        expires_at: Esto determina cuándo expira la promoción. <br/> Si no se especifica ningún valor, la promoción nunca expira.
+        starts_at: >-
+          Determina cuando la promoción se puede aplicar a pedidos. <br/> Si no se especifica ningún valor, la promoción estará inmediatamente
+          disponible.
       spree/stock_location:
-        active: "Esto determina si el stock de esta ubicación puede ser usado cuando se hagan los paquetes.<br/> Default: Revisado"
-        backorderable_default: "Cuando esta seleccionado, los artículos del stock en esta ubicación serán por defecto para ordenes pendientes.<br/> Default: Unchecked"
-        check_stock_on_transfer: "Los niveles de inventario serán revisados al realizar transferencias de stock. <br/> Default: Checked"
-        fulfillable: "Cuando no este seleccionado, esto indica que los artículos en esta ubicación no requieren cumplimiento real. El stock no será revisado cuando el envío y los correos no serán enviados.<br/> Default: Checked"
-        propagate_all_variants: "Cuando no este seleccionado, Esto creara un artículo del stock por cada variante en este stock location.<br/> Default: Checked"
-        restock_inventory: "Cuando está seleccionado, el inventario devuelto se puede agregar de nuevo a los niveles de stock de esta ubicación.<br/> Default: checked"
+        active: 'Esto determina si el stock de esta ubicación puede ser usado cuando se hagan los paquetes.<br/> Default: Revisado'
+        backorderable_default: 'Cuando esta seleccionado, los artículos del stock en esta ubicación serán por defecto para ordenes pendientes.<br/>
+          Default: Unchecked'
+        check_stock_on_transfer: 'Los niveles de inventario serán revisados al realizar transferencias de stock. <br/> Default: Checked'
+        fulfillable: >-
+          Cuando no este seleccionado, esto indica que los artículos en esta ubicación no requieren cumplimiento real. El stock no será revisado
+          cuando el envío y los correos no serán enviados.<br/> Default: Checked
+        propagate_all_variants: 'Cuando no este seleccionado, Esto creara un artículo del stock por cada variante en este stock location.<br/>
+          Default: Checked'
+        restock_inventory: 'Cuando está seleccionado, el inventario devuelto se puede agregar de nuevo a los niveles de stock de esta ubicación.<br/>
+          Default: checked'
       spree/store:
-        available_locales: 'Esto determina los idiomas disponibles para elegir en la tienda'
-        cart_tax_country_iso: 'Esto determina qué país se utiliza para los impuestos sobre los carritos (pedidos que aún no tienen una dirección). <br/> Predeterminado: Ninguno.'
-        code: 'Un identificador de tu tienda, Los desarrolladores lo necesitaran si tu operas con multiples tiendas'
+        available_locales: Esto determina los idiomas disponibles para elegir en la tienda
+        cart_tax_country_iso: >-
+          Esto determina qué país se utiliza para los impuestos sobre los carritos (pedidos que aún no tienen una dirección). <br/> Predeterminado:
+          Ninguno.
+        code: Un identificador de tu tienda, Los desarrolladores lo necesitaran si tu operas con multiples tiendas
       spree/tax_rate:
-        validity_period: "Esto determina el período de validez dentro del cual la tasa de impuestos es válida y se aplicará a los artículos elegibles. <br /> Si no se especifica ningún valor de fecha de inicio, la tasa de impuestos estará inmediatamente disponible. <br /> Si no hay valor de fecha de vencimiento Se especifica, la tasa impositiva nunca expirará"
+        validity_period: >-
+          Esto determina el período de validez dentro del cual la tasa de impuestos es válida y se aplicará a los artículos elegibles. <br />
+          Si no se especifica ningún valor de fecha de inicio, la tasa de impuestos estará inmediatamente disponible. <br /> Si no hay valor de
+          fecha de vencimiento Se especifica, la tasa impositiva nunca expirará
       spree/variant:
-        tax_category: 'Esto determina qué clase de impuestos se aplica a esta variante.<br/> Predeterminado: Usar categoría de impuestos del producto asociado con esta variante'
-        deleted: 'Variante eliminada'
-        deleted_explanation: "Esta variante se eliminó en% {date}."
-        deleted_explanation_with_replacement: "Esta variante se eliminó en% {date}. Desde entonces ha sido sustituida por otra con el mismo SKU."
+        deleted: Variante eliminada
+        deleted_explanation: Esta variante se eliminó en% {date}.
+        deleted_explanation_with_replacement: Esta variante se eliminó en% {date}. Desde entonces ha sido sustituida por otra con el mismo SKU.
+        tax_category: >-
+          Esto determina qué clase de impuestos se aplica a esta variante.<br/> Predeterminado: Usar categoría de impuestos del producto asociado
+          con esta variante
     home: Inicio
     i18n:
       available_locales: Traduciones Disponibles
@@ -958,33 +941,35 @@ es-MX:
       localization_settings: Ajustes de traducciones
       this_file_language: Español (México)
     icon: Icono
-    identifier:
+    identifier: 
     image: Imagen
     images: Imágenes
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
     inactive: Inactivo
-    incl:
+    incl: 
     included_in_price: Incluido en el precio
     included_price_validation: No puede ser seleccionado a menos que hayas elegido una zona de impuestos por defecto
     incomplete: Incompleto
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: Ingresa tu correo en el formulario a continuación
     insufficient_stock: No hay inventario suficiente, sólo %{on_hand} disponibles
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Interceptar dirección de Email
     intercept_email_instructions: Sustituir el receptor del email con ésta dirección.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Proveedor de pago no válido
     invalid_promotion_action: Acción de promoción inválida
     invalid_promotion_rule: Regla de promoción no válida
     inventory: Inventario
     inventory_adjustment: Ajuste de inventario
     inventory_error_flash_for_insufficient_quantity: Un artículo en tu carro ya no está disponible
-    inventory_error_flash_for_insufficient_shipment_quantity: "Cantidad seleccionada de %{unavailable_items} no esta disponible. Aún así, los artículos pueden estar disponibles en otra ubicación de stock, por favor intente nuevamente."
+    inventory_error_flash_for_insufficient_shipment_quantity: >-
+      Cantidad seleccionada de %{unavailable_items} no esta disponible. Aún así, los artículos pueden estar disponibles en otra ubicación de stock,
+      por favor intente nuevamente.
     inventory_state: Estado del Inventario
     inventory_states:
       backordered: En espera
@@ -1001,26 +986,26 @@ es-MX:
       operators:
         gt: mayor que
         gte: mayor o igual que
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Ruta
     last_name: Apellidos
     last_name_begins_with: Apellido comienza por
     learn_more: Aprender más
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Lista
     loading: Cargando
     locale_changed: Idioma cambiado
     location: Localización
     lock: Bloquear
-    log_entries:
+    log_entries: 
     logged_in_as: Conectado como
     logged_in_succesfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
@@ -1029,24 +1014,24 @@ es-MX:
     login_failed: Falló el inicio de sesión
     login_name: Iniciar sesión
     logout: Cerrar sesión
-    logs:
+    logs: 
     look_for_similar_items: Buscar artículos similares
     make_refund: Realizar devolución
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Precio principal
+    master_sku: SKU principal
     match_choices:
       all: Todos
       none: Ninguno
     max_items: Máximo de elementos
     member_since: Miembro desde
-    memo:
-    master_sku: SKU principal
+    memo: 
     meta_description: Meta descripción
     meta_keywords: Meta palabras clave
-    meta_title:
+    meta_title: 
     metadata: Metadatos
     minimal_amount: Cantidad mínima
     modify_stock_count: Modificar (+/-)
@@ -1056,12 +1041,12 @@ es-MX:
     my_account: Mi cuenta
     my_orders: Mis pedidos
     name: Nombre
-    name_on_card:
+    name_on_card: 
     name_or_sku: Nombre o código de producto
     new: Nuevo
     new_adjustment: Nuevo Ajuste
     new_adjustment_reason: Nueva razón de ajuste
-    new_country:
+    new_country: 
     new_customer: Nuevo cliente
     new_customer_return: Nueva devolución del cliente
     new_image: Nueva Imagen
@@ -1079,7 +1064,7 @@ es-MX:
     new_refund_reason: Nueva razón del reembolso
     new_return_authorization: Nueva autorización de devolución
     new_rma_reason: Nuevo RMA razón
-    new_shipment_at_location:
+    new_shipment_at_location: 
     new_shipping_category: Nueva categoría de envío
     new_shipping_method: Nueva forma de envío
     new_state: Nuevo estado
@@ -1098,25 +1083,25 @@ es-MX:
     next: siguiente
     no_actions_added: No se agregaron acciones
     no_option_values_on_product_html: El producto no tiene valores de opciones asociados.
-    no_payment_found:
-    no_pending_payments:
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: No se han encontrado productos
     no_resource: No %{resource} encontrado
     no_resource_found: No %{resource} encontrado
     no_results: Sin resultados
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: No se han añadido nuevas reglas
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: No hay detalles de ubicación provistos.
     none: Ninguno
-    none_selected:
+    none_selected: 
     normal_amount: Cantidad normal
     not: false
     not_available: N/A
     not_enough_stock: No hay suficiente inventario en la ubicación fuente para completar esta transferencia.
     not_found: "%{resource} no encontrado"
-    note:
+    note: 
     notice_messages:
       product_cloned: El producto ha sido clonado
       product_deleted: El producto ha sido elminado
@@ -1129,7 +1114,7 @@ es-MX:
     open: Abrir
     open_all_adjustments: Abrir todos los ajustes
     option_type: Tipo de opción
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Tipos de opción
     option_value: Valor de la opción
     option_values: Valores de la opción
@@ -1139,9 +1124,9 @@ es-MX:
     or_over_price: "%{price} o más"
     order: Pedido
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Detalles del pedido
     order_email_resent: Email de pedido reenviado
     order_information: Información del pedido
@@ -1151,22 +1136,24 @@ es-MX:
         instructions: Su orden ha sido CANCELADA. Por favor mantenga esta información de cancelación para sus registros
         order_summary_canceled: Resumen del pedido [CANCELADO]
         subject: Cancelación de pedido
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer: |
-          Querido cliente,
+        dear_customer: 'Querido cliente,
+
+          '
         instructions: Por favor revise y mantenga la siguiente información del pedido para sus registros
         order_summary: Resumen del pedido
         subject: Confirmación de pedido
-        subtotal:
+        subtotal: 
         thanks: Gracias por su negocio
-        total:
+        total: 
     order_not_found: No pudimos encontrar su orden. Por favor inténtalo de nuevo
-    order_number:
+    order_number: 
     order_please_refresh: El pedido no está listo para ser completado. Por favor, actualice los totales.
     order_processed_successfully: Su pedido se ha procesado correctamente
-    order_resumed:
+    order_refresh_totals: Actualizar totales
+    order_resumed: 
     order_state:
       address: Dirección
       awaiting_return: Esperando Respuesta
@@ -1174,18 +1161,17 @@ es-MX:
       cart: Carrito
       complete: Completado
       confirm: Confirmado
-      considered_risky:
+      considered_risky: 
       delivery: Envío
       payment: Pago
       resumed: Reanudado
       returned: Devuelto
-    order_refresh_totals: Actualizar totales
     order_summary: Resumen de pedido
     order_sure_want_to: "¿Está seguro de quiere %{event} este pedido?"
     order_total: Total del pedido
     order_updated: Pedido actualizado
     orders: Pedidos
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Fuera de Inventario
     overview: General
     package_from: Paquete desde
@@ -1198,11 +1184,11 @@ es-MX:
     path: Ruta
     pay: Pagar
     payment: Pago
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Información del pago
     payment_method: Método de pago
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Métodos de pago
     payment_processing_failed: El pago no ha podido ser procesado, por favor revise los datos proporcionados.
     payment_processor_choose_banner_text: Si necesitas ayuda eligiendo un procesador de pagos, por favor visita
@@ -1220,7 +1206,7 @@ es-MX:
       void: Vacío
     payment_updated: Pago actualizado
     payments: Pagos
-    pending:
+    pending: 
     percent: Porcentaje
     percent_per_item: Porcentaje por artículo
     permalink: Enlace permanente
@@ -1229,13 +1215,13 @@ es-MX:
     please_define_payment_methods: Por favor primero defina algunos métodos de pago
     populate_get_error: Algo salió mal. Por favor intente agregando el artículo de nuevo
     powered_by: Hecho con
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Presentación
     previous: Anterior
-    previous_state_missing:
+    previous_state_missing: 
     price: Precio
     price_range: Rango de precio
     price_sack: Price Sack
@@ -1247,16 +1233,16 @@ es-MX:
     product_properties: Propiedades del producto
     product_rule:
       choose_products: Elija productos
-      label:
+      label: 
       match_all: todos
       match_any: al menos uno de
-      match_none:
+      match_none: 
       product_source:
         group: Del grupo de productos
         manual: Elegir manualmente
+    product_without_default_price_cta: Por favor, cree un Master Price!
+    product_without_default_price_info: Este producto no tiene precio en la moneda default (%{default_currency}).
     products: Productos
-    product_without_default_price_info: "Este producto no tiene precio en la moneda default (%{default_currency})."
-    product_without_default_price_cta: "Por favor, cree un Master Price!"
     promotion: Promoción
     promotion_action: Acción de promoción
     promotion_action_types:
@@ -1264,14 +1250,14 @@ es-MX:
         description: Creates a promotion credit adjustment on the order
         name: Crear ajuste
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Llene el carrito con la cantidad específica de variantes
         name: Crear artículos de línea
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Acciones
     promotion_form:
       match_policies:
@@ -1306,10 +1292,10 @@ es-MX:
       user_logged_in:
         description: Disponible sólo para usuarios con sesión iniciada
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promociones
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Propiedades
     property: Propiedad
     prototype: Prototipo
@@ -1326,40 +1312,40 @@ es-MX:
     receive: recibir
     receive_stock: Recibir inventario
     received: Recibido
-    reception_status:
+    reception_status: 
     reference: Referencia
     refund: Devolver
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Registrar
     registration: Registro
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Recuerdame
     remove: Eliminar
     rename: Renombrar
-    report:
+    report: 
     reports: Informes
     resend: Volver a enviar
     reset_password: Reiniciar mi contraseña
@@ -1368,35 +1354,35 @@ es-MX:
     resumed: Reanudado
     return: volver
     return_authorization: Autorización para devolución
-    return_authorization_reasons:
     return_authorization_fire_error: No se puede realizar esta acción en la autorización de devolución de mercancía.
+    return_authorization_reasons: 
     return_authorization_updated: Devolver autorización actualizada
     return_authorizations: Autorizaciones para devoluciones
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Devolver cantidad
     returned: regresó
-    returns:
+    returns: 
     review: Revisar
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: Crédito RMA
     rma_number: Número RMA
     rma_value: Valor RMA
     roles: Funciones
     rules: Reglas
-    safe:
+    safe: 
     sales_total: Total de ventas
     sales_total_description: Total de ventas de todos los pedidos
     sales_totals: Total de Ventas
     save_and_continue: Guardar y continuar
-    save_my_address:
+    save_my_address: 
     say_no: false
     say_yes: Sí
     scope: Alcance
@@ -1406,8 +1392,8 @@ es-MX:
     secure_connection_type: Tipo de conexión segura
     security_settings: Configuraciones de seguridad
     select: Seleccionar
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Seleccionar desde prototipo
     select_stock: Elegir inventario
     send_copy_of_all_mails_to: Envia una copia de todos los correos a
@@ -1419,8 +1405,8 @@ es-MX:
     ship_address: Dirección de envío
     ship_total: Envío Total
     shipment: Envío
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Querido cliente,\n
@@ -1433,13 +1419,13 @@ es-MX:
     shipment_state: Estado del envío
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: 
       partial: parcial
       pending: pendiente
       ready: listo
       shipped: enviado
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Envíos
     shipped: Enviado
     shipping: Envío
@@ -1453,72 +1439,72 @@ es-MX:
     shipping_method: Método de envío
     shipping_methods: Métodos de envío
     shipping_price_sack: Monedero
-    shipping_total:
+    shipping_total: 
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrito de compras
     show: Mostrar
     show_active: mostrar activos
     show_deleted: Mostrar eliminados
     show_only_complete_orders: Mostrar sólo los pedidos completados
-    show_only_considered_risky:
+    show_only_considered_risky: 
     show_rate_in_label: Mostrar tarifa en etiqueta
     sku: Código
-    skus:
-    slug:
+    skus: 
+    slug: 
     source: Origen
     special_instructions: Instrucciones especiales
     split: Dividir
     spree_gateway_error_flash_for_checkout: hubo un problema con su información de pago. Por favor, revísela e inténtelo de nuevo.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Inicio
     state: Estado
     state_based: Estado base
+    state_machine_states:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
+    states: Provincias
     states_count:
       one: "%{count} estado"
       other: "%{count} estados"
-    state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states: Provincias
     states_required: Estados Requeridos
     status: Estado
-    stock:
+    stock: 
     stock_location: Ubicación de Inventario
     stock_location_info: Información sobre Ubicación de Inventario
     stock_locations: Ubicación de Inventario
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Manejo de Inventario
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: 
     stock_movements: Movimientos de Inventario
     stock_movements_for_stock_location: Movimientos de inventario para %{stock_location_name}
     stock_successfully_transferred: El Stock fue transferido exitosamente entre ubicaciones.
@@ -1532,28 +1518,29 @@ es-MX:
     street_address_2: Dirección (continuación)
     subtotal: Subtotal
     subtract: Restar
-    success:
+    success: 
     successfully_created: "¡%{resource} ha sido creado con éxito"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} ha sido borrado con éxito"
     successfully_signed_up_for_analytics: Registrado exitosamente para Spree Analytics
     successfully_updated: "%{resource} ha sido actualizado con éxito"
-    summary:
+    summary: 
     tax: Impuestos
     tax_categories: Categorías de impuestos
     tax_category: Categoría de impuestos
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation: Las tasas de impuesto son una cantidad decimal para ayudar en el cálculo (por ejemplo, si la tasa de impuesto es 5% entonces introduce 0.05)
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: Las tasas de impuesto son una cantidad decimal para ayudar en el cálculo (por ejemplo, si la tasa de impuesto
+      es 5% entonces introduce 0.05)
     tax_rates: Tasas de impuestos
     taxon: Categoría
     taxon_edit: Editar categoría
     taxon_placeholder: Agregar taxón
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Categorías
     taxonomy: Taxonomy
     taxonomy_edit: Editar categorías
@@ -1568,35 +1555,35 @@ es-MX:
         subject: Testmail
     test_mode: Modo de Prueba
     thank_you_for_your_order: Gracias por su pedido. Por favor imprima una copia de esta información para sus registros
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: 'Hubo problemas con los siguientes campos:'
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Miniatura
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Tiempo
     to_add_variants_you_must_first_define: Para agregar variantes, primero debe definir
     total: Total
     total_excluding_vat: Total pre-impuestos
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Seguimiento
     tracking_number: Número de Rastreo
     tracking_url: URL de Rastreo
     tracking_url_placeholder: por ejemplo http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Transferir desde
     transfer_stock: Transferencia de inventario
     transfer_to_location: Transferir a
-    tree: "Árbol"
+    tree: Árbol
     type: Tipo
     type_to_search: Tipo a buscar
     unable_to_connect_to_gateway: No ha sido posible conectarse a la pasarela.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Bajo %{price}
     unfinalize_all_adjustments: Desfinalizar todos los ajustes
     unlock: Desbloquear
@@ -1605,7 +1592,7 @@ es-MX:
     update: Actualizar
     updating: Actualizando
     usage_limit: Límite de uso
-    use_app_default:
+    use_app_default: 
     use_billing_address: Usar la dirección de facturación
     use_new_cc: Usar una tarjeta diferente
     use_s3: Usar Amazon S3 para imágenes
@@ -1615,12 +1602,12 @@ es-MX:
     users: Usuarios
     validation:
       cannot_be_less_than_shipped_units: no puede ser menos que el número de unidades enviadas.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: Excede el inventario disponible. Por favor asegúrate de que los artículos tengan una cantidad válida
       is_too_large: es demasiado grande -- no hay suficientes productos disponibles para ésa cantidad
       must_be_int: debe ser un entero
       must_be_non_negative: debe ser un valor no negativo
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     validity_period: Periodo de validez
     value: valor
     variant: Variante
@@ -1646,3 +1633,8 @@ es-MX:
     zipcode: Código Postal
     zone: Zona
     zones: Zonas
+  time:
+    formats:
+      solidus:
+        long: "%B %d, %Y %-l:%M %p"
+        short: "%b %-d '%y %-l:%M%P"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,21 +1,22 @@
+---
 es:
   activemodel:
     attributes:
       spree/order_cancellations:
-        quantity: Cantidad
-        state: Estado
-        shipment: Envío
         cancel: Cancelar
+        quantity: Cantidad
+        shipment: Envío
+        state: Estado
     errors:
       models:
         spree/fulfilment_changer:
           attributes:
+            current_shipment:
+              can_not_have_backordered_inventory_units: tiene unidades pendientes de stock en el inventario
+              has_already_been_shipped: Ya ha sido enviado
             desired_shipment:
               can_not_transfer_within_same_shipment: no puede ser igual que el envío actual
               not_enough_stock_at_desired_location: cantidad insuficiente en la ubicación de stock deseada
-            current_shipment:
-              has_already_been_shipped: Ya ha sido enviado
-              can_not_have_backordered_inventory_units: tiene unidades pendientes de stock en el inventario
   activerecord:
     attributes:
       spree/address:
@@ -29,11 +30,11 @@ es:
         zipcode: Código Postal
       spree/adjustment:
         adjustable: Ajustable
+        adjustment_reason_id: Razón
         amount: Cantidad
         label: Descripción
         name: Nombre
         state: Estado
-        adjustment_reason_id: Razón
       spree/adjustment_reason:
         active: Activo
         code: Código
@@ -60,8 +61,8 @@ es:
         states_required: Provincia o estado requeridos
       spree/credit_card:
         base: ''
-        cc_type: Tipo
         card_code: Código tarjeta
+        cc_type: Tipo
         expiration: Caducidad
         month: Mes
         name: Nombre
@@ -69,12 +70,12 @@ es:
         verification_value: Valor verificación
         year: Año
       spree/customer_return:
+        created_at: Fecha/Hora
+        name: Nombre
         number: Numero de devolución
         pre_tax_total: Total antes de impuestos
-        total: Total
-        created_at: "Fecha/Hora"
         reimbursement_status: Estado del reembolso
-        name: Nombre
+        total: Total
       spree/image:
         alt: Text Alternativo
         attachment: Nombre del archivo
@@ -104,6 +105,7 @@ es:
         canceler_id: Cancelador
         checkout_complete: Completar Pedido
         completed_at: Completado En
+        considered_risky: Arriesgado
         coupon_code: Código Cupón
         created_at: Fecha del Pedido
         email: Email del Cliente
@@ -117,7 +119,6 @@ es:
         special_instructions: Instrucciones especiales
         state: Estado
         total: Total
-        considered_risky: Arriesgado
       spree/order/bill_address:
         address1: Calle dirección de facturación
         city: Ciudad dirección de facturación
@@ -149,15 +150,15 @@ es:
         preference_source: Origen de preferencia
         type: Proveedor
       spree/price:
-        currency: Moneda
         amount: Precio
+        currency: Moneda
         is_default: Válido Actualmente
       spree/product:
         available_on: Disponible
         cost_currency: Moneda de coste
         cost_price: Precio de coste
-        description: Descripción
         depth: Profundidad
+        description: Descripción
         height: Altura
         master_price: Precio Principal
         meta_description: Meta Description
@@ -196,30 +197,30 @@ es:
         description: Crea un ajuste en una línea de pedido en función de la cantidad
       spree/promotion/actions/free_shipping:
         description: Realiza todos los envíos en el pedido gratuitos
-      spree/promotion/rules/item_total:
-        description: El total del pedido cumple con estos criterios
       spree/promotion/rules/first_order:
         description: Debe ser el primer pedido del cliente
+      spree/promotion/rules/first_repeat_purchase_since:
+        description: Disponible sólo para usuarios que no han comprado en un tiempo determinado
+        form_text: 'Aplicar esta promoción a usuarios cuyo último pedido fue hace más de X días: '
+      spree/promotion/rules/item_total:
+        description: El total del pedido cumple con estos criterios
       spree/promotion/rules/landing_page:
-          description: El cliente debe haber visitado la página especificada
+        description: El cliente debe haber visitado la página especificada
+      spree/promotion/rules/nth_order:
+        description: Aplique una promoción a cada énesimo pedido que un usuario haya completado.
+        form_text: 'Aplicar esta promoción a los usuarios con N pedidos: '
       spree/promotion/rules/one_use_per_user:
         description: Sólo un uso por usuario
       spree/promotion/rules/option_value:
         description: El pedido incluye el producto(s) que coinciden con el valor(es) de la opción correspondiente
       spree/promotion/rules/product:
         description: El pedido incluye el producto(s)
+      spree/promotion/rules/taxon:
+        description: El pedido incluye productos con los siguientes taxon(s)
       spree/promotion/rules/user:
         description: Disponible sólo para los siguientes usuarios
       spree/promotion/rules/user_logged_in:
         description: Disponible sólo para usuarios registrados
-      spree/promotion/rules/taxon:
-        description: El pedido incluye productos con los siguientes taxon(s)
-      spree/promotion/rules/nth_order:
-        description: Aplique una promoción a cada énesimo pedido que un usuario haya completado.
-        form_text: "Aplicar esta promoción a los usuarios con N pedidos: "
-      spree/promotion/rules/first_repeat_purchase_since:
-        description: Disponible sólo para usuarios que no han comprado en un tiempo determinado
-        form_text: "Aplicar esta promoción a usuarios cuyo último pedido fue hace más de X días: "
       spree/promotion/rules/user_role:
         description: El pedido incluye el usuario con las siguientes funciones específicas
       spree/promotion_category:
@@ -233,19 +234,19 @@ es:
         refund_reason_id: Razón
       spree/refund_reason:
         active: Activo
-        name: Nombre
         code: Código
+        name: Nombre
       spree/reimbursement:
-        created_at: "Fecha/Hora"
+        created_at: Fecha/Hora
         number: Número
         reimbursement_status: Estado
         total: Total
       spree/reimbursement/credit:
         amount: Cantidad
       spree/reimbursement_type:
+        created_at: Fecha/Hora
         name: Nombre
         type: Tipo
-        created_at: "Fecha/Hora"
       spree/return_authorization:
         amount: Cantidad
         pre_tax_total: Total antes de impuestos
@@ -264,18 +265,18 @@ es:
         return_reason: Razón
         total: Total
       spree/return_reason:
-        name: Nombre
         active: Activo
-        created_at: "Fecha/Hora"
+        created_at: Fecha/Hora
         memo: Memo
+        name: Nombre
         number: Número de RMA
         state: Estado
       spree/role:
         name: Nombre
-      spree/shipping_category:
-        name: Nombre
       spree/shipment:
         tracking: Número de Tracking
+      spree/shipping_category:
+        name: Nombre
       spree/shipping_method:
         admin_name: Nombre Interno
         carrier: Courier
@@ -285,43 +286,20 @@ es:
         service_level: Nivel de Servicio
         tracking_url: Tracking URL
       spree/shipping_rate:
-        label: Etiqueta
-        tax_rate: Tasa de Impuestos
-        shipping_rate: Cantidad del Envío
         amount: Cantidad
+        label: Etiqueta
+        shipping_rate: Cantidad del Envío
+        tax_rate: Tasa de Impuestos
       spree/state:
         abbr: Abreviatura
         name: Nombre
-      spree/store:
-        url: URL del sitio
-        meta_description: Meta Description
-        meta_keywords: Meta Keywords
-        seo_title: Seo Title
-        name: Nombre del Sitio
-        mail_from_address: Dirección de Mail de Envío
-        cart_tax_country_iso: País de Impuestos para Carritos Vacíos
-      spree/store_credit:
-        amount: Cantidad
-        amount_authorized: Cantidad Autorizada
-        amount_credited: Cantidad Adeudada
-        amount_used: Cantidad Usada
-        category_id: Tipo de Crédito
-        created_at: Issued On
-        created_by_id: Creado Por
-        invalidated_at: Invalidado
-        memo: Memo
-      spree/store_credit_event:
-        action: Accción
-        user_total_amount: Total no Usado
-      spree/store_credit_update_reason:
-        name: Razón para actualizar
       spree/stock_item:
         count_on_hand: Existencias
       spree/stock_location:
-        admin_name: Nombre Interno
         active: Activo
         address1: Dirección
         address2: Dirección (cont.)
+        admin_name: Nombre Interno
         backorderable_default: Stock Negativo por defecto
         check_stock_on_transfer: Comprobar stock en la transferencia
         city: Ciudad
@@ -350,18 +328,41 @@ es:
         shipped_at: Enviado en
         source_location_id: Localización de origen
         tracking_number: Número de seguimiento
+      spree/store:
+        cart_tax_country_iso: País de Impuestos para Carritos Vacíos
+        mail_from_address: Dirección de Mail de Envío
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        name: Nombre del Sitio
+        seo_title: Seo Title
+        url: URL del sitio
+      spree/store_credit:
+        amount: Cantidad
+        amount_authorized: Cantidad Autorizada
+        amount_credited: Cantidad Adeudada
+        amount_used: Cantidad Usada
+        category_id: Tipo de Crédito
+        created_at: Issued On
+        created_by_id: Creado Por
+        invalidated_at: Invalidado
+        memo: Memo
+      spree/store_credit_event:
+        action: Accción
+        user_total_amount: Total no Usado
+      spree/store_credit_update_reason:
+        name: Razón para actualizar
       spree/tax_category:
         description: Descripción
-        name: Nombre
         is_default: Por defecto
+        name: Nombre
         tax_code: Código de impuesto
       spree/tax_rate:
         amount: Tasa
+        expires_at: Fecha de expiración
         included_in_price: Incluido en el precio
         name: Nombre
         show_rate_in_label: Mostrar tasa en la etiqueta
         starts_at: Fecha de inicio
-        expires_at: Fecha de expiración
       spree/taxon:
         description: Descripción
         icon: Icono
@@ -374,8 +375,8 @@ es:
       spree/taxonomy:
         name: Nombre
       spree/tracker:
-        analytics_id: Analytics ID
         active: Activo
+        analytics_id: Analytics ID
       spree/user:
         email: Email
         password: Constraseña
@@ -391,14 +392,85 @@ es:
         weight: Peso
         width: Anchura
       spree/zone:
+        default_tax: Zona de impuestos por defecto
         description: Descripción
         name: Nombre
-        default_tax: Zona de impuestos por defecto
+    errors:
+      models:
+        spree/calculator/tiered_flat_rate:
+          attributes:
+            base:
+              keys_should_be_positive_number: Los valores de los tramos clave deben ser mayores que 0
+            preferred_tiers:
+              should_be_hash: debe ser una hash
+        spree/calculator/tiered_percent:
+          attributes:
+            base:
+              keys_should_be_positive_number: Los valores de los tramos clave deben ser mayores que 0
+              values_should_be_percent: Los valores de los tramos deben ser porcentajes entre 0% y 100%
+            preferred_tiers:
+              should_be_hash: should be a hash
+        spree/classification:
+          attributes:
+            taxon_id:
+              already_linked: Ya está vinculada a este producto
+        spree/credit_card:
+          attributes:
+            base:
+              card_expired: La tarjeta ha expirado
+              expiry_invalid: La caducidad de la tarjeta no es válida
+        spree/inventory_unit:
+          attributes:
+            base:
+              cannot_destroy_shipment_state: No se puede anular unidad de inventario en %{state} por el de envío
+            state:
+              cannot_destroy: No se puede anular unidad de inventario en %{state}
+        spree/line_item:
+          attributes:
+            price:
+              not_a_number: no es válido
+        spree/price:
+          attributes:
+            currency:
+              invalid_code: Código de divisa no válido
+        spree/promotion:
+          attributes:
+            apply_automatically:
+              disallowed_with_code: Rechazado para promociones con un código
+              disallowed_with_path: Rechazado para promociones con una ruta
+        spree/refund:
+          attributes:
+            amount:
+              greater_than_allowed: es mayor que la cantidad permitida.
+        spree/reimbursement:
+          attributes:
+            base:
+              return_items_order_id_does_not_match: Uno o mas de los artículos devueltos no pertenecen al pedido del reembolso.
+        spree/return_item:
+          attributes:
+            inventory_unit:
+              other_completed_return_item_exists: "%{inventory_unit_id} ya ha sido considerado como devuelto por el artículo %{return_item_id}"
+            reimbursement:
+              cannot_be_associated_unless_accepted: No se puede asociar a un artículo devuelto que no está aceptado.
+        spree/shipment:
+          attributes:
+            base:
+              cannot_remove_items_shipment_state: No se pueden eliminar artículos de un %{state} de envío
+            state:
+              cannot_destroy: No se puede eliminar un %{state} de envío
+        spree/store:
+          attributes:
+            base:
+              cannot_destroy_default_store: No se puede eliminar la Tienda por defecto.
+        spree/user_address:
+          attributes:
+            user_id:
+              default_address_exists: Ya tiene una dirección predeterminada
+        spree/wallet_payment_source:
+          attributes:
+            payment_source:
+              has_to_be_payment_source_class: Tiene que ser un Spree::PaymentSource
     models:
-      # LegacyUser maps to this model_name so we want to provide translations for it
-      user:
-        one: Usuario
-        other: Usuarios
       spree/address:
         one: Dirección
         other: Direcciones
@@ -438,12 +510,6 @@ es:
       spree/calculator/price_sack:
         one: Saco de Precios
         other: Saco de Precios
-      spree/calculator/tiered_percent:
-        one: Porcentaje por Niveles
-        other: Porcentaje por Niveles
-      spree/calculator/tiered_flat_rate:
-        one: Tarifa Plana Gradual
-        other: Tarifa Plana Gradual
       spree/calculator/returns/default_refund_amount:
         one: Importe de Reembolso Predeterminado
         other: Importe de Reembolso Predeterminado
@@ -462,6 +528,12 @@ es:
       spree/calculator/shipping/price_sack:
         one: Saco de Precios
         other: Saco de Precios
+      spree/calculator/tiered_flat_rate:
+        one: Tarifa Plana Gradual
+        other: Tarifa Plana Gradual
+      spree/calculator/tiered_percent:
+        one: Porcentaje por Niveles
+        other: Porcentaje por Niveles
       spree/country:
         one: País
         other: Países
@@ -507,10 +579,10 @@ es:
       spree/payment_method:
         one: Método de Pago
         other: Métodos de Pago
-      spree/payment_method/check: Pagos con Cheque/Transferencia
-      spree/payment_method/store_credit: Pagos de Crédito de la Tienda
       spree/payment_method/bogus_credit_card: Pagos con tarjeta de crédito Bogus
+      spree/payment_method/check: Pagos con Cheque/Transferencia
       spree/payment_method/simple_bogus_credit_card: Pagos con tarjeta de crédito Simple Bogus
+      spree/payment_method/store_credit: Pagos de Crédito de la Tienda
       spree/price:
         one: Precio
         other: Precios
@@ -528,26 +600,26 @@ es:
       spree/promotion/actions/create_quantity_adjustments: Crear un ajuste por cantidad
       spree/promotion/actions/free_shipping: Envío gratuito
       spree/promotion/rules/first_order: Primer pedido
+      spree/promotion/rules/first_repeat_purchase_since: Primera Compra repetida desde
       spree/promotion/rules/item_total: Total de Artículo
       spree/promotion/rules/landing_page: Página de destino
+      spree/promotion/rules/nth_order: N Pedidos
       spree/promotion/rules/one_use_per_user: Un uso por Usuario
       spree/promotion/rules/option_value: Valor(es) de Opción
       spree/promotion/rules/product: Producto(s)
+      spree/promotion/rules/taxon: Taxon(s)
       spree/promotion/rules/user: Usuario
       spree/promotion/rules/user_logged_in: Usuario Autorizado
-      spree/promotion/rules/taxon: Taxon(s)
-      spree/promotion/rules/nth_order: N Pedidos
-      spree/promotion/rules/first_repeat_purchase_since: Primera Compra repetida desde
       spree/promotion/rules/user_role: Función(es) de Usuario
       spree/promotion_category:
         one: Categoría de la Promoción
         other: Categorías de la Promoción
-      spree/promotion_code_batch:
-        one: Batch de Código de Promoción
-        other: Batches de Códigos de Promoción
       spree/promotion_code:
         one: Código de Promoción
         other: Códigos de Promoción
+      spree/promotion_code_batch:
+        one: Batch de Código de Promoción
+        other: Batches de Códigos de Promoción
       spree/property:
         one: Tipo de Propiedad
         other: Tipos de Propiedad
@@ -588,12 +660,12 @@ es:
       spree/stock_item:
         one: Artículo en Stock
         other: Artículos en Stock
-      spree/stock_movement:
-        one: Movimiento de Stock
-        other: Movimientos de Stock
       spree/stock_location:
         one: Localización del Stock
         other: Localizaciones del Stock
+      spree/stock_movement:
+        one: Movimiento de Stock
+        other: Movimientos de Stock
       spree/stock_transfer:
         one: Transferencia de Stock
         other: Transferencias de Stock
@@ -633,91 +705,14 @@ es:
       spree/zone:
         one: Zone
         other: Zones
-    errors:
-      models:
-        spree/calculator/tiered_flat_rate:
-          attributes:
-            base:
-              keys_should_be_positive_number: "Los valores de los tramos clave deben ser mayores que 0"
-            preferred_tiers:
-              should_be_hash: "debe ser una hash"
-        spree/calculator/tiered_percent:
-          attributes:
-            base:
-              keys_should_be_positive_number: "Los valores de los tramos clave deben ser mayores que 0"
-              values_should_be_percent: "Los valores de los tramos deben ser porcentajes entre 0% y 100%"
-            preferred_tiers:
-              should_be_hash: "should be a hash"
-        spree/classification:
-          attributes:
-            taxon_id:
-              already_linked: "Ya está vinculada a este producto"
-        spree/credit_card:
-          attributes:
-            base:
-              card_expired: "La tarjeta ha expirado"
-              expiry_invalid: "La caducidad de la tarjeta no es válida"
-        spree/inventory_unit:
-          attributes:
-            state:
-              cannot_destroy: "No se puede anular unidad de inventario en %{state}"
-            base:
-              cannot_destroy_shipment_state: "No se puede anular unidad de inventario en %{state} por el de envío"
-        spree/line_item:
-          attributes:
-            price:
-              not_a_number: "no es válido"
-        spree/price:
-          attributes:
-            currency:
-              invalid_code: "Código de divisa no válido"
-        spree/promotion:
-          attributes:
-            apply_automatically:
-              disallowed_with_code: Rechazado para promociones con un código
-              disallowed_with_path: Rechazado para promociones con una ruta
-        spree/refund:
-          attributes:
-            amount:
-              greater_than_allowed: es mayor que la cantidad permitida.
-        spree/reimbursement:
-          attributes:
-            base:
-              return_items_order_id_does_not_match: Uno o mas de los artículos devueltos no pertenecen al pedido del reembolso.
-        spree/return_item:
-          attributes:
-            reimbursement:
-              cannot_be_associated_unless_accepted: No se puede asociar a un artículo devuelto que no está aceptado.
-            inventory_unit:
-              other_completed_return_item_exists: "%{inventory_unit_id} ya ha sido considerado como devuelto por el artículo %{return_item_id}"
-        spree/shipment:
-          attributes:
-            state:
-              cannot_destroy: "No se puede eliminar un %{state} de envío"
-            base:
-              cannot_remove_items_shipment_state: "No se pueden eliminar artículos de un %{state} de envío"
-        spree/store:
-          attributes:
-            base:
-              cannot_destroy_default_store: No se puede eliminar la Tienda por defecto.
-        spree/user_address:
-          attributes:
-            user_id:
-              default_address_exists: "Ya tiene una dirección predeterminada"
-        spree/wallet_payment_source:
-          attributes:
-            payment_source:
-              has_to_be_payment_source_class: "Tiene que ser un Spree::PaymentSource"
-  time:
-    formats:
-      solidus:
-        long: '%B %d, %Y %-l:%M %p'
-        short: "%b %-d '%y %-l:%M%P"
+      user:
+        one: Usuario
+        other: Usuarios
   spree:
     abbreviation: Abreviatura
     accept: Aceptar
-    acceptance_status: Estado Aceptación
     acceptance_errors: Errores Aceptación
+    acceptance_status: Estado Aceptación
     accepted: Aceptado
     account: Cuenta
     account_updated: Cuenta actualizada
@@ -743,7 +738,6 @@ es:
     activate: Activar
     active: Activo
     add: Añadir
-    added: Añadido
     add_action_of_type: Añadir acción del tipo
     add_country: Añadir País
     add_coupon_code: Añadir Código Cupón
@@ -754,7 +748,6 @@ es:
     add_option_value: Añadir valor de opción
     add_product: Añadir Producto
     add_product_properties: Añadir Propiedades de Producto
-    add_variant_properties: Añadir Propiedades de la Variante
     add_rule_of_type: Añadir regla del tipo
     add_state: Añadir Estado
     add_stock: Añadir Stock
@@ -763,6 +756,8 @@ es:
     add_to_cart: Añadir al Carrito
     add_to_stock_location: Añadir a localización de stock
     add_variant: Añadir Variante
+    add_variant_properties: Añadir Propiedades de la Variante
+    added: Añadido
     adding_match: Añadiendo coincidencia
     additional_item: Artículo adicional
     address1: Dirección
@@ -771,26 +766,23 @@ es:
     adjustment: Ajuste
     adjustment_amount: Cantidad
     adjustment_labels:
-      line_item: '%{promotion} (%{promotion_name})'
-      order: '%{promotion} (%{promotion_name})'
+      line_item: "%{promotion} (%{promotion_name})"
+      order: "%{promotion} (%{promotion_name})"
       tax_rates:
-        sales_tax: '%{name}'
-        vat: '%{name} (Incluido en el precio)'
-        sales_tax_with_rate: '%{name} %{amount}'
-        vat_with_rate: '%{name} %{amount} (Incluido en el precio)'
+        sales_tax: "%{name}"
         sales_tax_refund: 'Reintegro: %{name}'
-        vat_refund: 'Reintegro: %{name} (Incluido en el precio)'
         sales_tax_refund_with_rate: 'Reintegro: %{name} %{amount}'
+        sales_tax_with_rate: "%{name} %{amount}"
+        vat: "%{name} (Incluido en el precio)"
+        vat_refund: 'Reintegro: %{name} (Incluido en el precio)'
         vat_refund_with_rate: 'Reintegro: %{name} %{amount} (Incluido en el Precio)'
+        vat_with_rate: "%{name} %{amount} (Incluido en el precio)"
     adjustment_reasons: Razones de Ajuste
-    adjustment_successfully_closed: ¡El ajuste ha sido cerrado satisfactoriamente!
-    adjustment_successfully_opened: ¡El ajuste ha sido abierto satisfactoriamente!
+    adjustment_successfully_closed: "¡El ajuste ha sido cerrado satisfactoriamente!"
+    adjustment_successfully_opened: "¡El ajuste ha sido abierto satisfactoriamente!"
     adjustment_total: Ajuste Total
     adjustments: Ajustes
     admin:
-      stores:
-        form:
-          no_cart_tax_country: "No hay impuestos en carritos sin dirección"
       images:
         index:
           choose_files: Selecciona los archivos para subir
@@ -800,73 +792,76 @@ es:
       payments:
         source_forms:
           storecredit:
-            not_supported: "Actualmente no está soportado la creación de pagos de crédito de tienda a través de la administración."
+            not_supported: Actualmente no está soportado la creación de pagos de crédito de tienda a través de la administración.
       prices:
-        any_country: "Cualquier país"
+        any_country: Cualquier país
+        edit:
+          edit_price: Editar precio
         index:
           amount_greater_than: Cantidad mayor que
           amount_less_than: Cantidad inferior a
           new_price: Nuevo precio
-        edit:
-          edit_price: Editar precio
         new:
           new_price: Nuevo precio
       promotions:
-        form:
-          starts_at_placeholder: Inmediatamente
-          expires_at_placeholder: Nunca
-          activation: Activación
-          general: General
+        activations_edit:
+          auto: Todos los pedidos intentarán utilizar esta promoción
+          multiple_codes_html: Esta promoción utiliza %{count} códigos de promoción
+          single_code_html: 'Esta promoción utiliza el código de promoción: <code>%{code}</code>'
         activations_new:
           auto: Aplicar a todos los pedidos
           multiple_codes: Multiples códigos de promoción
           path: URL Path
           single_code: Código de promoción único
-        activations_edit:
-          auto: Todos los pedidos intentarán utilizar esta promoción
-          single_code_html: "Esta promoción utiliza el código de promoción: <code>%{code}</code>"
-          multiple_codes_html: "Esta promoción utiliza %{count} códigos de promoción"
+        form:
+          activation: Activación
+          expires_at_placeholder: Nunca
+          general: General
+          starts_at_placeholder: Inmediatamente
       store_credits:
-        add: "Añadir crédito de tienda"
-        amount_authorized: "Cantidad Autorizada"
-        amount_credited: "Cantidad Acreditada"
-        amount_used: "Cantidad Usada"
-        back_to_edit: "Volver a la edición"
-        back_to_user_list: "Volver a la lista de usuarios"
-        back_to_store_credit_list: "Lista de créditos de Tienda"
-        change_amount: "Cambiar cantidad"
-        created_by: "Creado Por"
-        credit_type: "Tipo de Crédito"
-        current_balance: "Saldo actual:"
-        edit: "Edición de crédito de tienda"
-        edit_amount: "Edición del importe de crédito de tienda"
-        history: "Historial de crédito de tienda"
-        invalidate_store_credit: "Ivalidando crédito de tienda"
-        invalidated: "Invalidado"
-        issued_on: "Emitido en"
-        new: "Nuevo crédito de tienda"
-        no_store_credit_selected: "No se ha seleccionado crédito de tienda"
-        payment_originator: "Pago - Pedido #%{order_number}"
-        reason_for_updating: "Motivo de actualización"
-        refund_originator: "Devolución - Pedido #%{order_number}"
-        resource_name: "créditos de tienda"
-        user_originator: "Usuario - %{email}"
-        unable_to_create: "No se puede crear crédito de tienda"
-        unable_to_update: "No se puede actualizar el crédito de tienda"
-        unable_to_delete: "No se puede eliminar el crédito de tienda"
-        unable_to_invalidate: "No se puede invalidar el crédito de tienda"
-        select_reason: "Seleccione una razón para este crédito de tienda"
-        select_amount_update_reason: "Seleccione una razón para actualizar la cantidad"
-        total_unused: "Total sin usar"
-        type_html_header: "Tipo de Crédito"
-        view: "Ver crédito de tienda"
+        add: Añadir crédito de tienda
+        amount_authorized: Cantidad Autorizada
+        amount_credited: Cantidad Acreditada
+        amount_used: Cantidad Usada
+        back_to_edit: Volver a la edición
+        back_to_store_credit_list: Lista de créditos de Tienda
+        back_to_user_list: Volver a la lista de usuarios
+        change_amount: Cambiar cantidad
+        created_by: Creado Por
+        credit_type: Tipo de Crédito
+        current_balance: 'Saldo actual:'
+        edit: Edición de crédito de tienda
+        edit_amount: Edición del importe de crédito de tienda
         errors:
-          cannot_change_used_store_credit: "El crédito de la tienda que se ha reclamado no se puede cambiar"
-          cannot_be_modified: "No se puede modificar"
-          amount_used_cannot_be_greater: "No puede ser mayor que la cantidad acreditada"
           amount_authorized_exceeds_total_credit: " excede el crédito disponible"
-          amount_used_not_zero: "Es mayor que cero. No se puede eliminar el crédito de tienda"
-          update_reason_required: "Se debe seleccionar una razón para el cambio"
+          amount_used_cannot_be_greater: No puede ser mayor que la cantidad acreditada
+          amount_used_not_zero: Es mayor que cero. No se puede eliminar el crédito de tienda
+          cannot_be_modified: No se puede modificar
+          cannot_change_used_store_credit: El crédito de la tienda que se ha reclamado no se puede cambiar
+          update_reason_required: Se debe seleccionar una razón para el cambio
+        history: Historial de crédito de tienda
+        invalidate_store_credit: Ivalidando crédito de tienda
+        invalidated: Invalidado
+        issued_on: Emitido en
+        new: Nuevo crédito de tienda
+        no_store_credit_selected: No se ha seleccionado crédito de tienda
+        payment_originator: 'Pago - Pedido #%{order_number}'
+        reason_for_updating: Motivo de actualización
+        refund_originator: 'Devolución - Pedido #%{order_number}'
+        resource_name: créditos de tienda
+        select_amount_update_reason: Seleccione una razón para actualizar la cantidad
+        select_reason: Seleccione una razón para este crédito de tienda
+        total_unused: Total sin usar
+        type_html_header: Tipo de Crédito
+        unable_to_create: No se puede crear crédito de tienda
+        unable_to_delete: No se puede eliminar el crédito de tienda
+        unable_to_invalidate: No se puede invalidar el crédito de tienda
+        unable_to_update: No se puede actualizar el crédito de tienda
+        user_originator: Usuario - %{email}
+        view: Ver crédito de tienda
+      stores:
+        form:
+          no_cart_tax_country: No hay impuestos en carritos sin dirección
       tab:
         areas: Ubicaciones
         checkout: Reembolsos y Devoluciones
@@ -877,8 +872,8 @@ es:
         overview: Resumen
         payments: Pagos
         products: Productos
-        promotions: Promociones
         promotion_categories: Categorías de la Promoción
+        promotions: Promociones
         properties: Tipos de Propiedad
         reports: Informes
         rma: RMA
@@ -900,7 +895,7 @@ es:
         items: Artículos
         items_purchased: Artículos Comprados
         order_history: Historial de Pedidos
-        order_num: "Pedido #"
+        order_num: 'Pedido #'
         orders: Pedidos
         store_credit: Crédito de Tienda
         user_information: Información del Usuario
@@ -908,23 +903,23 @@ es:
         user_page_actions:
           create_order: Crear pedido para este usuario
       variants:
-        table_filter:
-          show_deleted: Mostrar variantes eliminadas
-        new:
-          new_variant: Nueva variante
         edit:
           edit_variant: Editar Variante
         form:
           dimensions: Dimensiones
-          use_product_tax_category: Usar Categoría de Impuestos del Producto
           pricing: Precio
           pricing_hint: Estos valores se informan en la página de detalle del producto y se pueden sobreescribir más abajo
+          use_product_tax_category: Usar Categoría de Impuestos del Producto
+        new:
+          new_variant: Nueva variante
+        table_filter:
+          show_deleted: Mostrar variantes eliminadas
     administration: Administración
     agree_to_privacy_policy: Acepto la Política de Privacidad
     agree_to_terms_of_service: Acepto los Términos y Condiciones de Uso del Servicio
     all: Todo
-    all_adjustments_finalized: ¡Todos los ajustes finalizaron con éxito!
-    all_adjustments_unfinalized: ¡No Todos los ajustes han finalizados!
+    all_adjustments_finalized: "¡Todos los ajustes finalizaron con éxito!"
+    all_adjustments_unfinalized: "¡No Todos los ajustes han finalizados!"
     all_departments: Todos los departamentos
     all_items_have_been_returned: Todos los artículos han sido devueltos
     already_signed_up_for_analytics: Ya te has registrado en Spree Analytics
@@ -936,16 +931,16 @@ es:
     analytics_desc_list_1: Obtén la información de ventas en directo tal y como sucede.
     analytics_desc_list_2: Se necesita solamente una cuenta libre de Spree para activarlo.
     analytics_desc_list_3: Absolutamente ningún código para instalar.
-    analytics_desc_list_4: ¡Es completamente gratuito!
+    analytics_desc_list_4: "¡Es completamente gratuito!"
     analytics_trackers: Analytics Trackers
     and: y
     apply_code: Aplicar el código
     approve: aprobar
-    approver: Aprobador
     approved_at: Aprobado en
-    are_you_sure: ¿Estás seguro?
-    are_you_sure_delete: ¿Estás seguro de que quieres borrar este registro?
-    are_you_sure_ship_stock_transfer: ¿Está seguro de que quieres enviar esta transferencia de stock?
+    approver: Aprobador
+    are_you_sure: "¿Estás seguro?"
+    are_you_sure_delete: "¿Estás seguro de que quieres borrar este registro?"
+    are_you_sure_ship_stock_transfer: "¿Está seguro de que quieres enviar esta transferencia de stock?"
     authorization_failure: Fallo en la autorización
     authorized: Autorizada
     auto_capture: Auto Captura
@@ -955,9 +950,8 @@ es:
     avs_response: Respuesta AVS
     back: Atrás
     back_end: Backend
-    backordered: Pedido pendiente stock
-    back_to_adjustments_list: Volver a Lista de ajustes
     back_to_adjustment_reason_list: Volver a Lista de razones de ajuste
+    back_to_adjustments_list: Volver a Lista de ajustes
     back_to_countries_list: Volver a Lista de Países
     back_to_customer_return: Volver a Devolución cliente
     back_to_customer_return_list: Volver a Lista Devoluciones cliente
@@ -968,12 +962,12 @@ es:
     back_to_payment_methods_list: Volver a Lista de Métodos de Pago
     back_to_payments_list: Volver a Lista de Pagos
     back_to_products_list: Volver a Lista de Productos
-    back_to_promotions_list: Volver a Lista de Promociones
     back_to_promotion_categories_list: Volver a Lista de Categorías de Promociones
+    back_to_promotions_list: Volver a Lista de Promociones
     back_to_properties_list: Volver a Lista de Tipos de Propiedades
-    back_to_reports_list: Volver a Lista de Informes
     back_to_refund_reason_list: Volver a Lista de Motivos de Devolución
     back_to_reimbursement_type_list: Volver a Lista de Tipos de Reembolso
+    back_to_reports_list: Volver a Lista de Informes
     back_to_return_authorizations_list: Volver a Lista RMA
     back_to_rma_reason_list: Volver a Lista de razones RMA
     back_to_shipping_categories: Volver a Categorías de Envío
@@ -993,6 +987,7 @@ es:
     backorderable: Disponible sin stock
     backorderable_default: Permitir pedidos sin stock por defecto
     backorderable_header: Disponible sin Stock
+    backordered: Pedido pendiente stock
     backorders_allowed: Pedidos sin stock permitidos
     balance_due: Balance adeudado
     base_amount: Cantidad Base
@@ -1005,19 +1000,21 @@ es:
     calculator: Calculador
     calculator_settings_warning: Si se cambia el tipo de calculador, debe guardar primero antes de editar los ajustes de la calculador
     cancel: cancelar
-    cancel_inventory: 'Cancelar Artículos'
+    cancel_inventory: Cancelar Artículos
     canceled: cancelado
     canceled_at: Cancelado en
     canceler: Responsable cancelación
     cancellation: Cancelación
-    cannot_create_payment_without_payment_methods_html: No se puede crear un pago para un pedido sin definir antes algún método de pago. %{link}
     cannot_create_payment_link: Por favor, definir algún método de pago previamente.
+    cannot_create_payment_without_payment_methods_html: No se puede crear un pago para un pedido sin definir antes algún método de pago. %{link}
     cannot_create_returns: No se puede crear una devolución de un pedido sin artículos enviados.
+    cannot_perform_operation: No se pudo realizar la operación solicitada
     cannot_rebuild_shipments_order_completed: No se puede rehacer el envío de un pedido completado.
     cannot_rebuild_shipments_shipments_not_pending: No se puede rehacer el envío de un pedido sin envíos pendientes.
-    cannot_perform_operation: No se pudo realizar la operación solicitada
     cannot_set_shipping_method_without_address: No se puede establecer un método de envío hasta que se faciliten detalles del cliente.
-    cannot_update_email: No tiene acceso para actualizar la dirección de correo de este usuario. <br />Por favor, contactar con un administrador si necesita llevar a cabo esta acción.
+    cannot_update_email: >-
+      No tiene acceso para actualizar la dirección de correo de este usuario. <br />Por favor, contactar con un administrador si necesita llevar
+      a cabo esta acción.
     capture: Captura
     capture_events: Captura eventos
     card_code: Código de Tarjeta
@@ -1026,10 +1023,10 @@ es:
     card_type_is: El tipo de Tarjeta es
     cart: Carrito
     cart_subtotal:
-      one: 'Subtotal (1 artículo)'
-      other: 'Subtotal (%{count} artículos)'
+      one: Subtotal (1 artículo)
+      other: Subtotal (%{count} artículos)
     carton_external_number: Número externo embalaje
-    carton_orders: 'Otros pedidos con embalaje'
+    carton_orders: Otros pedidos con embalaje
     categories: Categorías
     category: Categoría
     charged: Cargado
@@ -1037,7 +1034,7 @@ es:
     check_stock_on_transfer: Comprobar stock en la transferencia
     checkout: Realizar pedido
     choose_a_customer: Elegir un cliente
-    choose_a_taxon_to_sort_products_for: "Elegir un taxón para ordenar los productos por"
+    choose_a_taxon_to_sort_products_for: Elegir un taxón para ordenar los productos por
     choose_currency: Elegir Divisa
     choose_dashboard_locale: Elegir Idioma del Panel
     choose_location: Elegir localización
@@ -1047,9 +1044,12 @@ es:
     clear_cache_warning: El borrado de la cache puede reducir temporalmente las prestaciones de la tienda.
     clone: Clonar
     close: Cerrar
-    closed: Cerrado
     close_stock_transfer:
-      confirm: "¿Está seguro de cerrar esta transferencia de stock?\n\nEl Stock se cambiará con los artículos recibidos y ya no se podrá editar la transferencia de stock."
+      confirm: |-
+        ¿Está seguro de cerrar esta transferencia de stock?
+
+        El Stock se cambiará con los artículos recibidos y ya no se podrá editar la transferencia de stock.
+    closed: Cerrado
     code: Código
     company: Compañía
     complete: completo
@@ -1087,29 +1087,28 @@ es:
     coupon_code_not_eligible: Este código de cupón no se puede utilizar en este pedido
     coupon_code_not_found: El código del cupón que has introducido no existe. Por favor, inténtalo de nuevo.
     coupon_code_unknown_error: Este código de cupón no se puede aplicar ahora al carrito.
-    customer: Cliente
-    customer_return: Devolución de cliente
-    customer_returns: Devoluciones de cliente
     create: Crear
     create_a_new_account: Crear una nueva cuenta
-    create_reimbursement: Crear un reembolso
     create_one: Crear uno
+    create_reimbursement: Crear un reembolso
     created_at: Creado en
     created_by: Creado por
     created_successfully: Creado satisfactoriamente
     credit: Crédito
-    credits: Créditos
     credit_allowed: Crédito permitido
     credit_card: Tarjeta de Crédito
     credit_cards: Tarjetas de Crédito
     credit_owed: Crédito vigente
+    credits: Créditos
     currency: Divisa
     currency_settings: Ajustes moneda
     current: actual
-    current_promotion_usage: ! 'Uso actual: %{count}'
+    current_promotion_usage: 'Uso actual: %{count}'
     customer: Cliente
     customer_details: Detalles Cliente
     customer_details_updated: Detalles Cliente actualizados
+    customer_return: Devolución de cliente
+    customer_returns: Devoluciones de cliente
     customer_search: Búsqueda Cliente
     cut: Cortar
     cvv_response: Respuesta CVV
@@ -1135,8 +1134,8 @@ es:
     default_tax: Impuesto por Defecto
     default_tax_zone: Zona de Impuestos por defecto
     delete: Borrar
-    deleted_variants_present: Algunas líneas de este pedido tienen productos que ya no están disponibles.
     deleted_successfully: Borrado satisfactoriamente
+    deleted_variants_present: Algunas líneas de este pedido tienen productos que ya no están disponibles.
     delivery: Entrega
     depth: Fondo
     description: Descripción
@@ -1145,19 +1144,19 @@ es:
     destroy: Eliminar
     details: Detalles
     discount_amount: Cantidad Descuento
-    dismiss_banner: ¡No. Gracias! No me interesa, no mostrar este mensaje otra vez
+    dismiss_banner: "¡No. Gracias! No me interesa, no mostrar este mensaje otra vez"
     display: Mostrar
     download_promotion_code_list: Descargar Lista de códigos
     edit: Editar
-    editing_country: Editando País
+    edit_refund_reason: Editar Razón Reintegro
     editing_adjustment_reason: Editando Razón de Ajuste
+    editing_country: Editando País
     editing_option_type: Editando Tipo de Opción
     editing_payment_method: Editando Método de Pago
     editing_product: Editando Producto
     editing_promotion: Editando Promoción
     editing_promotion_category: Editando Categoría Promoción
     editing_property: Editando Tipo Propiedad
-    edit_refund_reason: Editar Razón Reintegro
     editing_refund: Editando Reintegro
     editing_refund_reason: Editando Razón Reintegro
     editing_reimbursement: Editando Reembolso
@@ -1197,17 +1196,21 @@ es:
     error: error
     errors:
       messages:
-        cannot_modify_transfer_item_closed_stock_transfer: Los artículos en Transferencia son parte de una Transferencia de stock cerrada que no se puede modificar.
         cannot_delete_finalized_stock_transfer: La Transferencia de stock finalizada no se puede eliminar.
-        cannot_delete_transfer_item_with_finalized_stock_transfer: Los artículos de una Transferencia que forman parte de una transferencia de stock finalizada, no se pueden eliminar.
-        cannot_update_expected_transfer_item_with_finalized_stock_transfer: La cantidad no se puede actualizar utilizando artículos que forman parte de una transferencia de stock finalizada.
+        cannot_delete_transfer_item_with_finalized_stock_transfer: Los artículos de una Transferencia que forman parte de una transferencia de
+          stock finalizada, no se pueden eliminar.
+        cannot_modify_transfer_item_closed_stock_transfer: Los artículos en Transferencia son parte de una Transferencia de stock cerrada que
+          no se puede modificar.
+        cannot_update_expected_transfer_item_with_finalized_stock_transfer: La cantidad no se puede actualizar utilizando artículos que forman
+          parte de una transferencia de stock finalizada.
         could_not_create_taxon: No se puede crear el taxón
-        transfer_item_insufficient_stock: La variante del artículo de transferencia no posee suficiente stock en la localización de stock en origen.
         no_payment_methods_available: No hay métodos de pago configurados para este entorno
-        no_shipping_methods_available: No hay métodos de envío disponible para la localización seleccionada, por favor, cambie la dirección e inténtelo otra vez.
+        no_shipping_methods_available: No hay métodos de envío disponible para la localización seleccionada, por favor, cambie la dirección e
+          inténtelo otra vez.
+        transfer_item_insufficient_stock: La variante del artículo de transferencia no posee suficiente stock en la localización de stock en origen.
     errors_prohibited_this_record_from_being_saved:
       one: 1 error impidió que se guardaran los datos
-      other: ! '%{count} errores impidieron que se guardaran los datos'
+      other: "%{count} errores impidieron que se guardaran los datos"
     event: Evento
     events:
       spree:
@@ -1223,35 +1226,16 @@ es:
         user:
           signup: Dar de alta Usuario
     exceptions:
-      count_on_hand_setter: No se puede establecer el inventario manualmente, ya que se establece automáticamente por "callback". Por favor, usar en cambio `update_column(:count_on_hand, value)`
+      count_on_hand_setter: >-
+        No se puede establecer el inventario manualmente, ya que se establece automáticamente por "callback". Por favor, usar en cambio `update_column(:count_on_hand,
+        value)`
     exchange_for: Intercambiar por
     excl: excl.
+    existing_shipments: Envíos existentes
     expected: Esperado
     expected_items: Artículos esperados
     expiration: Caducidad
     extension: Extensión
-    existing_shipments: Envíos existentes
-    hints:
-      spree/price:
-        country: "Esto determina en qué país es válido el precio.<br/>Por defecto: Cualquier País"
-        master_variant: "Al cambiar el precio de la variante master no cambiará los precios del resto de las variantes de este producto, pero se utilizará como referencia en las variantes de nueva creación"
-        options: "Estas opciones se utilizan para crear variantes en la tabla de variantes y se pueden cambiar en la pestaña de variantes"
-      spree/product:
-        promotionable: "Esto determina si las promociones pueden aplicarse a este producto.<br/>Predeterminado: Revisado"
-        shipping_category: "Esto determina qué tipo de envío requiere este producto.<br/> Predeterminado: Default"
-        tax_category: "Esto determina qué clase de impuestos se aplica a este producto.<br/> Predeterminado: Ninguno"
-      spree/promotion:
-        starts_at: "Determina cuando la promoción se puede aplicar a pedidos. <br/> Si no se especifica ningún valor, la promoción estará inmediatamente disponible."
-        expires_at: "Esto determina cuándo expira la promoción. <br/> Si no se especifica ningún valor, la promoción nunca expira."
-      spree/store:
-        cart_tax_country_iso: "Esto determina qué país se utiliza para los impuestos sobre los carritos (pedidos que aún no tienen una dirección). <br/> Predeterminado: Ninguno."
-      spree/variant:
-        tax_category: "Esto determina qué clase de impuestos se aplica a esta variante.<br/> Predeterminado: Usar categoría de impuestos del producto asociado con esta variante"
-        deleted: "Variante eliminada"
-        deleted_explanation: "Esta variante se eliminó en% {date}."
-        deleted_explanation_with_replacement: "Esta variante se eliminó en% {date}. Desde entonces ha sido sustituida por otra con el mismo SKU."
-      spree/tax_rate:
-        validity_period: "Esto determina el período de validez dentro del cual la tasa de impuestos es válida y se aplicará a los artículos elegibles. <br /> Si no se especifica ningún valor de fecha de inicio, la tasa de impuestos estará inmediatamente disponible. <br /> Si no hay valor de fecha de vencimiento Se especifica, la tasa impositiva nunca expirará "
     failed_payment_attempts: Falló la tentativa de pago
     failure: Fallo
     filename: Nombre de fichero
@@ -1260,18 +1244,21 @@ es:
     finalize: Finalizar
     finalize_all_adjustments: Finalizar todos los Ajustes
     finalize_stock_transfer:
-      confirm: "¿Está seguro de finalizar esta transferencia de stock?\n\nNo podrá añadir o editar artículos de la transferencia"
-    find_a_taxon: Encontrar un taxón
+      confirm: |-
+        ¿Está seguro de finalizar esta transferencia de stock?
+
+        No podrá añadir o editar artículos de la transferencia
     finalized: Finalizado
     finalized_at: Finalizado en
     finalized_by: Finalizado por
+    find_a_taxon: Encontrar un taxón
     first_item: Primer artículo
     first_name: Nombre
     first_name_begins_with: Nombre empieza con
     flat_percent: Porcentaje plano
     flat_rate_per_order: Tasa plana
     flexible_rate: Tasa flexible
-    forgot_password: ¿Olvidó la contraseña?
+    forgot_password: "¿Olvidó la contraseña?"
     free_shipping: Envío gratuito
     free_shipping_amount: "-"
     from: De
@@ -1294,14 +1281,45 @@ es:
         price_diff_subtract_html: "(Restar: %{amount_html})"
     hidden: Oculto
     hide_out_of_stock: Ocultar del stock
+    hints:
+      spree/price:
+        country: 'Esto determina en qué país es válido el precio.<br/>Por defecto: Cualquier País'
+        master_variant: >-
+          Al cambiar el precio de la variante master no cambiará los precios del resto de las variantes de este producto, pero se utilizará como
+          referencia en las variantes de nueva creación
+        options: Estas opciones se utilizan para crear variantes en la tabla de variantes y se pueden cambiar en la pestaña de variantes
+      spree/product:
+        promotionable: 'Esto determina si las promociones pueden aplicarse a este producto.<br/>Predeterminado: Revisado'
+        shipping_category: 'Esto determina qué tipo de envío requiere este producto.<br/> Predeterminado: Default'
+        tax_category: 'Esto determina qué clase de impuestos se aplica a este producto.<br/> Predeterminado: Ninguno'
+      spree/promotion:
+        expires_at: Esto determina cuándo expira la promoción. <br/> Si no se especifica ningún valor, la promoción nunca expira.
+        starts_at: >-
+          Determina cuando la promoción se puede aplicar a pedidos. <br/> Si no se especifica ningún valor, la promoción estará inmediatamente
+          disponible.
+      spree/store:
+        cart_tax_country_iso: >-
+          Esto determina qué país se utiliza para los impuestos sobre los carritos (pedidos que aún no tienen una dirección). <br/> Predeterminado:
+          Ninguno.
+      spree/tax_rate:
+        validity_period: "Esto determina el período de validez dentro del cual la tasa de impuestos es válida y se aplicará a los artículos elegibles.
+          <br /> Si no se especifica ningún valor de fecha de inicio, la tasa de impuestos estará inmediatamente disponible. <br /> Si no hay
+          valor de fecha de vencimiento Se especifica, la tasa impositiva nunca expirará "
+      spree/variant:
+        deleted: Variante eliminada
+        deleted_explanation: Esta variante se eliminó en% {date}.
+        deleted_explanation_with_replacement: Esta variante se eliminó en% {date}. Desde entonces ha sido sustituida por otra con el mismo SKU.
+        tax_category: >-
+          Esto determina qué clase de impuestos se aplica a esta variante.<br/> Predeterminado: Usar categoría de impuestos del producto asociado
+          con esta variante
     home: Inicio
     i18n:
       available_locales: Idiomas disponibles
       fields: Campos
       language: Lengua
       localization_settings: Ajustes Localización
-      only_incomplete: Sólo incompletos
       only_complete: Sólo completos
+      only_incomplete: Sólo incompletos
       select_locale: Seleccionar idioma
       show_only: Mostrar sólo
       supported_locales: Idiomas soportados
@@ -1312,17 +1330,17 @@ es:
     identifier: Identificador
     image: Imagen
     images: Imágenes
-    implement_eligible_for_return: "Debe implementar #eligible_for_return? por su EligibilityValidator."
-    implement_requires_manual_intervention: "Debe implementar #requires_manual_intervention? por su EligibilityValidator."
+    implement_eligible_for_return: 'Debe implementar #eligible_for_return? por su EligibilityValidator.'
+    implement_requires_manual_intervention: 'Debe implementar #requires_manual_intervention? por su EligibilityValidator.'
     inactive: Inactivo
     incl: incl.
     included_in_price: Incluido en el Precio
     included_price_validation: no se puede seleccionar a menos de que se haya establecido una Zona de Impuestos por defecto
     incomplete: Incompleto
-    info_product_has_multiple_skus: "Este producto tiene %{count} variantes:"
     info_number_of_skus_not_shown:
-      one: "y otro"
-      other: "y %{count} más"
+      one: y otro
+      other: y %{count} más
+    info_product_has_multiple_skus: 'Este producto tiene %{count} variantes:'
     instructions_to_reset_password: Introduzca su correo electrónico en el formulario de abajo
     insufficient_stock: Insuficiente stock disponible, sólo quedan %{on_hand} disponibles
     insufficient_stock_for_order: Insuficiente stock para el pedido
@@ -1359,8 +1377,8 @@ es:
         gte: Mayor o igual que
     items_cannot_be_shipped: No podemos calcular los costes de envío para los artículos seleccionados.
     items_in_rmas: Artículos en RMA's (Return Merchandise Authorizations)
-    items_to_be_reimbursed: Artículos a reembolsar
     items_reimbursed: Artículos reembolsados
+    items_to_be_reimbursed: Artículos a reembolsar
     jirafe: Jirafe
     landing_page_rule:
       path: Ruta
@@ -1368,7 +1386,7 @@ es:
     last_name_begins_with: Apellido empieza con
     learn_more: saber más
     lifetime_stats: Histórico de estadísticas
-    line_item_adjustments: "Line item adjustments"
+    line_item_adjustments: Line item adjustments
     list: Lista
     listing_countries: Países
     listing_orders: Pedidos
@@ -1380,8 +1398,7 @@ es:
     locale_changed: Cambiada configuración regional
     location: Localización
     lock: Bloquear
-    log_entries: "Log Entries"
-    logs: "Logs"
+    log_entries: Log Entries
     logged_in_as: Conectado como
     logged_in_succesfully: Conectado satisfactoriamente
     logged_out: Ha desconectado su sesión.
@@ -1390,13 +1407,14 @@ es:
     login_failed: No se ha podido iniciar la sesión, error de autenticación.
     login_name: Acceder
     logout: Desconectar
+    logs: Logs
     look_for_similar_items: Mirar artículos similares
     make_refund: Efectuar Reintegro
     make_sure_the_above_reimbursement_amount_is_correct: Asegurarse de que la cantidad del reembolso arriba indicada es correcta
     manage_promotion_categories: Gestionar Categorías de Promoción
     manage_stock: Stock de Tienda
-    manual_intervention_required: Se requiere intervención manual
     manage_variants: Gestionar Variantes
+    manual_intervention_required: Se requiere intervención manual
     master_price: Precio principal
     master_variant: Variante principal
     match_choices:
@@ -1422,9 +1440,9 @@ es:
     new: Nuevo
     new_adjustment: Nuevo Ajuste
     new_adjustment_reason: Razón Nuevo Ajuste
+    new_country: Nuevo País
     new_customer: Nuevo Cliente
     new_customer_return: Nueva Devolución Cliente
-    new_country: Nuevo País
     new_image: Nueva Imagen
     new_option_type: Nuevo Tipo de Opción
     new_order: Nuevo Pedido
@@ -1438,17 +1456,17 @@ es:
     new_property: Nuevo Tipo de Propiedad
     new_refund: Nuevo Reintegro
     new_refund_reason: Nueva Razón Reintegro
-    new_rma_reason: Nueva Razón RMA
     new_return_authorization: Nuevo RMA
+    new_rma_reason: Nueva Razón RMA
+    new_shipment_at_location: Nuevo envío a la localización
     new_shipping_category: Nueva Categoría Envío
     new_shipping_method: Nuevo Método de Envío
-    new_shipment_at_location: Nuevo envío a la localización
     new_state: Nueva Provincia/Estado
     new_stock_location: Nueva Localización de Stock
     new_stock_movement: Nuevo Movimiento de Stock
     new_stock_transfer: Nueva Transferencia de Stock
-    new_store_credit: Nuevo Crédito de Tienda
     new_store: Nueva tienda
+    new_store_credit: Nuevo Crédito de Tienda
     new_tax_category: Nueva Categoría de Impuestos
     new_tax_rate: Nuevo tasa de Impuestos
     new_taxon: Nuevo Taxón
@@ -1461,35 +1479,35 @@ es:
     no_actions_added: No se han añadido acciones
     no_images_found: No se han encontrado imágenes
     no_inventory_selected: No se ha seleccionado inventario
+    no_option_values_on_product_html: Este producto no tiene asociados valores de opción. Añada algunos a través de Option Types en el %{link}.
     no_orders_found: No hay pedidos
-    no_option_values_on_product_html: "Este producto no tiene asociados valores de opción. Añada algunos a través de Option Types en el %{link}."
-    no_payment_methods_found: No se han encontrado métodos de pago
     no_payment_found: No se han encontrado pagos
+    no_payment_methods_found: No se han encontrado métodos de pago
     no_pending_payments: No hay pagos pendientes
     no_products_found: No se han encontrado productos
     no_promotions_found: No se han encontrado promociones
+    no_resource: No se ha encontrado %{resource}.
+    no_resource_found: No se ha encontrado %{resource}
+    no_resource_found_html: "¡No se ha encontrado %{resource}, %{add_one_link}!"
+    no_resource_found_link: Añadir uno
     no_results: No hay resultados
     no_rules_added: No se han añadido reglas
-    no_resource: 'No se ha encontrado %{resource}.'
-    no_resource_found_html: '¡No se ha encontrado %{resource}, %{add_one_link}!'
-    no_resource_found_link: Añadir uno
-    no_resource_found: ! 'No se ha encontrado %{resource}'
-    no_shipping_methods_found: No se han encontrado métodos de envío
     no_shipping_method_selected: No se han seleccionado métodos de envío.
-    no_trackers_found: No se han encontrado rastreadores
+    no_shipping_methods_found: No se han encontrado métodos de envío
     no_stock_locations_found: No se han encontrado localizaciones de stock
+    no_trackers_found: No se han encontrado rastreadores
     no_tracking_present: No se han suministrado detalles de seguimiento.
     no_variants_found: No se han encontrado variantes.
     no_variants_found_try_again: No se han encontrado variantes. Intente cambiando los valores de búsqueda.
     none: Ninguno
     none_selected: Ninguno Seleccionado
     normal_amount: Cantidad Normal
-    not: no
+    not: false
     not_available: N/D
     not_enough_stock: No hay suficiente Inventario en la localización de origen para completar esta transferencia.
-    not_found: ! '%{resource} no ha sido encontrado'
+    not_found: "%{resource} no ha sido encontrado"
     note: Nota
-    note_already_received_a_refund: "Nota: Este pedido ya ha tenido un reintegro.  Asegúrese que la cantidad especificada arriba es correcta."
+    note_already_received_a_refund: 'Nota: Este pedido ya ha tenido un reintegro.  Asegúrese que la cantidad especificada arriba es correcta.'
     notice_messages:
       product_cloned: El producto ha sido clonado
       product_deleted: El producto ha sido borrado
@@ -1499,7 +1517,7 @@ es:
       variant_not_deleted: La Variante no pudo ser borrada
     num_orders: "# Pedidos"
     number: Número
-    number_of_codes: ! '%{count} códigos'
+    number_of_codes: "%{count} códigos"
     on_hand: Disponible
     open: Abrir
     option_type: Tipo de Opción
@@ -1510,7 +1528,7 @@ es:
     optional: Opcional
     options: Opciones
     or: o
-    or_over_price: ! '%{price} o mas'
+    or_over_price: "%{price} o mas"
     order: Pedido
     order_adjustments: Ajustes pedido
     order_already_completed: Pedido ya está completado
@@ -1526,16 +1544,16 @@ es:
         instructions: Su pedido ha sido CANCELADO. Por favor, guarde esta información de cancelación para sus control.
         order_summary_canceled: Resumen de pedido [CANCELADO]
         subject: Cancelación de Pedido
-        subtotal: ! 'Subtotal:'
-        total: ! 'Total Pedido:'
+        subtotal: 'Subtotal:'
+        total: 'Total Pedido:'
       confirm_email:
         dear_customer: Estimado Cliente,
         instructions: Por favor, revise y guarde esta información para su control.
         order_summary: Resumen Pedido
         subject: Confirmación Pedido
-        subtotal: ! 'Subtotal:'
+        subtotal: 'Subtotal:'
         thanks: Gracias por su compra.
-        total: ! 'Total Pedido:'
+        total: 'Total Pedido:'
       inventory_cancellation:
         dear_customer: Estimado Cliente,
         instructions: Algunos de los artículos de su pedido han sido CANCELADOS. Por favor, guarde esta información para su control.
@@ -1572,8 +1590,8 @@ es:
     package_from: paquete de
     pagination:
       next_page: Próxima página &raquo;
-      previous_page: ! '&laquo; página anterior'
-      truncate: ! '&hellip;'
+      previous_page: "&laquo; página anterior"
+      truncate: "&hellip;"
     password: Contraseña
     paste: Pegar
     path: Ruta
@@ -1581,14 +1599,13 @@ es:
     payment: Pago
     payment_amount: Cantidad a pagar
     payment_could_not_be_created: No se puede crear el pago.
-    payments_failed_count:
-      one: 1 Pago
-      other: '%{count} Pagos'
     payment_identifier: Identificador pago
     payment_information: Información del pago
     payment_method: Método de pago
-    payment_methods: Métodos de pago
     payment_method_not_supported: Este método de pago no está soportado. Por favor, elija otro.
+    payment_method_settings_warning: Si está cambiando el tipo de método de pago, primero debe guardarlo para poder editar la configuración a
+      posteriori
+    payment_methods: Métodos de pago
     payment_processing_failed: El pago no se ha podido procesar, por favor revise los datos de entrada
     payment_processor_choose_banner_text: Si necesita ayuda eligiendo un procesador de pagos, visite
     payment_processor_choose_link: nuestra página de pagos
@@ -1599,34 +1616,37 @@ es:
       completed: Completado
       credit_owed: Crédito cliente
       failed: Fallado
+      invalid: Inválido
       paid: Pagado
       pending: Pendiente
       processing: Procesando
       void: Vacío
-      invalid: Inválido
     payment_updated: Pago actualizado
     payments: Pagos
+    payments_failed_count:
+      one: 1 Pago
+      other: "%{count} Pagos"
+    pending: Pendiente
     percent: Porcentaje
     percent_per_item: Porcentaje por Artículo
     permalink: Permalink
-    pending: Pendiente
     phone: Teléfono
     place_order: Realizar pedido
     please_define_payment_methods: Por favor, definir algún método de pago primero.
     please_enter_reasonable_quantity: Por favor, entre una cantidad razonable.
     populate_get_error: Algo salió mal. Por favor, intente añadir el artículo otra vez.
     powered_by: Powered by
-    pre_tax_refund_amount: Cantidad reintegro antes de Impuestos
     pre_tax_amount: Cantidad antes de Impuestos
+    pre_tax_refund_amount: Cantidad reintegro antes de Impuestos
     pre_tax_total: Total antes de Impuestos
+    preference_source_none: "(custom)"
+    preference_source_using: Usando preferencias estáticas "%{name}"
     preferred_reimbursement_type: Tipo Reembolso preferido
     presentation: Presentación
     previous: Previo
     price: Precio
     price_range: Rango Precio
     price_sack: Saco de Precio
-    preference_source_none: '(custom)'
-    preference_source_using: 'Usando preferencias estáticas "%{name}"'
     process: Procesar
     product: Producto
     product_details: Detalles Producto
@@ -1644,34 +1664,35 @@ es:
         manual: Elegir manualmente
     products: Productos
     promotion: Promoción
-    promotionable: Promocionable
     promotion_action: Acción de Promoción
     promotion_actions: Acciones
     promotion_code_batch_mailer:
-      promotion_code_batch_finished:
-        subject: Promotion code batch finished
-        message: "All %{number_of_codes} codes have been created for promotion: "
       promotion_code_batch_errored:
+        message: 'Promotion code batch errored (%{error}) for promotion: '
         subject: Promotion code batch errored
-        message: "Promotion code batch errored (%{error}) for promotion: "
+      promotion_code_batch_finished:
+        message: 'All %{number_of_codes} codes have been created for promotion: '
+        subject: Promotion code batch finished
     promotion_code_batches:
-      errored: "Errored: %{error}"
-      finished: "All %{number_of_codes} codes have been created."
-      processing: "Processing: %{number_of_codes_processed} / %{number_of_codes}"
+      errored: 'Errored: %{error}'
+      finished: All %{number_of_codes} codes have been created.
+      processing: 'Processing: %{number_of_codes_processed} / %{number_of_codes}'
     promotion_form:
       match_policies:
         all: Sigue todas estas reglas
         any: No sigue ninguna de estas reglas
     promotion_rule: Regla de Promoción
-    promotions: Promociones
-    promotion_successfully_created: ¡La promoción ha sido creada con éxito!
-    promotion_total_changed_before_complete: "Algunas de las promociones de su pedido no son aptas y se han eliminado. Por favor, compruebe de nuevo el importe del pedido y vuelva a intentarlo."
+    promotion_successfully_created: "¡La promoción ha sido creada con éxito!"
+    promotion_total_changed_before_complete: >-
+      Algunas de las promociones de su pedido no son aptas y se han eliminado. Por favor, compruebe de nuevo el importe del pedido y vuelva a
+      intentarlo.
     promotion_uses: Usos de la promoción
+    promotionable: Promocionable
+    promotions: Promociones
     propagate_all_variants: Propagar a todas la variantes
     properties: Tipos de Propiedad
     property: Tipo de Propiedad
     provider: Proveedor
-    payment_method_settings_warning: Si está cambiando el tipo de método de pago, primero debe guardarlo para poder editar la configuración a posteriori
     qty: Cant
     quantity: Cantidad
     quantity_returned: Cantidad devuelta
@@ -1680,8 +1701,8 @@ es:
     ready_to_ship: Listo para enviar
     reason: Razón
     receive: recibir
-    received: Recibido
     receive_stock: Recibir Stock
+    received: Recibido
     received_items: Artículos recibidos
     received_successfully: Recibido satisfactoriamente
     receiving: Recibiendo
@@ -1704,13 +1725,22 @@ es:
     refund_reasons: Razones del reintegro
     refunded_amount: Cantidad reintegrada
     refunds: Reintegros
-    refund_amount_must_be_greater_than_zero: La cantidad a reintegrar debe ser mayor que cero
     register: Registrar
     registration: Registro
     reimburse: Reembolsar
     reimbursed: Reembolsado
     reimbursement: Reembolso
-    reimbursement_perform_failed: "No se puede efectuar el reembolso. Error: %{error}"
+    reimbursement_mailer:
+      reimbursement_email:
+        days_to_send: dispone de %{days} días para devolver los artículos a cambiar.
+        dear_customer: Estimado Cliente,
+        exchange_summary: Resumen del cambio
+        for: por
+        instructions: Su reembolso ha sido procesado.
+        refund_summary: Resumen Reintegro
+        subject: Reimbursement Notificación
+        total_refunded: 'Total reintegrado: %{total}'
+    reimbursement_perform_failed: 'No se puede efectuar el reembolso. Error: %{error}'
     reimbursement_states:
       errored: Erróneo
       pending: Pendiente
@@ -1737,8 +1767,8 @@ es:
     return_authorization_states:
       authorized: Autorizada
       canceled: Cancelada
-    return_authorizations: Autorizaciones de devolución de mercancía
     return_authorization_updated: Autorización de mercancía a devolver actualizada
+    return_authorizations: Autorizaciones de devolución de mercancía
     return_item_inventory_unit_ineligible: La unidad de inventario del artículo devuelto deberá enviarse
     return_item_inventory_unit_reimbursed: Unidad de inventario del artículo devuelto ya se ha reembolsado
     return_item_order_not_completed: Se debe completar el pedido del artículo a devolver
@@ -1746,17 +1776,8 @@ es:
     return_item_time_period_ineligible: Artículo a devolver está fuera de plazo
     return_items: Artículos a devolver
     return_items_cannot_be_associated_with_multiple_orders: Artículos a devolver no pueden ir asociados a varios pedidos.
-    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: Articulos a devolver no pueden entrar en Inventario, porque están esperando un cambio.
-    reimbursement_mailer:
-      reimbursement_email:
-        days_to_send: ! 'dispone de %{days} días para devolver los artículos a cambiar.'
-        dear_customer: Estimado Cliente,
-        exchange_summary: Resumen del cambio
-        for: por
-        instructions: Su reembolso ha sido procesado.
-        refund_summary: Resumen Reintegro
-        subject: Reimbursement Notificación
-        total_refunded: ! 'Total reintegrado: %{total}'
+    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: Articulos a devolver no pueden entrar en Inventario,
+      porque están esperando un cambio.
     return_number: Número de devolución
     return_quantity: Cantidad devuelta
     return_reasons: Motivos devolución
@@ -1776,7 +1797,7 @@ es:
     save_and_continue: Guardar y continuar
     save_my_address: Guardar mi dirección
     say_no: 'No'
-    say_yes: 'Si'
+    say_yes: Si
     scope: Ambito
     search: Buscar
     search_results: Resultados para '%{keywords}'
@@ -1787,7 +1808,7 @@ es:
     select_a_reason: Seleccionar una razón
     select_a_stock_location: Seleccionar una localización de stock
     select_stock: Seleccionar stock
-    selected_quantity_not_available: ! 'la selección de %{item} no está disponible.'
+    selected_quantity_not_available: la selección de %{item} no está disponible.
     send_copy_of_all_mails_to: Enviar copia de todos los correos a
     send_mailer: Enviar Correo
     send_mails_as: Enviar Mails como
@@ -1798,12 +1819,15 @@ es:
     ship_address: Dirección de envío
     ship_address_required: Se requiere una dirección de envío válida
     ship_stock_transfer:
-      confirm: "¿Está seguro de marcar esta transferencia de stock para enviar?\n\nNo podrá efectuar cambios a la transferencia de stock"
+      confirm: |-
+        ¿Está seguro de marcar esta transferencia de stock para enviar?
+
+        No podrá efectuar cambios a la transferencia de stock
     ship_total: Total envío
-    shipped_at: Enviado en
     shipment: Envío
-    shipment_adjustments: "Ajustes envío"
-    shipment_details: "De %{stock_location} via %{shipping_method}"
+    shipment_adjustments: Ajustes envío
+    shipment_date: Fecha de envío
+    shipment_details: De %{stock_location} via %{shipping_method}
     shipment_mailer:
       shipped_email:
         dear_customer: Estimado Cliente,\n
@@ -1813,7 +1837,6 @@ es:
         thanks: "¡Gracias por su compra!"
         track_information: 'Información Seguimiento: %{tracking}'
         track_link: 'Link del Tracking: %{url}'
-    shipment_date: Fecha de envío
     shipment_number: Número de envío
     shipment_numbers: Números de envío
     shipment_state: Estado envío
@@ -1824,10 +1847,11 @@ es:
       pending: Pendiente
       ready: Listo
       shipped: Enviado
-    shipment_transfer_success: 'Las variantes se han transferido satisfactoriamente'
-    shipment_transfer_error: 'Ha habido un error transfiriendo variantes'
+    shipment_transfer_error: Ha habido un error transfiriendo variantes
+    shipment_transfer_success: Las variantes se han transferido satisfactoriamente
     shipments: Envíos
     shipped: Enviado
+    shipped_at: Enviado en
     shipping: Enviando
     shipping_address: Dirección de envío
     shipping_categories: Categorías de envío
@@ -1846,8 +1870,8 @@ es:
     shipping_rate_tax:
       label:
         sales_tax: "+ %{amount} %{tax_rate_name}"
-        vat: "incl. %{amount} %{tax_rate_name}"
-        vat_refund: "excl. %{amount} %{tax_rate_name}"
+        vat: incl. %{amount} %{tax_rate_name}
+        vat_refund: excl. %{amount} %{tax_rate_name}
     shipping_total: Total envío
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrito
@@ -1866,15 +1890,17 @@ es:
     special_instructions: Instrucciones especiales
     split: Dividir
     split_failed: No se pudo completar la división
-    spree_gateway_error_flash_for_checkout: Ha habido un problema con su información de pago. Por favor, revise su información e inténtelo de nuevo.
+    spree_gateway_error_flash_for_checkout: Ha habido un problema con su información de pago. Por favor, revise su información e inténtelo de
+      nuevo.
     ssl:
-      change_protocol: "Por favor, conectar usando HTTP (mejor que HTTPS) y reintentar esta solicitud."
+      change_protocol: Por favor, conectar usando HTTP (mejor que HTTPS) y reintentar esta solicitud.
     start: Empezar
     state: Provincia/Estado
     state_based: Basado en Estado/Provincias
     states: Provincias/Estados
     states_required: Se Requieren Provincias/Estados
     status: Estado
+    stock: Stock
     stock_location: Localización de Stock
     stock_location_info: Info Localización de Stock
     stock_locations: Localizaciones de Stock
@@ -1885,7 +1911,6 @@ es:
     stock_movements_for_stock_location: Movimientos de Stock para %{stock_location_name}
     stock_not_below_zero: El Stock no puede ser inferior a cero.
     stock_successfully_transferred: El Stock se ha transferido satisfactoriamente entre localizaciones.
-    stock: Stock
     stock_transfer: Transferencia de Stock
     stock_transfer_cannot_be_finalized: La Transferencia de stock no se puede finalizar
     stock_transfer_complete: Transferencia de Stock Completa
@@ -1896,34 +1921,34 @@ es:
     store_credit:
       actions:
         invalidate: Invalidar
-      credit_allocation_memo: "Esto es un crédito del crédito de la tienda. ID crédito %{id}"
-      currency_mismatch: "La divisa del crédito no coincide con la del pedido"
+      credit_allocation_memo: Esto es un crédito del crédito de la tienda. ID crédito %{id}
+      currency_mismatch: La divisa del crédito no coincide con la del pedido
       display_action:
         adjustment: Ajuste
+        admin:
+          authorize: Autorizado
+          eligible: Elegibilidad verificada
+          void: Anulado
         allocation: Añadida
         capture: Usado
         credit: Crédito
         invalidate: Invalidado
         void: Crédito
-        admin:
-          authorize: "Autorizado"
-          eligible: "Elegibilidad verificada"
-          void: "Anulado"
       errors:
-        unable_to_fund: "El pedido no se puede pagar usando los créditos de la Tienda"
-        cannot_invalidate_uncaptured_authorization: "No se puede invalidar un crédito de tienda con una autorización no capturada"
+        cannot_invalidate_uncaptured_authorization: No se puede invalidar un crédito de tienda con una autorización no capturada
+        unable_to_fund: El pedido no se puede pagar usando los créditos de la Tienda
       expiring: Caducando
-      insufficient_authorized_amount: "No se ha podido capturar mas que la cantidad autorizada"
-      insufficient_funds: "La cantidad de crédito restante no es suficiente"
+      insufficient_authorized_amount: No se ha podido capturar mas que la cantidad autorizada
+      insufficient_funds: La cantidad de crédito restante no es suficiente
       non_expiring: Sin caducidad
-      select_one_store_credit: "Seleccionar crédito para ir al balance restante"
+      select_one_store_credit: Seleccionar crédito para ir al balance restante
       store_credit: Crédito tienda
-      successful_action: "Crédito tienda generado satisfactoriamente %{action}"
-      unable_to_credit: "No se ha podido generar crédito: %{auth_code}"
-      unable_to_void: "No se ha podido anular código: %{auth_code}"
-      unable_to_find: "No se ha encontrado crédito"
-      unable_to_find_for_action: "No se ha encontrado crédito para el código de autenticación: %{auth_code} para acción: %{action}"
-      user_has_no_store_credits: "Usuario no tiene disponible crédito de tienda"
+      successful_action: Crédito tienda generado satisfactoriamente %{action}
+      unable_to_credit: 'No se ha podido generar crédito: %{auth_code}'
+      unable_to_find: No se ha encontrado crédito
+      unable_to_find_for_action: 'No se ha encontrado crédito para el código de autenticación: %{auth_code} para acción: %{action}'
+      unable_to_void: 'No se ha podido anular código: %{auth_code}'
+      user_has_no_store_credits: Usuario no tiene disponible crédito de tienda
     store_credit_category:
       default: Por defecto
     street_address: Dirección
@@ -1931,17 +1956,18 @@ es:
     subtotal: Subtotal
     subtract: Sustraer
     success: Éxito
-    successfully_created: ! '%{resource} ha sido creado satisfactoriamente!'
-    successfully_refunded: ! '%{resource} ha sido reintegrado satisfactoriamente!'
-    successfully_removed: ! '%{resource} ha sido borrado satisfactoriamente!'
+    successfully_created: "%{resource} ha sido creado satisfactoriamente!"
+    successfully_refunded: "%{resource} ha sido reintegrado satisfactoriamente!"
+    successfully_removed: "%{resource} ha sido borrado satisfactoriamente!"
     successfully_signed_up_for_analytics: ha sido registrado satisfactoriamente en Spree Analytics
-    successfully_updated: ! '%{resource} ha sido actualizado satisfactoriamente!'
+    successfully_updated: "%{resource} ha sido actualizado satisfactoriamente!"
     tax: Impuesto
-    tax_included: "Imp.(incl.)"
     tax_categories: Categorías de Impuesto
     tax_category: Categoría de Impuesto
     tax_code: Código de impuesto
-    tax_rate_amount_explanation: Las Tasas de Impuestos van con punto decimal para ayudar en los cálculos, p.ej. si la tasa es un 5% entonces escriba 0.05)
+    tax_included: Imp.(incl.)
+    tax_rate_amount_explanation: Las Tasas de Impuestos van con punto decimal para ayudar en los cálculos, p.ej. si la tasa es un 5% entonces
+      escriba 0.05)
     tax_rates: Tasas de impuestos
     taxon: Taxón
     taxon_edit: Editar Taxón
@@ -1956,12 +1982,12 @@ es:
     taxonomy: Taxonomía
     taxonomy_edit: Editar taxonomía
     taxonomy_tree_error: El cambio solicitado no se ha aceptado y el arbol ha vuelto a su estado anterior, por favor, inténtelo de nuevo.
-    taxonomy_tree_instruction: ! '* Clic derecho en una rama para acceder al menú de añadir, borrar u ordenar la rama.'
+    taxonomy_tree_instruction: "* Clic derecho en una rama para acceder al menú de añadir, borrar u ordenar la rama."
     taxons: Taxones
     test: Test
     test_mailer:
       test_email:
-        greeting: ¡Enhorabuena!
+        greeting: "¡Enhorabuena!"
         message: Si ha recibido este email, sus datos de correo son correctos.
         subject: Mail de prueba
     test_mode: Modo Test
@@ -1970,9 +1996,9 @@ es:
     there_were_problems_with_the_following_fields: Hay problemas con los siguientes campos
     this_order_has_already_received_a_refund: Este pedido ya ha recibido un reintegro
     thumbnail: Miniatura
-    tiers: Tramos
     tiered_flat_rate: Tramo tasa plana
     tiered_percent: Tramo porcentaje
+    tiers: Tramos
     time: Hora
     to: a
     to_add_variants_you_must_first_define: Para añadir variantes, deben definirse primero
@@ -1988,21 +2014,21 @@ es:
     tracking_url: URL Seguimiento
     tracking_url_placeholder: p.ej. http://quickship.com/package?num=:tracking
     transaction_id: ID Transacción
-    transfer_items: Artículos en Transferencia
     transfer_from_location: Transferencia de
+    transfer_items: Artículos en Transferencia
+    transfer_number: Número de Transferencia
     transfer_stock: Transferir Stock
     transfer_to_location: Transferencia a
-    transfer_number: Número de Transferencia
     tree: Árbol
     try_changing_search_values: Inténtelo cambiando los valores de búsqueda.
     type: Tipo
     type_to_search: Tipo a buscar
-    unable_to_find_all_inventory_units: No se encuentran las unidades de inventario especificadas
     unable_to_connect_to_gateway: No se puede conectar a la pasarela.
     unable_to_create_reimbursements: No se puede crear un reembolso porque hay artículos pendientes de intervención manual.
     unable_to_create_stock_transfer: No se puede crear una Transferencia de stock
-    unfinalize_all_adjustments: Sin finalizar todos los Ajustes
+    unable_to_find_all_inventory_units: No se encuentran las unidades de inventario especificadas
     under_price: Bajo %{price}
+    unfinalize_all_adjustments: Sin finalizar todos los Ajustes
     unlock: Desbloquear
     unrecognized_card_type: Tipo de tarjeta desconocida
     unshippable_items: Artículos no enviables
@@ -2016,22 +2042,23 @@ es:
     use_new_cc: Usar una nueva tarjeta
     use_new_cc_or_payment_method: Usar una nueva tarjeta / método de pago
     user: Usuario
-    user_rule:
-      choose_users: Elegir usuarios
     user_role_rule:
       choose_roles: Elegir Roles
       label: El Usuario debe disponer %{select} de estos roles
       match_all: todos
       match_any: al menos uno
+    user_rule:
+      choose_users: Elegir usuarios
     users: Usuarios
     validation:
-      unpaid_amount_not_zero: "La Cantidad no ha sido reintegrada en su totalidad. Aún se debe: %{amount}"
       cannot_be_less_than_shipped_units: no puede ser menor que el número de unidades enviadas.
-      cannot_destroy_line_item_as_inventory_units_have_shipped: No puede eliminar este elemento en linea, ya que algunas unidades del inventario ya se han enviado.
+      cannot_destroy_line_item_as_inventory_units_have_shipped: No puede eliminar este elemento en linea, ya que algunas unidades del inventario
+        ya se han enviado.
       exceeds_available_stock: excede el stock disponible. Por favor, asegúrese que los artículos tienen una cantidad válida.
       is_too_large: es muy grande -- ¡stock disponible es insuficiente para dicha cantidad!
       must_be_int: Debe ser un número entero
       must_be_non_negative: No puede ser un valor negativo
+      unpaid_amount_not_zero: 'La Cantidad no ha sido reintegrada en su totalidad. Aún se debe: %{amount}'
     validity_period: Período de validez
     value: Valor
     variant: Variante
@@ -2039,22 +2066,27 @@ es:
     variant_pricing: Precio Variante
     variant_properties: Propiedades Variante
     variant_search: Buscar Variante
-    variant_search_placeholder: "SKU o valor de opción"
+    variant_search_placeholder: SKU o valor de opción
     variant_to_add: Variante a añadir
     variant_to_be_received: Variante a recibir
     variants: Variantes
     version: Versión
     void: Vacío
     weight: Peso
-    what_is_a_cvv: ¿Qué es el código (CVV) de la tarjeta de crédito?
-    what_is_this: ¿Qué es esto?
+    what_is_a_cvv: "¿Qué es el código (CVV) de la tarjeta de crédito?"
+    what_is_this: "¿Qué es esto?"
     width: Ancho
     year: Año
-    you_have_no_orders_yet: Aún no tiene pedidos
     you_cannot_undo_action: No se puede deshacer esta acción
+    you_have_no_orders_yet: Aún no tiene pedidos
     your_cart_is_empty: Su carrito está vacío
     your_order_is_empty_add_product: Su pedido está vacío, por favor, añada algún producto
     zip: Código Postal
     zipcode: Código Postal
     zone: Zona
     zones: Zonas
+  time:
+    formats:
+      solidus:
+        long: "%B %d, %Y %-l:%M %p"
+        short: "%b %-d '%y %-l:%M%P"

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1,3 +1,4 @@
+---
 et:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ et:
         state: Maakond
         zipcode: Postiindeks
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,59 +25,59 @@ et:
         name: Name
         numcode: ISO Code
       spree/credit_card:
-        base:
-        cc_type:
-        month:
-        name:
-        number:
-        verification_value:
-        year:
+        base: 
+        cc_type: 
+        month: 
+        name: 
+        number: 
+        verification_value: 
+        year: 
       spree/inventory_unit:
-        state:
+        state: 
       spree/line_item:
-        price:
-        quantity:
+        price: 
+        quantity: 
       spree/option_type:
-        name:
-        presentation:
+        name: 
+        presentation: 
       spree/order:
-        checkout_complete:
+        checkout_complete: 
         completed_at: Esitatud
-        considered_risky:
-        coupon_code:
+        considered_risky: 
+        coupon_code: 
         created_at: Tellimuse kuupäev
         email: Kliendi e-post
         ip_address: IP Aadress
-        item_total:
-        number:
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
+        item_total: 
+        number: 
+        payment_state: 
+        shipment_state: 
+        special_instructions: 
+        state: 
         total: Kokku
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/payment:
         amount: Summa
       spree/payment_method:
         name: Nimetus
       spree/product:
         available_on: Saadaval alates
-        cost_currency:
+        cost_currency: 
         cost_price: Cost Price
         description: Kirjeldus
         master_price: Hind
@@ -85,17 +86,17 @@ et:
         shipping_category: Tarnekategooria
         tax_category: Maksukategooria
       spree/promotion:
-        advertise:
-        code:
-        description:
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        advertise: 
+        code: 
+        description: 
+        event_name: 
+        expires_at: 
+        name: 
+        path: 
+        starts_at: 
+        usage_limit: 
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Nimetus
         presentation: Presentation
@@ -106,23 +107,23 @@ et:
       spree/role:
         name: Nimetus
       spree/state:
-        abbr:
-        name:
+        abbr: 
+        name: 
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Kirjeldus
         name: Nimetus
@@ -141,14 +142,14 @@ et:
         password: Salasõna
         password_confirmation: Salasõna kordus
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_currency: 
+        cost_price: 
+        depth: 
+        height: 
+        price: 
+        sku: 
+        weight: 
+        width: 
       spree/zone:
         description: Kirjeldus
         name: Nimetus
@@ -157,47 +158,47 @@ et:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: Kaart on aegunud
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Aadress
@@ -205,70 +206,70 @@ et:
       spree/country:
         one: Riik
         other: Riigid
-      spree/credit_card:
-      spree/customer_return:
-      spree/inventory_unit:
-      spree/line_item:
-      spree/option_type:
-      spree/option_value:
+      spree/credit_card: 
+      spree/customer_return: 
+      spree/inventory_unit: 
+      spree/line_item: 
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Tellimus
         other: Tellimused
       spree/payment:
         one: Makse
         other: Maksed
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Toode
         other: Tooted
-      spree/promotion:
-      spree/promotion_category:
-      spree/property:
-      spree/prototype:
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
-      spree/return_authorization:
-      spree/return_authorization_reason:
-      spree/role:
+      spree/promotion: 
+      spree/promotion_category: 
+      spree/property: 
+      spree/prototype: 
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
+      spree/return_authorization: 
+      spree/return_authorization_reason: 
+      spree/role: 
       spree/shipment:
         one: Tarne
         other: Tarned
       spree/shipping_category:
         one: Tarnekategooria
         other: Tarnekategooriad
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: Maakond
         other: Maakonnad
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Maksukategooria
         other: Maksukategooriad
-      spree/tax_rate:
+      spree/tax_rate: 
       spree/taxon:
         one: Takson
         other: Taksonid
       spree/taxonomy:
         one: Taksonoomia
         other: Taksonoomiad
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: Kasutaja
         other: Kasutajad
-      spree/variant:
+      spree/variant: 
       spree/zone:
         one: Zone
         other: Zones
   spree:
     abbreviation: Lühend
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Konto
     account_updated: Konto uuendatud
     action: Toiming
@@ -281,7 +282,7 @@ et:
       list: Loetelu
       listing: Loetelu
       new: Uus
-      refund:
+      refund: 
       save: Salvesta
       update: Uuendus
     activate: Activate
@@ -289,145 +290,145 @@ et:
     add: Lisa
     add_action_of_type: Lisa toimingu tüüp
     add_country: Lisa riik
-    add_coupon_code:
-    add_new_header:
-    add_new_style:
+    add_coupon_code: 
+    add_new_header: 
+    add_new_style: 
     add_one: Lisa üks
     add_option_value: Lisa variatsionitüübi variante
     add_product: Lisa toode
     add_product_properties: Lisa toote omadusi
-    add_rule_of_type:
+    add_rule_of_type: 
     add_state: Lisa maakond
-    add_stock:
-    add_stock_management:
+    add_stock: 
+    add_stock_management: 
     add_to_cart: Lisa ostukorvi
     add_variant: Lisa variant
     additional_item: Iga järgneva toote summa
     address1: Aadress
     address2: Aadress (jätkub)
-    adjustable:
+    adjustable: 
     adjustment: Täiendus
     adjustment_amount: Kogus
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_successfully_closed: 
+    adjustment_successfully_opened: 
     adjustment_total: Adjustment Total
     adjustments: Täiendused
     admin:
       tab:
         configuration: Seadistus
-        option_types:
-        orders:
-        overview:
+        option_types: 
+        orders: 
+        overview: 
         products: Tooted
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
         reports: Raportid
-        taxonomies:
-        taxons:
+        taxonomies: 
+        taxons: 
         users: Kasutajad
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administreerimisliides
-    advertise:
-    agree_to_privacy_policy:
+    advertise: 
+    agree_to_privacy_policy: 
     agree_to_terms_of_service: Nõustu Kasutustingimustega
     all: Kõik
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: 
+    all_adjustments_opened: 
     all_departments: Kõik osakonnad
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
+    all_items_have_been_returned: 
+    allow_ssl_in_development_and_test: 
+    allow_ssl_in_production: 
+    allow_ssl_in_staging: 
+    already_signed_up_for_analytics: 
     alt_text: Alternatiivne tekst
     alternative_phone: Teine telefoninumber
     amount: Summa
     analytics_desc_header_1: Spree Analüütika
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
     analytics_desc_list_4: See on täiesti tasuta!
     analytics_trackers: Google Analytics
-    and:
-    approve:
-    approved_at:
-    approver:
+    and: 
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Kas oled kindel?
     are_you_sure_delete: Kas oled kindel, et soovid seda kirjet kustutada?
-    associated_adjustment_closed:
-    at_symbol: '@'
+    associated_adjustment_closed: 
+    at_symbol: "@"
     authorization_failure: Tõrge autoriseerimisel
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Saadaval alates
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Tagasi
-    back_end:
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_end: 
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Mine tagasi poodi
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_users_list: 
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Tasuda jäänud
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Arve saaja aadress
     billing: Arve esitamine
     billing_address: Arve saaja aadress
     both: Mõlemad
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Kalkulaator
     calculator_settings_warning: Kalkulaatoritüübi ja -seadete muutmiseks pead kõigepealt salvestama.
     cancel: Tühista
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: 
     cannot_create_returns: Tellimust ei saa tagastada, kuna seda pole veel väljastatud.
-    cannot_perform_operation:
-    cannot_set_shipping_method_without_address:
+    cannot_perform_operation: 
+    cannot_set_shipping_method_without_address: 
     capture: Lõpeta makse
-    capture_events:
+    capture_events: 
     card_code: Kaardikood
     card_number: Kaardi number
-    card_type:
+    card_type: 
     card_type_is: Kaarditüüp on
     cart: Ostukorv
-    cart_subtotal:
+    cart_subtotal: 
     categories: Katergooriad
     category: Kategooria
-    charged:
-    check_for_spree_alerts:
+    charged: 
+    check_for_spree_alerts: 
     checkout: Vormista tellimus
     choose_a_customer: Vali klient
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 
+    choose_dashboard_locale: 
+    choose_location: 
     city: Linn
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Võta aluseks
     close: Sulge
-    close_all_adjustments:
+    close_all_adjustments: 
     code: Kood
     company: Ettevõte
     complete: Esitatud
@@ -438,110 +439,110 @@ et:
     confirm_password: Kinnita salasõna
     continue: Jätka
     continue_shopping: Jätka ostlemist
-    cost_currency:
+    cost_currency: 
     cost_price: Omahind
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
     countries: Riigid
     country: Riik
     country_based: Riigipõhine
     country_name: Nimi
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon:
-    coupon_code:
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
+    coupon: 
+    coupon_code: 
+    coupon_code_already_applied: 
+    coupon_code_applied: 
+    coupon_code_better_exists: 
+    coupon_code_expired: 
+    coupon_code_max_usage: 
+    coupon_code_not_eligible: 
+    coupon_code_not_found: 
+    coupon_code_unknown_error: 
     create: Loo kasutajakonto
     create_a_new_account: Loo uus konto
-    create_new_order:
-    create_reimbursement:
+    create_new_order: 
+    create_reimbursement: 
     created_at: Loodud
     credit: Krediit
     credit_card: Krediitkaart
-    credit_cards:
+    credit_cards: 
     credit_owed: Krediit võlgu
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credits: 
+    currency: 
+    currency_decimal_mark: 
+    currency_settings: 
+    currency_symbol_position: 
+    currency_thousands_separator: 
     current: Praegune
-    current_promotion_usage:
+    current_promotion_usage: 
     customer: Klient
     customer_details: Kliendi andmed
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Kliendi otsing
-    cut:
-    cvv_response:
+    cut: 
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
     date: Kuupäev
-    date_completed:
+    date_completed: 
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 
+      format: 
+      js_format: 
     date_range: Vali vahemik
-    default:
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default: 
+    default_refund_amount: 
+    default_tax: 
+    default_tax_zone: 
     delete: Kustuta
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Delivery
     depth: Sügavus
     description: Kirjeldus
-    destination:
+    destination: 
     destroy: Kustuta
-    details:
-    discount_amount:
-    dismiss_banner:
+    details: 
+    discount_amount: 
+    dismiss_banner: 
     display: Kuvatav väärtus
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: 
+    doesnt_track_inventory: 
     edit: Muuda
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Muuda kasutajakonto andmeid
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
+    email: 
     empty: Tühi
     empty_cart: Tühjenda ostukorv
     enable_mail_delivery: Luba e-mailide saatmine
@@ -551,39 +552,39 @@ et:
     error: Viga
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available:
-        no_shipping_methods_available:
-    errors_prohibited_this_record_from_being_saved:
+        could_not_create_taxon: 
+        no_payment_methods_available: 
+        no_shipping_methods_available: 
+    errors_prohibited_this_record_from_being_saved: 
     event: Sündmus
     events:
       spree:
         cart:
           add: Lisa ostukorvi
         checkout:
-          coupon_code_added:
+          coupon_code_added: 
         content:
-          visited:
+          visited: 
         order:
-          contents_changed:
-        page_view:
+          contents_changed: 
+        page_view: 
         user:
-          signup:
+          signup: 
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Aegub
     extension: Laiendus
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Faili nimi
-    fill_in_customer_info:
+    fill_in_customer_info: 
     filter_results: Filtreeri tulemusi
     finalize: Lõpeta
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: Esimese toote summa
     first_name: Eesnimi
     first_name_begins_with: Eesnimi algab
@@ -591,84 +592,84 @@ et:
     flat_rate_per_order: Fikseeritud summa tellimuse kohta
     flexible_rate: Paindlik summa
     forgot_password: Unustasid salasõna?
-    free_shipping:
-    free_shipping_amount:
-    front_end:
+    free_shipping: 
+    free_shipping_amount: 
+    front_end: 
     gateway: Lüüs
-    gateway_config_unavailable:
+    gateway_config_unavailable: 
     gateway_error: Lüüsi viga
-    general: "Üldine"
-    general_settings: "Üldised sätted"
+    general: Üldine
+    general_settings: Üldised sätted
     google_analytics: Google Analytics
     google_analytics_id: Google Analytics ID
     guest_checkout: Sooritas ostu külalisena
     guest_user_account: Vormista ost külalisena
     has_no_shipped_units: Postitatud esemed puuduvad
     height: Kõrgus
-    hide_cents:
+    hide_cents: 
     home: Avaleht
     i18n:
-      available_locales:
+      available_locales: 
       language: Keel
-      localization_settings:
+      localization_settings: 
       this_file_language: Eesti keel
     icon: Icon
-    identifier:
+    identifier: 
     image: Pilt
     images: Pildid
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: 
+    included_price_validation: 
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: Täida allolev vorm. Juhised salasõna uuesti seadistamiseks saadetakse Teile e-maili teel.
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
-    intercept_email_address:
-    intercept_email_instructions:
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    insufficient_stock_lines_present: 
+    intercept_email_address: 
+    intercept_email_instructions: 
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 
+    invalid_promotion_action: 
+    invalid_promotion_rule: 
     inventory: Varustus
     inventory_adjustment: Laoseisu korrigeerimine
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: 
+    inventory_state: 
     is_not_available_to_shipment_address: Pole tarneaadressile saadaval
-    iso_name:
+    iso_name: 
     item: Toode
     item_description: Toote kirjeldus
     item_total: Tooted kokku
     item_total_rule:
       operators:
-        gt:
-        gte:
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        gt: 
+        gte: 
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
-      path:
+      path: 
     last_name: Perekonnanimi
     last_name_begins_with: Perekonnanimi algab
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Loetelu
     loading: Laen...
     locale_changed: Keel vahetatud
     location: Asukoht
-    lock:
-    log_entries:
+    lock: 
+    log_entries: 
     logged_in_as: 'Sisse logitud:'
     logged_in_succesfully: Sisselogimine õnnestus!
     logged_out: Oled välja logitud!
@@ -677,38 +678,38 @@ et:
     login_failed: Sisselogimine ebaõnnestus. Palun kontrolli sisestatud andmeid.
     login_name: Kasutajanimi
     logout: Logi välja
-    logs:
+    logs: 
     look_for_similar_items: Teised sarnased tooted
     make_refund: Teosta tagasimakse
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Hind
     match_choices:
-      all:
-      none:
+      all: 
+      none: 
     max_items: Maksimaalne toodete arv
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Kirjeldus
     meta_keywords: Märksõnad
-    meta_title:
+    meta_title: 
     metadata: Metaandmed
     minimal_amount: Minimal Amount
     month: Kuu
-    more:
-    move_stock_between_locations:
+    more: 
+    move_stock_between_locations: 
     my_account: Minu konto
     my_orders: Minu tellimused
     name: Nimi
-    name_on_card:
+    name_on_card: 
     name_or_sku: Nimetus või SKU
     new: Uus
     new_adjustment: Uus täiendus
-    new_country:
+    new_country: 
     new_customer: Registreeru
-    new_customer_return:
+    new_customer_return: 
     new_image: Uus pilt
     new_option_type: Uus valik
     new_order: Uus tellimus
@@ -717,20 +718,20 @@ et:
     new_payment_method: Uus maksemeetod
     new_product: Uus toode
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Uus omadus
     new_prototype: Uus prototüüp
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Uue toote tagastamine
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Uus tarnekategooria
     new_shipping_method: Uus tarnemeetod
     new_state: Uus maakond
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: 
+    new_stock_movement: 
+    new_stock_transfer: 
     new_tax_category: Uus maksukategooria
     new_tax_rate: Uus maksumäär
     new_taxon: Uus liik
@@ -740,25 +741,25 @@ et:
     new_variant: Uus variant
     new_zone: Uus tsoon
     next: Järgmine
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: 
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: tooteid ei leitud
-    no_resource_found:
-    no_results:
-    no_returns_found:
-    no_rules_added:
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_resource_found: 
+    no_results: 
+    no_returns_found: 
+    no_rules_added: 
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
     none: Puuduvad
-    none_selected:
-    normal_amount:
+    none_selected: 
+    normal_amount: 
     not: mitte
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: 
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
       product_cloned: Toode on kloonitud
       product_deleted: Toode on kustutatud
@@ -766,47 +767,47 @@ et:
       product_not_deleted: Toote kustutamine ebaõnnestus
       variant_deleted: Variant kustutatud
       variant_not_deleted: Variandi kustutamine ebaõnnestus
-    num_orders:
+    num_orders: 
     on_hand: Laoseis
     open: Ava
-    open_all_adjustments:
-    option_type:
-    option_type_placeholder:
+    open_all_adjustments: 
+    option_type: 
+    option_type_placeholder: 
     option_types: Variatsioonid
-    option_value:
+    option_value: 
     option_values: valiku väärtused
     optional: Valikuline
     options: Variatsioonid
     or: või
-    or_over_price:
+    or_over_price: 
     order: Tellimus
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_adjustments: 
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Tellimuse info
     order_email_resent: E-mail tellimuse kohta uuesti saadetud
-    order_information:
+    order_information: 
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: 
+        instructions: 
+        order_summary_canceled: 
+        subject: 
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: 
+        instructions: 
+        order_summary: 
+        subject: 
+        subtotal: 
+        thanks: 
+        total: 
+    order_not_found: 
+    order_number: 
     order_processed_successfully: Tellimus edastatud
-    order_resumed:
+    order_resumed: 
     order_state:
       address: Aadress
       awaiting_return: ootab tagastamist
@@ -814,7 +815,7 @@ et:
       cart: Ostukorv
       complete: Esitatud
       confirm: kinnitamine
-      considered_risky:
+      considered_risky: 
       delivery: Saatmine
       payment: Tasumine
       resumed: resumed
@@ -824,28 +825,28 @@ et:
     order_total: Tellimus kokku
     order_updated: Tellimus uuendatud
     orders: Tellimused
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Laost lõppenud
-    overview: "Ülevaade"
-    package_from:
+    overview: Ülevaade
+    package_from: 
     pagination:
-      next_page:
-      previous_page:
+      next_page: 
+      previous_page: 
       truncate: "…"
     password: Salasõna
     paste: Paste
     path: Teekond
     pay: Maksa
     payment: Makse
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Makse informatsioon
     payment_method: Makseviis
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Makseviisid
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
+    payment_processing_failed: 
+    payment_processor_choose_banner_text: 
+    payment_processor_choose_link: 
     payment_state: Makse staatus
     payment_states:
       balance_due: Ootab tasumist
@@ -859,94 +860,94 @@ et:
       void: Kehtetu
     payment_updated: Makse uuendatud
     payments: Maksed
-    pending:
+    pending: 
     percent: Protsent
     percent_per_item: Percent Per Item
     permalink: Püsiviide
     phone: Telefon
     place_order: Esita tellimus
-    please_define_payment_methods:
-    populate_get_error:
+    please_define_payment_methods: 
+    populate_get_error: 
     powered_by: Toetab
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Kuvatav väärtus
     previous: Eelmine
-    previous_state_missing:
+    previous_state_missing: 
     price: Hind
-    price_range:
-    price_sack:
+    price_range: 
+    price_sack: 
     process: Töötle
     product: Toode
     product_details: Tooteinfo
     product_has_no_description: Tootel puudub kirjeldus
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: Toote omadused
     product_rule:
-      choose_products:
-      label:
-      match_all:
-      match_any:
-      match_none:
+      choose_products: 
+      label: 
+      match_all: 
+      match_any: 
+      match_none: 
       product_source:
-        group:
-        manual:
-    products:
-    promotion:
-    promotion_action:
+        group: 
+        manual: 
+    products: 
+    promotion: 
+    promotion_action: 
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: 
+        name: 
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: 
+        name: 
+    promotion_actions: 
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: 
+        any: 
+    promotion_rule: 
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: 
+        name: 
       item_total:
-        description:
-        name:
+        description: 
+        name: 
       landing_page:
-        description:
-        name:
+        description: 
+        name: 
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description:
-        name:
+        description: 
+        name: 
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
-        description:
-        name:
+        description: 
+        name: 
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
+        description: 
+        name: 
+    promotion_uses: 
+    promotionable: 
     promotions: Kampaaniad
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Omadused
     property: Omadus
     prototype: Prototüüp
@@ -957,46 +958,46 @@ et:
     quantity: Kogus
     quantity_returned: Quantity Returned
     quantity_shipped: Tarnitud kogus
-    quick_search:
+    quick_search: 
     rate: Hind
     reason: Põhjus
     receive: Võta vastu
-    receive_stock:
+    receive_stock: 
     received: Vastu võetud
-    reception_status:
-    reference:
+    reception_status: 
+    reference: 
     refund: Tagasimakse
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Registreeri kasutajakonto
     registration: Registreeru või vormista ost külalisena
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Mäleta mind
     remove: Eemalda
     rename: Rename
-    report:
+    report: 
     reports: Aruanded
     resend: Saada uuesti
     reset_password: Lähtesta salasõna
@@ -1005,186 +1006,186 @@ et:
     resumed: Jätkatud
     return: Tagastama
     return_authorization: Tagasta toode
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Toote tagastamine uuendatud
     return_authorizations: Tagasta tooted
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Tagastatav kogus
     returned: Tagastatud
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit:
+    returns: 
+    review: 
+    risk: 
+    risk_analysis: 
+    risky: 
+    rma_credit: 
     rma_number: Tagastatud toote number
     rma_value: Tagastatud toote väärtus
     roles: Rollid
-    rules:
-    safe:
+    rules: 
+    safe: 
     sales_total: Kogumüük
     sales_total_description: Tellimuste tulu kokku
-    sales_totals:
+    sales_totals: 
     save_and_continue: Salvesta ja jätka
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: 
+    say_no: 
+    say_yes: 
     scope: Käsitlusala
     search: Otsing
     search_results: Otsingu '%{keywords}' tulemused
     searching: Searching
     secure_connection_type: Turvalise ühenduse tüüp
-    security_settings:
+    security_settings: 
     select: Vali
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Vali prototüüpide hulgast
-    select_stock:
+    select_stock: 
     send_copy_of_all_mails_to: Saada koopia kõikidest e-mailidest
     send_mails_as: Saada e-mailid kui
-    server:
+    server: 
     server_error: Serveris esines viga
     settings: Sätted
     ship: Saada
     ship_address: Kättetoimetamise aadress
-    ship_total:
+    ship_total: 
     shipment: Tarne
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
+        dear_customer: 
+        instructions: 
+        shipment_summary: 
+        subject: 
+        thanks: 
+        track_information: 
+        track_link: 
     shipment_state: Tarne staatus
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: 
       partial: partial
       pending: Ootel
       ready: Tarneks valmis
       shipped: Tarnitud
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Tarned
     shipped: Saadetud
     shipping: Transport
     shipping_address: Kättetoimetamise aadress
     shipping_categories: Saatmiskategooriad
     shipping_category: Saatmiskategooria
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
     shipping_instructions: Kättetoimetamise lisainfo
     shipping_method: Tarneviis
     shipping_methods: Tarneviisid
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: 
+    shipping_total: 
     shop_by_taxonomy: "%{taxonomy}:"
     shopping_cart: Ostukorv
     show: Näita
     show_active: Näita aktiivseid
     show_deleted: Näita kustutatuid
     show_only_complete_orders: Näita ainult täidetud tellimusi
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: 
+    show_rate_in_label: 
     sku: SKU
-    skus:
-    slug:
-    source:
+    skus: 
+    slug: 
+    source: 
     special_instructions: Tarne lisajuhised
-    split:
-    spree_gateway_error_flash_for_checkout:
+    split: 
+    spree_gateway_error_flash_for_checkout: 
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Alates
     state: Maakond
     state_based: Maakonnapõhine
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Maakonnad
-    states_required:
+    states_required: 
     status: Staatus
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: 
+    stock_location: 
+    stock_location_info: 
+    stock_locations: 
+    stock_locations_need_a_default_country: 
+    stock_management: 
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
+    stock_transfer: 
+    stock_transfers: 
     stop: Kuni
     store: Pood
     street_address: Tänav
     street_address_2: Tänav (jätkub)
     subtotal: Vahesumma
     subtract: Lahuta
-    success:
-    successfully_created:
-    successfully_refunded:
-    successfully_removed:
-    successfully_signed_up_for_analytics:
-    successfully_updated:
-    summary:
+    success: 
+    successfully_created: 
+    successfully_refunded: 
+    successfully_removed: 
+    successfully_signed_up_for_analytics: 
+    successfully_updated: 
+    summary: 
     tax: Maksud
     tax_categories: Maksukategooriad
     tax_category: Maksukategooria
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
     tax_rates: Maksumäärad
     taxon: Taksonoomia
     taxon_edit: Redigeeri taksonoomiaid
-    taxon_placeholder:
+    taxon_placeholder: 
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taksonoomia
     taxonomy: Taxonomy
     taxonomy_edit: Redigeeri taksonoomiaid
@@ -1194,65 +1195,65 @@ et:
     test: Test
     test_mailer:
       test_email:
-        greeting:
-        message:
+        greeting: 
+        message: 
         subject: Testmail
     test_mode: Testrežiim
     thank_you_for_your_order: Täname teid tellimuse eest
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Pisipilt
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Aeg
     to_add_variants_you_must_first_define: variantide lisamiseks pead esmalt defineerima TODO
     total: Kokku
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Jälgimisnumber
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
     tree: Puu
     type: Tüüp
-    type_to_search:
+    type_to_search: 
     unable_to_connect_to_gateway: Juurdepääs ebaõnnestus.
-    unable_to_create_reimbursements:
-    under_price:
-    unlock:
+    unable_to_create_reimbursements: 
+    under_price: 
+    unlock: 
     unrecognized_card_type: Tundmatu kaarditüüp
-    unshippable_items:
+    unshippable_items: 
     update: Uuenda
     updating: Uuendan
     usage_limit: Kasutuslimiit
-    use_app_default:
+    use_app_default: 
     use_billing_address: Kasuta arve saaja aadressi
     use_new_cc: Kasuta uut kaarti
-    use_s3:
+    use_s3: 
     user: Kasutaja
     user_rule:
-      choose_users:
+      choose_users: 
     users: Kasutajad
     validation:
-      cannot_be_less_than_shipped_units:
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_be_less_than_shipped_units: 
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 
       is_too_large: on liiga suur – laos puudub soovitud kogus!
       must_be_int: peab olema täisarv
       must_be_non_negative: peab olema positiivne arv
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Väärtus
-    variant:
-    variant_placeholder:
+    variant: 
+    variant_placeholder: 
     variants: Variandid
     version: Versioon
     void: Muuda kehtetuks
@@ -1263,7 +1264,7 @@ et:
     year: Aasta
     you_have_no_orders_yet: You have no orders yet.
     your_cart_is_empty: Ostukorv on tühi
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: 
     zip: Postiindeks
     zipcode: Postiindeks
     zone: Tsoon

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,48 +1,50 @@
+---
 fa:
   Bazaar: بازار
   activerecord:
     attributes:
       spree/address:
-        address1: "آدرس"
-        address2: "ادامه آدرس"
-        city: "شهر"
-        country: "کشور"
-        firstname: "نام"
-        lastname: "نام‌خانوادگی"
-        phone: "تلفن"
-        state: "استان"
-        zipcode: "کد پستی"
+        address1: آدرس
+        address2: ادامه آدرس
+        city: شهر
+        country: کشور
+        firstname: نام
+        lastname: نام‌خانوادگی
+        phone: تلفن
+        state: استان
+        zipcode: کد پستی
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
         iso_name: ISO Name
-        name: "نام"
+        name: نام
         numcode: ISO Code
       spree/credit_card:
-        base:
-        cc_type: "نوع"
-        month: "ماه"
-        name:
-        number: "عدد"
-        verification_value:
-        year: "سال"
+        base: 
+        cc_type: نوع
+        month: ماه
+        name: 
+        number: عدد
+        verification_value: 
+        year: سال
       spree/inventory_unit:
-        state: "استان"
+        state: استان
       spree/line_item:
-        price: "قیمت"
-        quantity: "مقدار"
+        price: قیمت
+        quantity: مقدار
       spree/option_type:
-        name: "نام"
-        presentation: "نمایش"
+        name: نام
+        presentation: نمایش
       spree/order:
-        checkout_complete:
+        checkout_complete: 
         completed_at: پایان یافته در
+        considered_risky: ریسکی
         coupon_code: کد کوپن
         created_at: ساخته شده در
         email: ایمیل
@@ -54,31 +56,29 @@ fa:
         special_instructions: دستورالعمل ویژه
         state: وضعیت
         total: مجموع
-        considered_risky: ریسکی
-
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/payment:
-        amount:
+        amount: 
       spree/payment_method:
-        name:
+        name: 
       spree/product:
         available_on: Available On
-        cost_currency:
+        cost_currency: 
         cost_price: Cost Price
         description: Description
         master_price: Master Price
@@ -87,63 +87,63 @@ fa:
         shipping_category: Shipping Category
         tax_category: Tax Category
       spree/promotion:
-        advertise:
+        advertise: 
         code: کد
-        description:
-        event_name:
-        expires_at:
-        name: "نام"
-        path: "مسیر"
-        starts_at:
-        usage_limit:
+        description: 
+        event_name: 
+        expires_at: 
+        name: نام
+        path: مسیر
+        starts_at: 
+        usage_limit: 
       spree/promotion_category:
         name: نام
       spree/property:
-        name: "نام"
-        presentation: "نمایش"
+        name: نام
+        presentation: نمایش
       spree/prototype:
-        name: "نام"
+        name: نام
       spree/return_authorization:
         amount: مقدار
       spree/role:
-        name: "نام"
+        name: نام
       spree/state:
-        abbr:
-        name: "نام"
+        abbr: 
+        name: نام
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
         type: نوع
-        updated:
-        user:
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
-        description: "توضیحات"
-        name: "نام"
+        description: توضیحات
+        name: نام
       spree/tax_rate:
-        amount:
-        included_in_price:
-        show_rate_in_label:
+        amount: 
+        included_in_price: 
+        show_rate_in_label: 
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: 
+        permalink: 
+        position: 
       spree/taxonomy:
-        name: "نام"
+        name: نام
       spree/user:
-        email: "ایمیل"
-        password: "رمز‌عبور"
-        password_confirmation: "تایید رمز‌عبور"
+        email: ایمیل
+        password: رمز‌عبور
+        password_confirmation: تایید رمز‌عبور
       spree/variant:
-        cost_currency:
+        cost_currency: 
         cost_price: Cost Price
         depth: Depth
         height: Height
@@ -152,96 +152,96 @@ fa:
         weight: وزن
         width: عرض
       spree/zone:
-        description: "توضیحات"
-        name: "نام"
+        description: توضیحات
+        name: نام
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: اعتبار کارت تمام شده است
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
+      reimbursement_perform_failed: 
+      reimbursement_status: وضعیت بازپرداخت
+      reimbursement_type: نوع بازپرداخت
+      reimbursement_type_override: 
+      reimbursement_types: انواع بازپرداخت
+      reimbursements: بازپرداخت‌ها
       spree/address:
-        one: "آدرس"
-        other: "آدرس‌ها"
+        one: آدرس
+        other: آدرس‌ها
       spree/country:
-        one: "کشور"
-        other: "کشورها"
+        one: کشور
+        other: کشورها
       spree/credit_card:
-        one: "کارت اعتباری"
-        other: "کارت‌های اعتباری"
-      spree/customer_return:
-      spree/inventory_unit:
-      spree/line_item:
+        one: کارت اعتباری
+        other: کارت‌های اعتباری
+      spree/customer_return: 
+      spree/inventory_unit: 
+      spree/line_item: 
       spree/option_type: نوع گزینه
-      spree/option_value:
+      spree/option_value: 
       spree/order:
         one: سفارش
         other: سفارشات
       spree/payment:
         one: Payment
         other: Payments
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
-        one: "محصول"
-        other: "محصول‌ها"
+        one: محصول
+        other: محصول‌ها
       spree/promotion: فروش ویژه
       spree/promotion_category: دسته بندی فروش ویژه
       spree/property:
-        one: "خصوصیت"
-        other: "خصوصیات"
+        one: خصوصیت
+        other: خصوصیات
       spree/prototype:
         one: نمونه آزمایشی
         other: نمنونه های آزمایشی
       spree/refund_reason: دلیل استرداد
       spree/reimbursement: بازپرداخت
       spree/reimbursement_type: نوع بازپرداخت
-      reimbursement_perform_failed:
-      reimbursement_status: وضعیت بازپرداخت
-      reimbursement_type: نوع بازپرداخت
-      reimbursement_type_override:
-      reimbursement_types: انواع بازپرداخت
-      reimbursements: بازپرداخت‌ها
       spree/return_authorization: مجوز بازگشت
       spree/return_authorization_reason: دلیل مجوز بازگشت
       spree/role: نقش
@@ -249,22 +249,22 @@ fa:
       spree/shipping_category:
         one: دسته‌بندی حمل و نقل
         other: دسته‌بندی حمل نقل
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: State
         other: States
-      spree/stock_location:
-      spree/stock_transfer:
-      spree/tax_category:
-      spree/tax_rate:
-      spree/taxon:
+      spree/stock_location: 
+      spree/stock_transfer: 
+      spree/tax_category: 
+      spree/tax_rate: 
+      spree/taxon: 
       spree/taxonomy:
         one: Taxonomy
         other: Taxonomies
-      spree/tracker:
+      spree/tracker: 
       spree/user:
-        one: "کاربر"
-        other: "کاربرها"
+        one: کاربر
+        other: کاربرها
       spree/variant:
         one: Variant
         other: Variants
@@ -272,26 +272,24 @@ fa:
         one: Zone
         other: Zones
   spree:
-    quick_search: جستوجو سریع . . .
-    filter: فیلتر
-    abbreviation: "مخفف"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
-    account: "حساب"
-    account_updated: "حساب شما بروزرسانی شد!"
-    action: "حرکت"
+    abbreviation: مخفف
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
+    account: حساب
+    account_updated: حساب شما بروزرسانی شد!
+    action: حرکت
     actions:
       cancel: لغو
-      continue:
+      continue: 
       create: ایجاد
       destroy: پاک کردن
       edit: ویرایش
       list: لیست
       listing: لیست کردن
       new: جدید
-      save:
+      save: 
       update: بروز رسانی
     activate: Activate
     active: فعال
@@ -300,79 +298,79 @@ fa:
     add_country: افزودن کشور
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: 
     add_option_value: افزودن مقدار
     add_product: افزودن محصول
     add_product_properties: افزودن ویژگی های محصول
     add_rule_of_type: افزودن قانون نوع
     add_state: افزودن ایالت یا استان
-    add_stock:
-    add_stock_management:
+    add_stock: 
+    add_stock_management: 
     add_to_cart: افزودن به سبد خرید
-    add_variant:
+    add_variant: 
     additional_item: قیمت آیتم اضافه شده
-    address1:
-    address2:
+    address1: 
+    address2: 
     adjustment: تعدیل
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: 
+    adjustment_successfully_closed: 
+    adjustment_successfully_opened: 
     adjustment_total: تعدیل کل
     adjustments: تعدیلات
     admin:
       tab:
         configuration: تنظیمات
+        option_types: انواع اختیارات
         orders: سفارشات
         overview: نمای کلی
         products: محصولات
+        promotion_categories: 
         promotions: فروش ویژه
         properties: ویژگی ها
-        promotion_categories:
         prototypes: نمونه های اولیه
         reports: گزارشات
-        users: کاربران
-        option_types: انواع اختیارات
         taxonomies: رده بندی
         taxons: گونه
+        users: کاربران
     administration: مدیریت
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    agree_to_privacy_policy: 
+    agree_to_terms_of_service: 
     all: همه
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: 
+    all_adjustments_opened: 
     all_departments: همه ی دپارتمان ها
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
-    already_signed_up_for_analytics:
+    already_signed_up_for_analytics: 
     alt_text: متن جایگزین
     alternative_phone: تلفن جایگزین
     amount: مقدار
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: 
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
     analytics_trackers: ردگیرهای تحلیلی
     and: and
     are_you_sure: آیا مطمئن هستید؟
     are_you_sure_delete: آیا مطمئن هستید که می خواهید این سطر را پاک کنید؟
-    associated_adjustment_closed:
+    associated_adjustment_closed: 
+    at_symbol: "@"
     attachment_default_style: Attachments Style
     attachment_default_url: Attachments URL
     attachment_path: Attachments Path
     attachment_styles: Paperclip Styles
-    attachment_url:
-    at_symbol: '@'
+    attachment_url: 
     authorization_failure: خرابی در صدور مجوز
     available_on: موجود است در
     back: برگشت
     back_end: Back End
     back_to_adjustments_list: Back To Adjustments List
     back_to_images_list: Back To Images List
-    back_to_option_types_list:
-    back_to_orders_list:
+    back_to_option_types_list: 
+    back_to_orders_list: 
     back_to_payment_methods_list: Back To Payment Methods List
     back_to_payments_list: Back To Payments List
     back_to_products_list: Back To Products List
@@ -383,17 +381,17 @@ fa:
     back_to_shipping_categories: Back To Shipping Categories
     back_to_shipping_methods_list: Back To Shipping Methods List
     back_to_states_list: Back To States List
-    back_to_stock_locations_list:
-    back_to_stock_movements_list:
-    back_to_stock_transfers_list:
+    back_to_stock_locations_list: 
+    back_to_stock_movements_list: 
+    back_to_stock_transfers_list: 
     back_to_store: بازگشت به فروشگاه
     back_to_tax_categories_list: Back To Tax Categories List
     back_to_taxonomies_list: Back To Taxonomies List
     back_to_trackers_list: Back To Trackers List
-    back_to_users_list:
+    back_to_users_list: 
     back_to_zones_list: Back To Zones List
-    backorderable:
-    backorders_allowed:
+    backorderable: 
+    backorders_allowed: 
     balance_due: پرداخت نشده
     bill_address: آدرس
     billing: پرداخت
@@ -405,7 +403,7 @@ fa:
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order no shipped units.
     cannot_perform_operation: عملیات درخواستی قابل انجام نیست
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: 
     capture: Capture
     card_code: کد کارت
     card_number: شماره کارت
@@ -413,15 +411,15 @@ fa:
     cart: سبد خرید
     categories: دسته بندی ها
     category: دسته بندی
-    check_for_spree_alerts:
+    check_for_spree_alerts: 
     checkout: تصفیه حساب
-    choose_a_customer:
+    choose_a_customer: 
     choose_currency: انتخاب واحد پول
-    choose_dashboard_locale:
+    choose_dashboard_locale: 
     city: شهر
     clone: Clone
-    close:
-    close_all_adjustments:
+    close: 
+    close_all_adjustments: 
     code: کد
     company: کمپانی
     complete: تکمیل
@@ -435,36 +433,36 @@ fa:
     continue_shopping: ادامه خرید
     cost_currency: واحد پول
     cost_price: قیمت
-    could_not_connect_to_jirafe:
-    could_not_create_stock_movement:
-    count_on_hand:
+    could_not_connect_to_jirafe: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
     countries: کشورها
     country: کشور
     country_based: بر حسب کشور
-    country_name:
+    country_name: 
     coupon: کوپن
     coupon_code: کد کوپن
-    coupon_code_already_applied:
+    coupon_code_already_applied: 
     coupon_code_applied: The coupon code was successfully applied to your order.
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
+    coupon_code_better_exists: 
+    coupon_code_expired: 
+    coupon_code_max_usage: 
+    coupon_code_not_eligible: 
+    coupon_code_not_found: 
     create: ایجاد
     create_a_new_account: ایجاد یک حساب جدید
-    created_at:
+    created_at: 
     credit: اعتبار
     credit_card: کارت اعتباری
     credit_cards: Credit Cards
     credit_owed: اعتبار مقروض
     currency: واحد پول
-    currency_decimal_mark:
+    currency_decimal_mark: 
     currency_settings: Currency Settings
     currency_symbol_position: Put currency symbol before or after dollar amount?
-    currency_thousands_separator:
+    currency_thousands_separator: 
     current: جاری
-    current_promotion_usage:
+    current_promotion_usage: 
     customer: مشتری
     customer_details: جزئیات مشتری
     customer_details_updated: The customer's details have been updated.
@@ -472,20 +470,20 @@ fa:
     cut: Cut
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: 
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 
+      format: 
+      js_format: 
     date_range: محدوده ی زمانی
     default: پیش فرض
     default_meta_description: Default Meta Description
@@ -497,26 +495,26 @@ fa:
     delivery: تحویل
     depth: عمق
     description: توضیح
-    destination:
+    destination: 
     destroy: پاک کردن
     discount_amount: مقدار تخفیف
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: نمایش
     display_currency: Display currency
     edit: ویرایش
-    editing_resource: ویرایش منابع
-    editing_rma_reason: ویرایش دلایل RMA
     editing_option_type: ویرایش نوع انتخاب
     editing_payment_method: ویرایش متد پرداخت
     editing_product: ویرایش محصول
     editing_promotion: Editing Promotion
     editing_property: ویرایش اموال
     editing_prototype: ویرایش نمونه اولیه
+    editing_resource: ویرایش منابع
+    editing_rma_reason: ویرایش دلایل RMA
     editing_shipping_category: ویرایش دسته بندی ارسال
     editing_shipping_method: ویرایش روش ارسال
     editing_state: ویرایش ایالت یا استان
-    editing_stock_location:
-    editing_stock_movement:
+    editing_stock_location: 
+    editing_stock_movement: 
     editing_tax_category: ویرایش دسته بندی مالیات
     editing_tax_rate: ویرایش نرخ مالیات
     editing_tracker: ویرایش ردگیر
@@ -526,38 +524,39 @@ fa:
     empty: خالی
     empty_cart: سبد خرید خالی شود
     enable_mail_delivery: فعال سازی تحویل نامه
-    end:
+    end: 
     ending_in: Ending in
     environment: محیط
     error: ایراد
     errors:
       messages:
-        could_not_create_taxon: "امکان ایجاد نوع دسته‌بندی وجود ندارد"
-        no_payment_methods_available:
-        no_shipping_methods_available: "ارسال برای ناحیه انتخاب شده مقدور نمی‌باشد، لطفا منطقه‌ی دیگری را انتخاب کنید"
+        could_not_create_taxon: امکان ایجاد نوع دسته‌بندی وجود ندارد
+        no_payment_methods_available: 
+        no_shipping_methods_available: ارسال برای ناحیه انتخاب شده مقدور نمی‌باشد، لطفا منطقه‌ی دیگری را انتخاب کنید
     errors_prohibited_this_record_from_being_saved:
-      one: "یک ایراد مانع از انجام ذخیره‌سازی است"
+      one: یک ایراد مانع از انجام ذخیره‌سازی است
       other: "%{count} ایراد مانع از انجام ذخیره‌سازی است"
-    event: "رویداد"
+    event: رویداد
     events:
       spree:
         cart:
-          add: "اضافه به سبد خرید"
+          add: اضافه به سبد خرید
         checkout:
-          coupon_code_added: "کد کوپن اضافه شد"
+          coupon_code_added: کد کوپن اضافه شد
         content:
-          visited:
+          visited: 
         order:
-          contents_changed: "محتویات سفارش تغییر یافت"
-        page_view:
+          contents_changed: محتویات سفارش تغییر یافت
+        page_view: 
         user:
-          signup: "ثبت‌نام کاربر"
+          signup: ثبت‌نام کاربر
     exceptions:
-      count_on_hand_setter:
+      count_on_hand_setter: 
     expiration: انقضاء
     extension: الحاقی
     filename: نام فایل
-    fill_in_customer_info:
+    fill_in_customer_info: 
+    filter: فیلتر
     filter_results: فیلتر کردن نتایج
     finalize: نهایی کردن
     first_item: هزینه اولین آیتم
@@ -581,18 +580,19 @@ fa:
     guest_user_account: تصفیه حساب به عنوان کاربر میهمان
     has_no_shipped_units: has no shipped units
     height: ارتفاع
-    hide_cents:
+    hide_cents: 
     home: صفحه اصلی
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: فارسی(fa)
     icon: آیکون
     image: تصویر
     image_settings: Image Settings
     image_settings_updated: Image Settings successfully updated.
-    image_settings_warning: You will need to regenerate thumbnails if you update the paperclip styles. Use rake paperclip:refresh:thumbnails to do this.
+    image_settings_warning: You will need to regenerate thumbnails if you update the paperclip styles. Use rake paperclip:refresh:thumbnails to
+      do this.
     images: تصاویر
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
@@ -600,15 +600,15 @@ fa:
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
-    internal_name:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: 
+    invalid_payment_provider: 
+    invalid_promotion_action: 
+    invalid_promotion_rule: 
     inventory: انبار
     inventory_adjustment: تعدیلات انبار
-    inventory_error_flash_for_insufficient_quantity:
+    inventory_error_flash_for_insufficient_quantity: 
     is_not_available_to_shipment_address: is not available to shipment address
-    iso_name:
+    iso_name: 
     item: آیتم
     item_description: توضیحات آیتم
     item_total: کل آیتم ها
@@ -616,24 +616,24 @@ fa:
       operators:
         gt: بیشتر از
         gte: بیشتر از یا مساوی با
-    items_cannot_be_shipped:
-    jirafe:
+    items_cannot_be_shipped: 
+    jirafe: 
     landing_page_rule:
       path: Path
     last_name: نام خانوادگی
     last_name_begins_with: حرف آغازین نام خانوادگی
     learn_more: Learn More
     list: لیست
-    listing_countries:
+    listing_countries: 
     listing_orders: لیست کردن سفارش ها
     listing_products: Listing Products
     listing_reports: لیست کردن گزارش ها
     listing_tax_categories: لیست کردن دسته بندی های مالیات
     listing_users: لیست کردن کاربران
     loading: در حال بارگذاری
-    locale_changed: (زبان سایت به فارسی تغییر کرد)
-    location:
-    lock:
+    locale_changed: "(زبان سایت به فارسی تغییر کرد)"
+    location: 
+    lock: 
     logged_in_as: شما وارد شدید به عنوان
     logged_in_succesfully: ورود موفقیت آمیز بود
     logged_out: شما خارج شدید
@@ -644,7 +644,7 @@ fa:
     logout: خروج
     look_for_similar_items: جستجوی اقلام مشابه
     maestro_or_solo_cards: Maestro/Solo cards
-    mail_method_settings:
+    mail_method_settings: 
     mail_methods: متدهای نامه
     make_refund: Make refund
     master_price: قیمت اصلی
@@ -658,7 +658,7 @@ fa:
     minimal_amount: حداقل مقدار
     month: ماه
     more: بیشتر
-    move_stock_between_locations:
+    move_stock_between_locations: 
     my_account: حساب من
     my_orders: سفارش های من
     name: نام
@@ -682,9 +682,9 @@ fa:
     new_shipping_category: دسته بندی ارسال جدید
     new_shipping_method: متد ارسال جدید
     new_state: ایالت جدید
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: 
+    new_stock_movement: 
+    new_stock_transfer: 
     new_tax_category: دسته بندی مالیات جدید
     new_tax_rate: نرخ مالیات جدید
     new_taxon: دسته جدید
@@ -694,25 +694,25 @@ fa:
     new_variant: New Variant
     new_zone: ناحیه جدید
     next: بعدی
-    no_actions_added:
-    no_orders_found:
-    no_payment_methods_found:
-    no_pending_payments:
+    no_actions_added: 
+    no_orders_found: 
+    no_payment_methods_found: 
+    no_pending_payments: 
     no_products_found: هیچ محصولی یافت نشد
-    no_promotions_found:
-    no_resource_found:
+    no_promotions_found: 
+    no_resource_found: 
     no_results: بدون نتیجه
     no_rules_added: هیچ قانونی اضافه نشده
-    no_shipping_methods_found:
-    no_stock_locations_found:
-    no_trackers_found:
-    no_tracking_present:
+    no_shipping_methods_found: 
+    no_stock_locations_found: 
+    no_trackers_found: 
+    no_tracking_present: 
     none: هیچکدام
     normal_amount: مقدار نرمال
     not: not
     not_available: N/A
-    not_enough_stock:
-    not_found: ! '%{resource} is not found'
+    not_enough_stock: 
+    not_found: "%{resource} is not found"
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: محصول حذف شد
@@ -721,39 +721,39 @@ fa:
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
     on_hand: On Hand
-    open:
-    open_all_adjustments:
+    open: 
+    open_all_adjustments: 
     option_type: نوع اختیار
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: انواع اختیارات
     option_value: مقدار
     option_values: مقادیر
     optional: اختیاری
     options: اختیارات
     or: یا
-    or_over_price: ! '%{price} or over'
+    or_over_price: "%{price} or over"
     order: سفارش
     order_adjustments: Order adjustments
     order_details: جزئیات سفارش
     order_email_resent: Order Email Resent
-    order_information:
+    order_information: 
     order_mailer:
       cancel_email:
         dear_customer: مشتری محترم,
         instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
         subject: لغو سفارش
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: مشتری محترم,
         instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
         subject: تایید سفارش
-        subtotal:
+        subtotal: 
         thanks: از خرید شما متشکریم.
-        total:
-    order_not_found:
+        total: 
+    order_not_found: 
     order_number: سفارش
     order_processed_successfully: سفارش شما به طور موفقیت‌آمیز ثبت شد.
     order_state:
@@ -768,17 +768,17 @@ fa:
       resumed: ادامه
       returned: برگشت خورد
     order_summary: خلاصه سفارش
-    order_sure_want_to:
+    order_sure_want_to: 
     order_total: کل سفارش
     order_updated: سفارش بروز رسانی شد
     orders: سفارشات
     out_of_stock: موجودی نداریم
     overview: مرور کلی
-    package_from:
+    package_from: 
     pagination:
       next_page: next page &raquo;
-      previous_page: ! '&laquo; previous page'
-      truncate: ! '&hellip;'
+      previous_page: "&laquo; previous page"
+      truncate: "&hellip;"
     password: رمز عبور
     paste: Paste
     path: Path
@@ -786,7 +786,7 @@ fa:
     payment: پرداخت
     payment_information: اطلاعات پرداخت
     payment_method: روش پرداخت
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: روش های پرداخت
     payment_processing_failed: پردازش پرداخت با مشکل مواجه شد. لطفا اطلاعات ورودی خود را کنترل کنید
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -804,7 +804,7 @@ fa:
       void: void
     payment_updated: پرداخت بروز رسانی شد
     payments: پرداخت ها
-    percent:
+    percent: 
     percent_per_item: Percent Per Item
     permalink: Permalink
     phone: تلفن
@@ -821,64 +821,64 @@ fa:
     product: محصول
     product_details: اطلاعات محصول
     product_has_no_description: این محصول فاقد توضیحات است
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: ویژگی های محصول
     product_rule:
-      choose_products: "محصول‌ها را انتخاب کنید"
-      label:
-      match_all: "همه"
-      match_any: "حداقل یکی"
-      match_none:
+      choose_products: محصول‌ها را انتخاب کنید
+      label: 
+      match_all: همه
+      match_any: حداقل یکی
+      match_none: 
       product_source:
         group: از گروه محصول
         manual: انتخاب دستی
     products: محصولات
-    promotion: "فروش ویژه"
+    promotion: فروش ویژه
     promotion_action: فروش ویژه فعال
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: 
+        name: 
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: 
+        name: 
+    promotion_actions: 
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: 
+        any: 
+    promotion_rule: 
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: 
+        name: 
       item_total:
-        description:
-        name:
+        description: 
+        name: 
       landing_page:
-        description:
-        name:
+        description: 
+        name: 
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description:
-        name:
+        description: 
+        name: 
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
-        description:
-        name:
+        description: 
+        name: 
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
@@ -890,19 +890,20 @@ fa:
     provider: فراهم آورنده
     provider_settings_warning: If you are changing the provider type, you must save first before you can edit the provider settings
     qty: تعداد
-    quantity:
+    quantity: 
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
+    quick_search: جستوجو سریع . . .
     rate: Rate
     reason: Reason
     receive: receive
-    receive_stock:
+    receive_stock: 
     received: دریافت شد
     reference: ارجاع
+    refund: استرداد
     refund_amount_must_be_greater_than_zero: مقدار بازپرداخت باید از صفر بیشتر باشد
     refund_reasons: دلیل استرداد
     refunded_amount: مقدار استرداد
-    refund: استرداد
     register: به عنوان کاربر جدید ثبت نام کنید
     registration: ثبت نام
     remember_me: من را به یاد بسپار
@@ -925,14 +926,14 @@ fa:
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
-    roles: "نقش ها"
+    roles: نقش ها
     rules: قوانین
-    safe: مطمئن
     s3_access_key: Access Key
     s3_bucket: Bucket
     s3_headers: S3 Headers
     s3_protocol: S3 Protocol
     s3_secret: Secret Key
+    safe: مطمئن
     sales_total: کل فروش
     sales_total_description: کل فروش برای همه سفارش ها
     sales_totals: کلیه فروش ها
@@ -947,7 +948,7 @@ fa:
     security_settings: تنظیمات امنیتی
     select: انتخاب
     select_from_prototype: از نمونه اولیه انتخاب کن
-    select_stock:
+    select_stock: 
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
     server: سرور
@@ -955,8 +956,8 @@ fa:
     settings: تنظیمات
     ship: ارسال
     ship_address: Ship Address
-    ship_total:
-    shipment:
+    ship_total: 
+    shipment: 
     shipment_inc_vat: Shipment including VAT
     shipment_mailer:
       shipped_email:
@@ -965,8 +966,8 @@ fa:
         shipment_summary: Shipment Summary
         subject: Shipment Notification
         thanks: Thank you for your business.
-        track_information: ! 'Tracking Information: %{tracking}'
-        track_link:
+        track_information: 'Tracking Information: %{tracking}'
+        track_link: 
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder
@@ -980,20 +981,20 @@ fa:
     shipping_address: آدرس ارسال
     shipping_categories: دسته بندی های ارسال
     shipping_category: دسته بندی ارسال
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
     shipping_instructions: دستورالعمل های ارسال
     shipping_method: روش ارسال
     shipping_methods: روش های ارسال
-    shipping_price_sack:
+    shipping_price_sack: 
     shop_by_taxonomy: خرید بر حسب %{taxonomy}
     shopping_cart: سبد خرید
     show: نمایش
     show_active: Show Active
     show_deleted: Show Deleted
     show_only_complete_orders: نمایش سفارشات تکمیل شده
-    show_rate_in_label:
+    show_rate_in_label: 
     sku: کد کالا
     smtp: SMTP
     smtp_authentication_type: SMTP Authentication Type
@@ -1004,27 +1005,27 @@ fa:
     smtp_send_all_emails_as_from_following_address: تمام نامه ها را از آدرس ذیل ارسال کن
     smtp_send_copy_to_this_addresses: Sends a copy of all outgoing mails to this address. For multiple addresses, separate with commas.
     smtp_username: SMTP Username
-    source:
+    source: 
     special_instructions: ساختارهای خاص
-    split:
+    split: 
     spree/order:
-      coupon_code:
+      coupon_code: 
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     start: شروع
     start_date: Valid from
     state: ایالت یا استان
     state_based: State Based
     states: ایالات یا استان ها
-    states_required:
+    states_required: 
     status: وضعیت
     stock_location: مکان انبار
     stock_location_info: توضیحات انبار
     stock_locations: مکان انبارها
     stock_management: مدیریت انبار
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
     stock_transfer: ترخیص از انبار
     stock_transfers: ترخیص ها از انبار
     stop: توقف
@@ -1033,25 +1034,25 @@ fa:
     street_address_2: ادامه آدرس
     subtotal: جمع
     subtract: Subtract
-    successfully_created: ! '%{resource} با موفقیت اضافه شد!'
-    successfully_removed: ! '%{resource} با موفقیت حذف شد!'
-    successfully_signed_up_for_analytics:
-    successfully_updated: ! '%{resource} با موفقیت به روز رسانی شد!'
+    successfully_created: "%{resource} با موفقیت اضافه شد!"
+    successfully_removed: "%{resource} با موفقیت حذف شد!"
+    successfully_signed_up_for_analytics: 
+    successfully_updated: "%{resource} با موفقیت به روز رسانی شد!"
     tax: مالیات
     tax_categories: دسته بندی های مالیات
     tax_category: دسته بندی مالیات
-    tax_rate_amount_explanation:
+    tax_rate_amount_explanation: 
     tax_rates: نرخ مالیات
     tax_settings: تنظیمات مالیات
     tax_total: کل مالیات
     taxon: دسته
     taxon_edit: ویرایش دسته
-    taxon_placeholder:
+    taxon_placeholder: 
     taxonomies: رده‌بندی‌ها
     taxonomy: رده‌بندی
     taxonomy_edit: ویرایش طبقه بندی
     taxonomy_tree_error: The requested change has not been accepted and the tree has been returned to its previous state, please try again.
-    taxonomy_tree_instruction: ! '* Right click a child in the tree to access the menu for adding, deleting or sorting a child.'
+    taxonomy_tree_instruction: "* Right click a child in the tree to access the menu for adding, deleting or sorting a child."
     taxons: گونه ها
     test: تست
     test_mailer:
@@ -1061,27 +1062,27 @@ fa:
         subject: Testmail
     test_mode: مد تست
     thank_you_for_your_order: با تشکر، لطفا یک کپی از این صفحه برای نگهداری در نزد خود، پرینت کنید
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: به مشکلاتی در فیلدهای ذیل برخوردیم
     thumbnail: Thumbnail
-    time:
+    time: 
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: کل
     tracking: ردگیری
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
     tree: Tree
     type: نوع
     type_to_search: Type to search
     unable_to_connect_to_gateway: اتصال به درگاه مقدور نیست
     under_price: Under %{price}
-    unlock:
+    unlock: 
     unrecognized_card_type: نوع کارت ناشناخته
-    unshippable_items:
+    unshippable_items: 
     update: بروز رسانی
     updating: در حال بروز رسانی
     usage_limit: محدودیت استفاده
@@ -1090,18 +1091,18 @@ fa:
     use_s3: Use Amazon S3 For Images
     user: کاربر
     user_rule:
-      choose_users: "انتخاب کاربرها"
-    users: "کاربرها"
+      choose_users: انتخاب کاربرها
+    users: کاربرها
     validation:
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
       cannot_destory_line_item_as_inventory_units_have_shipped: Cannot destory line item as some inventory units have shipped.
-      exceeds_available_stock:
+      exceeds_available_stock: 
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: باید به صورت عدد صحیح وارد شوند
       must_be_non_negative: must be a non-negative value
     value: مقدار
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: 
     variants: Variants
     version: نسخه
     void: Void
@@ -1112,8 +1113,8 @@ fa:
     year: سال
     you_have_no_orders_yet: شما هنوز سفارشی ثبت نکرده اید
     your_cart_is_empty: سبد خرید شما خالی است
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: 
     zip: کد پستی
-    zipcode:
+    zipcode: 
     zone: ناحیه
     zones: ناحیه ها

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,3 +1,4 @@
+---
 fi:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ fi:
         state: Osavaltio tai maakunta
         zipcode: Postinumero
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +25,10 @@ fi:
         name: Nimi
         numcode: ISO-koodi
       spree/credit_card:
-        base:
+        base: 
         cc_type: Tyyppi
         month: Kuukausi
-        name:
+        name: 
         number: Numero
         verification_value: Tarkistuskoodi
         year: Vuosi
@@ -42,7 +43,7 @@ fi:
       spree/order:
         checkout_complete: Tilaus valmis
         completed_at: Valmistui
-        considered_risky:
+        considered_risky: 
         coupon_code: Kupongin koodi
         created_at: Tilauspäivä
         email: Asiakkaan sähköposti
@@ -95,7 +96,7 @@ fi:
         starts_at: Alkaa
         usage_limit: Käyttöraja
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Nimi
         presentation: Julkinen nimi
@@ -109,20 +110,20 @@ fi:
         abbr: Lyhenne
         name: Nimi
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Kuvaus
         name: Nimi
@@ -157,47 +158,47 @@ fi:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: Kortti on vanhentunut
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Osoite
@@ -208,15 +209,15 @@ fi:
       spree/credit_card:
         one: Luottokortti
         other: Luottokortit
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Myyntiyksikkö
         other: Myyntiyksikköä
       spree/line_item:
         one: Tuoterivi
         other: Tuoterivit
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Tilaus
         other: Tilaukset
@@ -232,20 +233,20 @@ fi:
       spree/promotion:
         one: Kampanja
         other: Kampanjat
-      spree/promotion_category:
+      spree/promotion_category: 
       spree/property:
         one: Ominaisuus
         other: Ominaisuudet
       spree/prototype:
         one: Prototyyppi
         other: Prototyypit
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Asiakaspalautus
         other: Asiakaspalautukset
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Rooli
         other: Roolit
@@ -261,11 +262,11 @@ fi:
       spree/state:
         one: Osavalitio
         other: Osavaltiot
-      spree/state_change:
+      spree/state_change: 
       spree/stock_location:
         one: Varasto
         other: Varastot
-      spree/stock_movement:
+      spree/stock_movement: 
       spree/stock_transfer:
         one: Varastosiirto
         other: Varastosiirrot
@@ -295,10 +296,10 @@ fi:
         other: Alueet
   spree:
     abbreviation: Lyhenne
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Tili
     account_updated: Tilin tiedot päivitetty
     action: Toimenpide
@@ -311,7 +312,7 @@ fi:
       list: Lista
       listing: Listataan
       new: Uusi
-      refund:
+      refund: 
       save: Tallenna
       update: Päivitä
     activate: Ota käyttöön
@@ -319,7 +320,7 @@ fi:
     add: Lisää
     add_action_of_type: Lisää toimintotyyppi
     add_country: Lisää maa
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Lisää uusi otsikko
     add_new_style: Lisää uusi tyyli
     add_one: Lisää yksi
@@ -335,7 +336,7 @@ fi:
     additional_item: Ylimääräiset kulut
     address1: Osoite
     address2: Osoite (jatkuu)
-    adjustable:
+    adjustable: 
     adjustment: Hintamuutos
     adjustment_amount: Summa
     adjustment_successfully_closed: Hintamuutos on nyt suljettu!
@@ -345,36 +346,36 @@ fi:
     admin:
       tab:
         configuration: Konfigurointi
-        option_types:
+        option_types: 
         orders: Tilaukset
         overview: Yleiskatsaus
         products: Tuotteet
+        promotion_categories: 
         promotions: Kampanjat
-        promotion_categories:
-        properties:
-        prototypes:
+        properties: 
+        prototypes: 
         reports: Raportit
-        taxonomies:
-        taxons:
+        taxonomies: 
+        taxons: 
         users: Käyttäjät
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Hallinnointi
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Hyväksy rekisteriselosteen ehdot
     agree_to_terms_of_service: Hyväksy käyttöehdot
     all: Kaikki
     all_adjustments_closed: Kaikki hintamuutokset on suljettiin!
     all_adjustments_opened: Kaikki hintamuutokset avattiin!
     all_departments: Kaikki tuoteryhmät
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Salli SSL-suojauksen käyttö kehitys- ja testiympäristöissä
     allow_ssl_in_production: Salli SSL-suojauksen käyttö tuotantoympäristössä
     allow_ssl_in_staging: Allow SSL to be used in staging mode
@@ -390,71 +391,71 @@ fi:
     analytics_desc_list_4: Se on täysin ilmainen!
     analytics_trackers: Tilastoinnin seurantakoodit
     and: ja
-    approve:
-    approved_at:
-    approver:
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Oletko varma?
     are_you_sure_delete: Haluatko varmasti poistaa tämän tiedon?
     associated_adjustment_closed: Tähän liitetty hintamuutos on suljettu, joten sitä ei huomioida laskuissa. Haluatko avata sen?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Valtuutus epäonnistui
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Saatavilla
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Takaisin
     back_end: Backend
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Takaisin kauppaan
     back_to_users_list: Takaisin käyttäjäluetteloon
     backorderable: Jälkitoimitus sallittu
-    backorderable_default:
-    backordered:
+    backorderable_default: 
+    backordered: 
     backorders_allowed: Jälkitoimitukset sallittu
     balance_due: Erääntyvät
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Laskun osoite
     billing: Laskutus
     billing_address: Laskutusosoite
     both: Molemmat
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Laskin
     calculator_settings_warning: Mikäli vaihdat laskimen tyyppiä, sinun täytyy ensin tallentaa ennen kuin voit muuttaa laskimen asetuksia
     cancel: peruuta
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: Et voi luoda maksua tilaukselle ilman että mitään maksutapoja on määritelty.
     cannot_create_returns: Palautuksia ei voida luoda, koska tilausta ei ole vielä lähetetty.
     cannot_perform_operation: Pyydettyä toimitoa ei voida suorittaa.
     cannot_set_shipping_method_without_address: Toimitustapaa ei voi valita ennen kuin asiakastiedot on annettu.
     capture: Kuittaa maksetuksi
-    capture_events:
+    capture_events: 
     card_code: Kortin koodi
     card_number: Kortin numero
-    card_type:
+    card_type: 
     card_type_is: Kortin tyyppi on
     cart: Ostoskori
-    cart_subtotal:
+    cart_subtotal: 
     categories: Kategoriat
     category: Kategoria
-    charged:
+    charged: 
     check_for_spree_alerts: Tarkasta Spreen varoitukset
     checkout: Kassa
     choose_a_customer: Valitse asiakas
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Valitse valuutta
     choose_dashboard_locale: Valitse hallintapaneelin kieli
-    choose_location:
+    choose_location: 
     city: Postitoimipaikka
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Klooni
     close: Sulje
     close_all_adjustments: Sulje kaikki hintamuutokset
@@ -471,7 +472,7 @@ fi:
     cost_currency: Maksuvaluutta
     cost_price: Kustannushinta
     could_not_connect_to_jirafe: Tietojen päivittäminen Jirafeen epäonnistui. Yritetään automaattisesti myöhemmin uudelleen.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: Varaston siirron tallentamisessa tapahtui jokin virhe. Yritä uudelleen.
     count_on_hand: Määrä varastossa
     countries: Maat
@@ -479,10 +480,10 @@ fi:
     country_based: Sijaintimaa
     country_name: Nimi
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Kuponki
     coupon_code: Tarjouskoodi
     coupon_code_already_applied: Kampanjakoodi on jo käytössä tällä tilauksella
@@ -492,17 +493,17 @@ fi:
     coupon_code_max_usage: Kaikki kampanjakoodit on jo käytetty
     coupon_code_not_eligible: Kampanjakoodi ei ole käytettävissä tälle tilaukselle
     coupon_code_not_found: Näppäilemääsi kampanjakoodia ei löytynyt. Yritä uudelleen.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Luo
     create_a_new_account: Tee uusi tili
-    create_new_order:
-    create_reimbursement:
+    create_new_order: 
+    create_reimbursement: 
     created_at: Luotu
     credit: Luotto
     credit_card: Luottokortti
     credit_cards: Luottokortit
     credit_owed: Veloittamatta
-    credits:
+    credits: 
     currency: Valuutta
     currency_decimal_mark: Valuutan desimaalien erotin
     currency_settings: Valuutta-asetukset
@@ -513,11 +514,11 @@ fi:
     customer: Asiakas
     customer_details: Asiakastiedot
     customer_details_updated: Asiakkaan tiedot on päivitetty.
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Asiakashaku
     cut: Leikkaa
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: App ID
@@ -536,41 +537,41 @@ fi:
       js_format: dd.mm.yy
     date_range: Päivämäärä (mistä mihin)
     default: Oletus
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Oletusvero
     default_tax_zone: Default Tax Zone
     delete: Poista
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Toimitus
     depth: Syvyys
     description: Kuvaus
     destination: Kohde
     destroy: Tuhoa
-    details:
+    details: 
     discount_amount: Alennuksen määrä
     dismiss_banner: Ei kiitos! En ole kiinnostunut, älä näytä tätä viestiä uudelleen.
     display: Näytä
     display_currency: Näytä valuutta
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Muokkaa
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Muokataan käyttäjää
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Sähköposti
     empty: Tyhjä
     empty_cart: Tyhjennä ostoskori
@@ -602,20 +603,22 @@ fi:
         user:
           signup: Käyttäjän rekisteröityminen
     exceptions:
-      count_on_hand_setter: 'Ei voida asettaa count_on_hand -tietoa manuaalisesti, koska recalculate_count_on_hand -callback asettaa sen automaattisesti. Käytä sen seuraavaa: update_column(:count_on_hand, value)'
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: >-
+        Ei voida asettaa count_on_hand -tietoa manuaalisesti, koska recalculate_count_on_hand -callback asettaa sen automaattisesti. Käytä sen
+        seuraavaa: update_column(:count_on_hand, value)
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Erääntyminen
     extension: Laajennus
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Tiedostonimi
     fill_in_customer_info: Täytä asiakastiedot
     filter_results: Suodata tuloksia
     finalize: Viimeistele
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: Ensimmäisen tuotteen kulut
     first_name: Etunimi
     first_name_begins_with: Etunimi alkaa
@@ -624,7 +627,7 @@ fi:
     flexible_rate: Joustava hinta
     forgot_password: Unohdettu salasana
     free_shipping: Ilmainen toimitus
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Front End
     gateway: Yhdyskäytävä
     gateway_config_unavailable: Yhdyskäytävä ei ole saatavilla ympäristöön
@@ -645,33 +648,33 @@ fi:
       localization_settings: Lokalisointiasetukset
       this_file_language: Suomi
     icon: Kuvake
-    identifier:
+    identifier: 
     image: Kuva
     images: Kuvat
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Sisällytetty hintaan
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Täytä alla oleva lomake, ja ohjeet salasanan palauttamiseksi lähetetään sähköpostilla:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Sisäinen nimi
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Virheellinen maksutavan tarjoaja.
     invalid_promotion_action: Virheellinen kampanjan toiminto.
     invalid_promotion_rule: Virheellinen kampanjan sääntö.
     inventory: Varasto
     inventory_adjustment: Varaston muutos
     inventory_error_flash_for_insufficient_quantity: Ostoskorissasi oleva tuote ei valitettavasti ole enää saatavilla.
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: ei ole saatavilla toimitusosoitteeseen
     iso_name: ISO-nimi
     item: Tuote
@@ -681,26 +684,26 @@ fi:
       operators:
         gt: suurempi kuin
         gte: suurempi tai yhtäsuuri kuin
-        lt:
-        lte:
+        lt: 
+        lte: 
     items_cannot_be_shipped: Toimituskulujen laskeminen näille tuotteille ei onnistunut.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Polku
     last_name: Sukunimi
     last_name_begins_with: Sukunimi alkaa
     learn_more: Lue lisää
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Lista
     loading: Ladataan
     locale_changed: Lokalisointi vaihdettu
     location: Sijainti
     lock: Lukitse
-    log_entries:
+    log_entries: 
     logged_in_as: Kirjauduttu
     logged_in_succesfully: Kirjauduttu onnistuneesti
     logged_out: Olet kirjautunut ulos.
@@ -709,23 +712,23 @@ fi:
     login_failed: Kirjautumisen autentikointi epäonnistui.
     login_name: Nimi
     logout: Kirjaudu ulos
-    logs:
+    logs: 
     look_for_similar_items: Etsi samanlaisia tuotteita
     make_refund: Tee hyvitys
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Toimitushinta
     match_choices:
       all: Kaikki
       none: Ei mitään
     max_items: Tuotteiden enimmäismäärä
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Meta-kuvaus
     meta_keywords: Meta-avainsanat
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Vähimmäismäärä
     month: Kuukausi
@@ -734,13 +737,13 @@ fi:
     my_account: Oma tili
     my_orders: Tilaukseni
     name: Nimi
-    name_on_card:
+    name_on_card: 
     name_or_sku: Nimi tai SKU
     new: Uusi
     new_adjustment: Uusi hintamuutos
-    new_country:
+    new_country: 
     new_customer: Uusi asiakas
-    new_customer_return:
+    new_customer_return: 
     new_image: Uusi kuva
     new_option_type: Uusi valintatyyppi
     new_order: Uusi tilaus
@@ -749,14 +752,14 @@ fi:
     new_payment_method: Uusi maksutapa
     new_product: Uusi tuote
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Uusi ominaisuus
     new_prototype: Uusi prototyyppi
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Uusi asiakaspalautus
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Uusi toimituskategoria
     new_shipping_method: Uusi toimitustapa
     new_state: Uusi osavaltio
@@ -773,24 +776,24 @@ fi:
     new_zone: Uusi alue
     next: Seuraava
     no_actions_added: Toimintoja ei lisätty
-    no_payment_found:
+    no_payment_found: 
     no_pending_payments: Ei maksuja odottamassa
     no_products_found: Ei löytynyt tuotteita
     no_resource_found: Kohdetta %{resource} ei löytynyt
     no_results: Ei tuloksia
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: Sääntöjä ei lisätty
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: Seurantatietoja ei ole annettu.
     none: Ei yhtäkään
-    none_selected:
+    none_selected: 
     normal_amount: Normaali määrä
     not: ei
     not_available: N/A
     not_enough_stock: Varastossa josta tuotteet pitäisi lähettää ei ole tarpeeksi montaa tuotetta siirron suorittamiseksi.
     not_found: "%{resource} ei löytynyt"
-    note:
+    note: 
     notice_messages:
       product_cloned: Tuote kloonattu
       product_deleted: Tuote poistettu
@@ -798,7 +801,7 @@ fi:
       product_not_deleted: Tuotetta ei voitu poistaa
       variant_deleted: Variantti poistettu
       variant_not_deleted: Varianttia ei voitu poistaa
-    num_orders:
+    num_orders: 
     on_hand: Saatavilla
     open: Avaa
     open_all_adjustments: Avaa kaikki hintamuutokset
@@ -813,9 +816,9 @@ fi:
     or_over_price: "%{price} or over"
     order: Tilaus
     order_adjustments: Tilauksen hintamuutokset
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Tilauksen tiedot
     order_email_resent: Tilausviesti uudelleenlähetetty
     order_information: Tilauksen tiedot
@@ -825,24 +828,24 @@ fi:
         instructions: Tilauksesi on PERUUTETTU. Ole hyvä ja pidä tämä peruutusvahvistus tallessa.
         order_summary_canceled: Tilauksen yhteenveto [PERUUTETTU]
         subject: Tilauksen peruutus
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Dear Customer,\n
         instructions: Ole hyvä ja pidä tilauksen tiedot tallessa.
         order_summary: Tilauksen yhteenveto
         subject: Tilausvahvistus
-        subtotal:
+        subtotal: 
         thanks: Thank you for your business.
-        total:
+        total: 
     order_not_found: Tilaustasi ei löytynyt näillä tiedoilla. Yritä ystävällisesti uudelleen.
-    order_number:
+    order_number: 
     order_populator:
       out_of_stock: "%{item} on loppunut varastosta."
       please_enter_reasonable_quantity: Anna joku kohtuullinen määrä.
-      selected_quantity_not_available:
+      selected_quantity_not_available: 
     order_processed_successfully: Tilauksenne käsitelty onnistuneesti
-    order_resumed:
+    order_resumed: 
     order_state:
       address: osoite
       awaiting_return: odottaa palautusta
@@ -850,7 +853,7 @@ fi:
       cart: ostoskori
       complete: valmis
       confirm: vahvista
-      considered_risky:
+      considered_risky: 
       delivery: toimitus
       payment: maksu
       resumed: resumed
@@ -860,7 +863,7 @@ fi:
     order_total: Tilaus yhteensä
     order_updated: Tilaus päivitetty
     orders: Tilaukset
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Ei saatavilla
     overview: Yleiskuva
     package_from: lähetys varastosta
@@ -873,8 +876,8 @@ fi:
     path: Polku
     pay: maksa
     payment: Maksu
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Maksun tiedot
     payment_method: Maksutapa
     payment_method_not_supported: Tätä maksutapaa ei voida hyväksyä. Valitse joku toinen maksutapa.
@@ -895,7 +898,7 @@ fi:
       void: mitätön
     payment_updated: Maksu päivitetty
     payments: Maksut
-    pending:
+    pending: 
     percent: Prosentti
     percent_per_item: Percent Per Item
     permalink: Permalink
@@ -904,13 +907,13 @@ fi:
     please_define_payment_methods: Ole hyvä ja määrittele ensin joitakin maksutapoja.
     populate_get_error: Jokin meni pieleen. Ole hyvä ja yritä lisätä tuotetta uudelleen.
     powered_by: Palvelun tarjoaa
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Esitys
     previous: Edellinen
-    previous_state_missing:
+    previous_state_missing: 
     price: Hinta
     price_range: Price Range
     price_sack: Price Sack
@@ -922,10 +925,10 @@ fi:
     product_properties: Tuotteen ominaisuudet
     product_rule:
       choose_products: Valitse tuotteet
-      label:
+      label: 
       match_all: kaikki
       match_any: ainakin yksi
-      match_none:
+      match_none: 
       product_source:
         group: Tuoteryhmästä
         manual: Valitse
@@ -937,14 +940,14 @@ fi:
         description: Luo tilaukselle hintamuutoksen kampanjan avulla
         name: Uusi hintamuutos
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Populates the cart with the specified quantity of variant
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Actions
     promotion_form:
       match_policies:
@@ -962,27 +965,27 @@ fi:
         description: Asiakkaan on täytynyt vierailla tietyllä sivulla
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Tilaus sisältää määritellyt tuotteet
         name: Tuotteet
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Saatavilla vain määritellyille käyttäjille
         name: Käyttäjä
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Kampanjat
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Ominaisuudet
     property: Ominaisuus
     prototype: Prototyyppi
@@ -993,46 +996,46 @@ fi:
     quantity: Määrä
     quantity_returned: Palautettu määrä
     quantity_shipped: Toimitettu määrä
-    quick_search:
+    quick_search: 
     rate: Taso
     reason: Syy
     receive: vastaanota
     receive_stock: Varastoon
     received: Vastaanotettu
-    reception_status:
+    reception_status: 
     reference: Viite
     refund: Hyvitä
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Rekisteröidy uutena käyttäjänä
     registration: Rekisteröityminen
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Muista minut
     remove: Poista
     rename: Nimeä uudelleen
-    report:
+    report: 
     reports: Raportit
     resend: Lähetä uudelleen
     reset_password: Palauta salasana
@@ -1041,34 +1044,34 @@ fi:
     resumed: Jatkettu
     return: palaa
     return_authorization: Asiakaspalautus
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Asiakaspalautus päivitetty
     return_authorizations: Asiakaspalautukset
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Palautettava määrä
     returned: Palattu
-    returns:
+    returns: 
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA Credit
     rma_number: Palautusnumero (RMA)
     rma_value: Palautusnumeron arvo
     roles: Roolit
     rules: Säännöt
-    safe:
+    safe: 
     sales_total: Kokonaismyynti
     sales_total_description: Kaikkien tilausten kokonaismyynti
     sales_totals: Myynti yhteensä
     save_and_continue: Tallenna ja jatka
-    save_my_address:
+    save_my_address: 
     say_no: Ei
     say_yes: Kyllä
     scope: Laajuus
@@ -1078,8 +1081,8 @@ fi:
     secure_connection_type: Turvallinen yhteystyyppi
     security_settings: Turvallisuusasetukset
     select: Valitse
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Valitse prototyypistä
     select_stock: Valitse varasto
     send_copy_of_all_mails_to: Lähetä kopio kaikista sähköposteista
@@ -1091,8 +1094,8 @@ fi:
     ship_address: Toimitusosoite
     ship_total: Toimitus yhteensä
     shipment: Toimitus
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Hyvä asiakkaamme,\n
@@ -1105,13 +1108,13 @@ fi:
     shipment_state: Toimituksen tila
     shipment_states:
       backorder: jälkitoimitus
-      canceled:
+      canceled: 
       partial: vajaa
       pending: odottava
       ready: valmis
       shipped: toimitettu
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Toimitukset
     shipped: Toimitettu
     shipping: Toimitus
@@ -1125,67 +1128,67 @@ fi:
     shipping_method: Toimitustapa
     shipping_methods: Toimitustavat
     shipping_price_sack: Hintasäkki
-    shipping_total:
+    shipping_total: 
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: Ostoskori
     show: Näytä
     show_active: Näytä aktiiviset
     show_deleted: Näytä poistetut
     show_only_complete_orders: Näytä vain valmiit tilaukset
-    show_only_considered_risky:
+    show_only_considered_risky: 
     show_rate_in_label: Näytä vero hinnoissa
     sku: SKU
-    skus:
-    slug:
+    skus: 
+    slug: 
     source: Lähde
     special_instructions: Erityisohjeet
     split: Jaa osiin
     spree_gateway_error_flash_for_checkout: Maksusi tiedoissa oli virhe. Ole hyvä ja tarkista tiedot, ja yritä uudelleen.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Alku
     state: Osavaltio
     state_based: Sijaintilääni/-osavaltio
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Läänit/osavaltiot
     states_required: Maakunta vaaditaan
     status: Tila
-    stock:
+    stock: 
     stock_location: Varaston sijainti
     stock_location_info: Varaston tiedot
     stock_locations: Varastot
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Varastonhallinta
     stock_management_requires_a_stock_location: Luo ensin varasto, että voit hallita varastotilannetta.
     stock_movements: Varastosiirrot
@@ -1199,28 +1202,28 @@ fi:
     street_address_2: Katuosoite (jatkoa)
     subtotal: Summa
     subtract: Vähennä
-    success:
+    success: 
     successfully_created: "%{resource} luonti onnistui!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} poisto onnistui!"
     successfully_signed_up_for_analytics: Rekisteröidytty Spree Analyticsiin
     successfully_updated: "%{resource} päivitys onnistui!"
-    summary:
+    summary: 
     tax: Vero
     tax_categories: Verokategoriat
     tax_category: Verokategoria
-    tax_code:
-    tax_included:
+    tax_code: 
+    tax_included: 
     tax_rate_amount_explanation: Veroprosentit ilmoitetaan desimaalin sadasosina helpottamaan laskemista, (esim. 5% ilmoitetaan 0.05)
     tax_rates: Veroprosentit
     taxon: Taksoni
     taxon_edit: Muokkaa taksonia
     taxon_placeholder: Lisää taksoni
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taksonomiat
     taxonomy: Taxonomy
     taxonomy_edit: Muokkaa taksonomiaa
@@ -1237,24 +1240,24 @@ fi:
     thank_you_for_your_order: Kiitos tilauksestasi! Tulosta tarvittaessa kopio tästä vahvistuksesta.
     there_are_no_items_for_this_order: Tilaus ei sisällä yhtään tuotetta. Lisää tuote jatkaaksesi tästä eteenpäin.
     there_were_problems_with_the_following_fields: Seuraavissa kentissä oli virhe
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Näytekuva
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Aika
     to_add_variants_you_must_first_define: Ennen variantin lisäämistä sinun tulee määritellä
     total: Yhteensä
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Seuranta
     tracking_number: Seurantatunnus
     tracking_url: Seurantaosoite
     tracking_url_placeholder: esim. https://ohjelmat.posti.fi/Saapumisilmoitus/fi/:tracking
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Siirto varastosta
     transfer_stock: Tee varastosiirto
     transfer_to_location: Siirrä varastoon
@@ -1262,7 +1265,7 @@ fi:
     type: Tyyppi
     type_to_search: Type to search
     unable_to_connect_to_gateway: Ei saatu yhteyttä yhdyskäytävään
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
     unlock: Avaa lukitus
     unrecognized_card_type: Tunnistamaton korttityyppi
@@ -1270,7 +1273,7 @@ fi:
     update: Päivitä
     updating: Päivitetään
     usage_limit: Käyttöraja
-    use_app_default:
+    use_app_default: 
     use_billing_address: Käytä laskutusosoitetta
     use_new_cc: Käytä uutta korttia
     use_s3: Käytä Amazon S3:a kuvia varten
@@ -1280,12 +1283,12 @@ fi:
     users: Käyttäjät
     validation:
       cannot_be_less_than_shipped_units: ei voi olla pienempi kuin toimitettu määrä.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: ylittää nykyisen varastotilanteen. Varmista tuoterivien oikea kappalemäärä.
       is_too_large: on liian iso -- varastossa ei riittävästi tuotteita
       must_be_int: täytyy olla kokonaisluku
       must_be_non_negative: täytyy olla ei-negatiivinen
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Arvo
     variant: Variantti
     variant_placeholder: Valitse variantti

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,21 +1,22 @@
+---
 fr:
   activemodel:
     attributes:
       spree/order_cancellations:
-        quantity: Quantité
-        state: Statut
-        shipment: Livraison
         cancel: Annuler
+        quantity: Quantité
+        shipment: Livraison
+        state: Statut
     errors:
       models:
         spree/fulfilment_changer:
           attributes:
+            current_shipment:
+              can_not_have_backordered_inventory_units: a de l'inventaire en attente
+              has_already_been_shipped: a déjà été envoyé
             desired_shipment:
               can_not_transfer_within_same_shipment: doit être différent de la livraison
               not_enough_stock_at_desired_location: pas assez de stock dans le lieu indiqué
-            current_shipment:
-              has_already_been_shipped: a déjà été envoyé
-              can_not_have_backordered_inventory_units: a de l'inventaire en attente
   activerecord:
     attributes:
       spree/address:
@@ -30,11 +31,11 @@ fr:
         zipcode: Code Postal
       spree/adjustment:
         adjustable: Ajustable
+        adjustment_reason_id: Raison
         amount: Montant
         label: Label
         name: Nom
         state: Statut
-        adjustment_reason_id: Raison
       spree/adjustment_reason:
         active: Actif
         code: Code
@@ -61,8 +62,8 @@ fr:
         states_required: Province / Région / État nécessaire
       spree/credit_card:
         base: ''
-        cc_type: Type
         card_code: Code de carte bancaire
+        cc_type: Type
         expiration: Expiration
         month: Mois
         name: Nom
@@ -70,13 +71,13 @@ fr:
         verification_value: Code de sécurité
         year: Année
       spree/customer_return:
+        created_at: Date/Heure
+        name: Nom
         number: Numéro de retour
         pre_tax_total: Total avant taxes
+        reimbursement_status: Statut de remboursement
         total: Total
         total_excluding_vat: Total avant TVA
-        created_at: "Date/Heure"
-        reimbursement_status: Statut de remboursement
-        name: Nom
       spree/image:
         alt: Texte alternatif
         attachment: Nom de fichier
@@ -114,8 +115,8 @@ fr:
         ip_address: Adresse IP
         item_total: Nombre total d'articles
         number: Nombre
-        payment_state: "État du paiement"
-        shipment_state: "État du colis"
+        payment_state: État du paiement
+        shipment_state: État du colis
         special_instructions: Instructions spéciales
         state: État de la commande
         total: Total
@@ -150,15 +151,15 @@ fr:
         preference_source: Méthode préférée
         type: Type
       spree/price:
-        currency: Monnaie
         amount: Prix
+        currency: Monnaie
         is_default: Valide actuellement
       spree/product:
         available_on: Disponible le
         cost_currency: Devise du prix
         cost_price: Prix d'achat
-        description: Description
         depth: Profondeur
+        description: Description
         height: Hauteur
         master_price: Prix de départ
         meta_description: Description (Meta)
@@ -196,34 +197,34 @@ fr:
         description: Créer une réduction sur le produit selon la quantité
       spree/promotion/actions/free_shipping:
         description: Proposer la livraison gratuite à la commande
-      spree/promotion/rules/item_total:
-        description: Le total de commande répond à ces critères
       spree/promotion/rules/first_order:
         description: Doit être la première commande du client
+      spree/promotion/rules/first_repeat_purchase_since:
+        description: Disponible pour les utilisateurs n'ayant pas commandés depuis un certain temps
+        form_text: 'Appliquer cette réduction aux utilisateurs n''ayant pas commandés depuis au moins X jours: '
+      spree/promotion/rules/item_total:
+        description: Le total de commande répond à ces critères
       spree/promotion/rules/landing_page:
-          description: Le client doit avoir visité la page indiquée
+        description: Le client doit avoir visité la page indiquée
+      spree/promotion/rules/nth_order:
+        description: Appliquer une réduction à tout n-ième commande des clients
+        form_text: 'Appliquer une réduction à tout n-ième commande des clients:'
       spree/promotion/rules/one_use_per_user:
         description: Une utilisation par client
       spree/promotion/rules/option_value:
         description: La commande inclus les produits indiqués avec les bonnes options
       spree/promotion/rules/product:
         description: La commande inclus les produits indiqués
+      spree/promotion/rules/store:
+        description: Disponible seulement pour les boutiques données
+      spree/promotion/rules/taxon:
+        description: La commande inclus des produits avec les taxon(s) donnés
       spree/promotion/rules/user:
         description: Disponible seulement pour les clients indiqués
       spree/promotion/rules/user_logged_in:
         description: Disponible seulement pour les clients connectés
-      spree/promotion/rules/taxon:
-        description: La commande inclus des produits avec les taxon(s) donnés
-      spree/promotion/rules/nth_order:
-        description: "Appliquer une réduction à tout n-ième commande des clients"
-        form_text: "Appliquer une réduction à tout n-ième commande des clients:"
-      spree/promotion/rules/first_repeat_purchase_since:
-        description: Disponible pour les utilisateurs n'ayant pas commandés depuis un certain temps
-        form_text: "Appliquer cette réduction aux utilisateurs n'ayant pas commandés depuis au moins X jours: "
       spree/promotion/rules/user_role:
         description: La commande inclus des utilisateurs avec les rôles donnés
-      spree/promotion/rules/store:
-        description: Disponible seulement pour les boutiques données
       spree/promotion_category:
         name: Nom
       spree/property:
@@ -237,19 +238,19 @@ fr:
         refund_reason_id: Raison
       spree/refund_reason:
         active: Actif
-        name: Nom
         code: Code
+        name: Nom
       spree/reimbursement:
-        created_at: "Date/Heure"
+        created_at: Date/Heure
         number: Numéro
         reimbursement_status: Statut
         total: Total
       spree/reimbursement/credit:
         amount: Montant
       spree/reimbursement_type:
+        created_at: Date/Heure
         name: Nom
         type: Type
-        created_at: "Date/Heure"
       spree/return_authorization:
         amount: Montant
         pre_tax_total: Total avant taxes
@@ -261,26 +262,26 @@ fr:
         charged: Réglé
         exchange_variant: Echangé pour
         inventory_unit_state: Etat
-        item_received?: "Produit reçu?"
+        item_received?: Produit reçu?
         override_reimbursement_type_id: Modification du type de remboursement
         preferred_reimbursement_type_id: Type de remboursement préférentiel
         reception_status: Statut de réception
-        resellable: "Revendable?"
+        resellable: Revendable?
         return_reason: Raison
         total: Total
       spree/return_reason:
-        name: Nom
         active: Actif
-        created_at: "Date/Heure"
+        created_at: Date/Heure
         memo: Memo
+        name: Nom
         number: Numéro
         state: Statut
       spree/role:
         name: Nom
-      spree/shipping_category:
-        name: Nom
       spree/shipment:
         tracking: Numéro de suivi
+      spree/shipping_category:
+        name: Nom
       spree/shipping_method:
         admin_name: Nom
         carrier: Transporteur
@@ -290,10 +291,10 @@ fr:
         service_level: Niveau de service
         tracking_url: URL de suivi
       spree/shipping_rate:
-        label: Label
-        tax_rate: Taxes
-        shipping_rate: Tarif de livraison
         amount: Montant
+        label: Label
+        shipping_rate: Tarif de livraison
+        tax_rate: Taxes
       spree/state:
         abbr: Abréviation
         name: Nom
@@ -305,36 +306,13 @@ fr:
         type: Type
         updated: Mis à jour le
         user: Utilisateur
-      spree/store:
-        mail_from_address: Courriel d'envoi
-        meta_description: Description (Meta)
-        meta_keywords: Mots-clés (Meta)
-        name: Nom du site
-        seo_title: Titre SEO
-        url: Adresse URL
-        cart_tax_country_iso: Taxe du pays pour les paniers vides
-      spree/store_credit:
-        amount: Montant
-        amount_authorized: Montant autorisé
-        amount_credited: Montant crédité
-        amount_used: Montant utilisé
-        category_id: Catégorie
-        created_at: Créé à
-        created_by_id: Créé par
-        invalidated_at: Invalidé
-        memo: Memo
-      spree/store_credit_event:
-        action: Action
-        user_total_amount: Montant total
-      spree/store_credit_update_reason:
-        name: Raison de la mise à jour
       spree/stock_item:
         count_on_hand: Nombre à disposition
       spree/stock_location:
-        admin_name: Nom
         active: Actif
         address1: Adresse
         address2: Adresse complémentaire
+        admin_name: Nom
         backorderable_default: Rupture de stock (défaut)
         check_stock_on_transfer: Vérifier le stock au moment du transfert
         city: Ville
@@ -353,18 +331,41 @@ fr:
         originated_by: Depuis
         quantity: Quantité
         variant: Variante
+      spree/store:
+        cart_tax_country_iso: Taxe du pays pour les paniers vides
+        mail_from_address: Courriel d'envoi
+        meta_description: Description (Meta)
+        meta_keywords: Mots-clés (Meta)
+        name: Nom du site
+        seo_title: Titre SEO
+        url: Adresse URL
+      spree/store_credit:
+        amount: Montant
+        amount_authorized: Montant autorisé
+        amount_credited: Montant crédité
+        amount_used: Montant utilisé
+        category_id: Catégorie
+        created_at: Créé à
+        created_by_id: Créé par
+        invalidated_at: Invalidé
+        memo: Memo
+      spree/store_credit_event:
+        action: Action
+        user_total_amount: Montant total
+      spree/store_credit_update_reason:
+        name: Raison de la mise à jour
       spree/tax_category:
         description: Description
-        name: Nom
         is_default: Défaut
+        name: Nom
         tax_code: Taxe code
       spree/tax_rate:
         amount: Taux
+        expires_at: Date d'expiration
         included_in_price: Inclus dans le prix
         name: Nom
         show_rate_in_label: Afficher le taux dans l'étiquette
         starts_at: Commence à
-        expires_at: Date d'expiration
       spree/taxon:
         description: Description
         icon: Icône
@@ -377,14 +378,14 @@ fr:
       spree/taxonomy:
         name: Nom
       spree/tracker:
-        analytics_id: ID d'analyse
         active: Actif
+        analytics_id: ID d'analyse
       spree/user:
         email: Courriel
+        lifetime_value: Total dépensé
         password: Mot de passe
         password_confirmation: Confirmation du mot de passe
         spree_roles: Roles
-        lifetime_value: Total dépensé
       spree/variant:
         cost_currency: Devise du prix
         cost_price: Prix coûtant
@@ -407,20 +408,20 @@ fr:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: "Les clés Tier devraient toutes être des nombres plus grand que 0"
+              keys_should_be_positive_number: Les clés Tier devraient toutes être des nombres plus grand que 0
             preferred_tiers:
-              should_be_hash: "devrait être une table de hachage"
+              should_be_hash: devrait être une table de hachage
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: "Les clés Tier devraient toutes être des nombres plus grand que 0"
-              values_should_be_percent: "Les valeurs Tier devraient toutes être des percentages compris entre 0% et 100%"
+              keys_should_be_positive_number: Les clés Tier devraient toutes être des nombres plus grand que 0
+              values_should_be_percent: Les valeurs Tier devraient toutes être des percentages compris entre 0% et 100%
             preferred_tiers:
-              should_be_hash: "devrait être une table de hachage"
+              should_be_hash: devrait être une table de hachage
         spree/classification:
           attributes:
             taxon_id:
-              already_linked: "est déjà relié à ce produit"
+              already_linked: est déjà relié à ce produit
         spree/credit_card:
           attributes:
             base:
@@ -428,10 +429,10 @@ fr:
               expiry_invalid: Cette carte est invalide
         spree/inventory_unit:
           attributes:
-            state:
-              cannot_destroy: "Impossible de détruire une unité de stock %{state}"
             base:
-              cannot_destroy_shipment_state: "Impossible de détruire une unité de stock pour une livraison %{state}"
+              cannot_destroy_shipment_state: Impossible de détruire une unité de stock pour une livraison %{state}
+            state:
+              cannot_destroy: Impossible de détruire une unité de stock %{state}
         spree/line_item:
           attributes:
             currency:
@@ -439,7 +440,7 @@ fr:
         spree/price:
           attributes:
             currency:
-              invalid_code: "n'est pas une monnaie valide"
+              invalid_code: n'est pas une monnaie valide
         spree/promotion:
           attributes:
             apply_automatically:
@@ -452,19 +453,20 @@ fr:
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match: Un ou plusieurs des articles de retour spécifiées n'appartiennent pas à la même commande que du remboursement.
+              return_items_order_id_does_not_match: Un ou plusieurs des articles de retour spécifiées n'appartiennent pas à la même commande que
+                du remboursement.
         spree/return_item:
           attributes:
-            reimbursement:
-              cannot_be_associated_unless_accepted: ne peut pas être associé à un article retourné qui n'est pas accepté.
             inventory_unit:
               other_completed_return_item_exists: "%{inventory_unit_id} est déjà pris par un article retourné %{return_item_id}"
+            reimbursement:
+              cannot_be_associated_unless_accepted: ne peut pas être associé à un article retourné qui n'est pas accepté.
         spree/shipment:
           attributes:
-            state:
-              cannot_destroy: "Impossible de détruire une livraison %{state}"
             base:
-              cannot_remove_items_shipment_state: "Impossible d'enlever des produits à une livraison %{state}"
+              cannot_remove_items_shipment_state: Impossible d'enlever des produits à une livraison %{state}
+            state:
+              cannot_destroy: Impossible de détruire une livraison %{state}
         spree/store:
           attributes:
             base:
@@ -472,15 +474,12 @@ fr:
         spree/user_address:
           attributes:
             user_id:
-              default_address_exists: "a déjà une adresse par défaut"
+              default_address_exists: a déjà une adresse par défaut
         spree/wallet_payment_source:
           attributes:
             payment_source:
-              has_to_be_payment_source_class: "doit être un Spree::PaymentSource"
+              has_to_be_payment_source_class: doit être un Spree::PaymentSource
     models:
-      user:
-        one: Utilisateur
-        other: Utilisateurs
       spree/address:
         one: Adresse
         other: Adresses
@@ -520,12 +519,6 @@ fr:
       spree/calculator/price_sack:
         one: Prix de retour
         other: Prix de retour
-      spree/calculator/tiered_percent:
-        one: Pourcentage progressif
-        other: Pourcentages progressifs
-      spree/calculator/tiered_flat_rate:
-        one: Taux fixe échelonné
-        other: Taux fixes échelonnés
       spree/calculator/returns/default_refund_amount:
         one: Montant de remboursement par défaut
         other: Montants de remboursement par défaut
@@ -544,6 +537,12 @@ fr:
       spree/calculator/shipping/price_sack:
         one: Prix de retour
         other: Prix de retour
+      spree/calculator/tiered_flat_rate:
+        one: Taux fixe échelonné
+        other: Taux fixes échelonnés
+      spree/calculator/tiered_percent:
+        one: Pourcentage progressif
+        other: Pourcentages progressifs
       spree/country:
         one: Pays
         other: Pays
@@ -589,10 +588,10 @@ fr:
       spree/payment_method:
         one: Méthode de paiement
         other: Méthodes de paiement
-      spree/payment_method/check: Vérification des paiements
-      spree/payment_method/store_credit: Stockage des paiements
       spree/payment_method/bogus_credit_card: Paiement fallacieux par carte de crédit
+      spree/payment_method/check: Vérification des paiements
       spree/payment_method/simple_bogus_credit_card: Paiement fallacieux simple par carte de crédit
+      spree/payment_method/store_credit: Stockage des paiements
       spree/price:
         one: Prix
         other: Prix
@@ -610,24 +609,24 @@ fr:
       spree/promotion/actions/create_quantity_adjustments: Ajuster les quantités de la commande
       spree/promotion/actions/free_shipping: Livraison offerte
       spree/promotion/rules/first_order: Première commande
+      spree/promotion/rules/first_repeat_purchase_since: Première achat depuis
       spree/promotion/rules/item_total: Nombre de produits
       spree/promotion/rules/landing_page: Page de présentation
+      spree/promotion/rules/nth_order: N-ième commande
       spree/promotion/rules/one_use_per_user: Une utilisation par client
       spree/promotion/rules/option_value: Options
       spree/promotion/rules/product: Produit(s)
+      spree/promotion/rules/taxon: Taxon(s)
       spree/promotion/rules/user: Utilisateur
       spree/promotion/rules/user_logged_in: Utilisateur connecté
-      spree/promotion/rules/taxon: Taxon(s)
-      spree/promotion/rules/nth_order: N-ième commande
-      spree/promotion/rules/first_repeat_purchase_since: Première achat depuis
       spree/promotion/rules/user_role: Rôle(s) de l'utilisateur
       spree/promotion_category:
         one: Catégorie de promotion
         other: Catégories de promotion
-      spree/promotion_code_batch:
+      spree/promotion_code:
         one: Code de réduction
         other: Codes de réduction
-      spree/promotion_code:
+      spree/promotion_code_batch:
         one: Code de réduction
         other: Codes de réduction
       spree/property:
@@ -672,13 +671,13 @@ fr:
       spree/state:
         one: Région
         other: Régions
+      spree/state_change:
+        one: Changement de région
+        other: Changements de région
       spree/stock: stock
       spree/stock_item:
         one: Unité de stock
         other: Unités de stock
-      spree/state_change:
-        one: Changement de région
-        other: Changements de région
       spree/stock_location:
         one: Emplacement du stock
         other: Emplacements du stock
@@ -721,6 +720,9 @@ fr:
       spree/zone:
         one: Zone
         other: Zones
+      user:
+        one: Utilisateur
+        other: Utilisateurs
   spree:
     abbreviation: Abréviation
     accept: Accepter
@@ -750,7 +752,6 @@ fr:
     activate: Activer
     active: Actif
     add: Ajouter
-    added: Ajouté
     add_action_of_type: Ajouter l'action de type
     add_country: Ajouter un pays
     add_coupon_code: Ajouter un code promo
@@ -761,7 +762,6 @@ fr:
     add_option_value: Ajouter la valeur de l'option
     add_product: Ajouter un produit
     add_product_properties: Ajouter des propriétés au produit
-    add_variant_properties: Ajouter des propriétés à la variante
     add_rule_of_type: Ajouter une règle de type
     add_state: Ajouter une région
     add_stock: Ajouter un stock
@@ -770,6 +770,8 @@ fr:
     add_to_cart: Ajouter au panier
     add_to_stock_location: Ajouter au lieu de stockage
     add_variant: Ajouter une variante
+    add_variant_properties: Ajouter des propriétés à la variante
+    added: Ajouté
     adding_match: Ajouter match
     additional_item: Coût d'un article supplémentaire
     address1: Adresse
@@ -778,22 +780,19 @@ fr:
     adjustment: Ajustement
     adjustment_amount: Montant
     adjustment_labels:
-      line_item: '%{promotion} (%{promotion_name})'
-      order: '%{promotion} (%{promotion_name})'
+      line_item: "%{promotion} (%{promotion_name})"
+      order: "%{promotion} (%{promotion_name})"
       tax_rates:
-        sales_tax: '%{name}'
-        vat: '%{name} (Included in Price)'
-        sales_tax_with_rate: '%{name} %{amount}'
-        vat_with_rate: '%{name} %{amount} (Included in Price)'
+        sales_tax: "%{name}"
+        sales_tax_with_rate: "%{name} %{amount}"
+        vat: "%{name} (Included in Price)"
+        vat_with_rate: "%{name} %{amount} (Included in Price)"
     adjustment_reasons: Raison de l'ajustement
     adjustment_successfully_closed: Ajustement fermé avec succès!
     adjustment_successfully_opened: Ajustement ouvert avec succès!
     adjustment_total: Ajustement Total
     adjustments: Ajustements
     admin:
-      stores:
-        form:
-          no_cart_tax_country: "Aucunes taxes pour les paniers sans adresse"
       images:
         index:
           choose_files: Choisir le fichier à télécharger
@@ -803,82 +802,85 @@ fr:
       payments:
         source_forms:
           storecredit:
-            not_supported: "Créer des paiements de carte bancaire via l'admin n'est pas supporté"
+            not_supported: Créer des paiements de carte bancaire via l'admin n'est pas supporté
       prices:
-        any_country: "Tous les pays"
+        any_country: Tous les pays
+        edit:
+          edit_price: Modifier prix
         index:
           amount_greater_than: Montant supérieur à
           amount_less_than: Montant inférieur à
           new_price: Nouveau prix
-        edit:
-          edit_price: Modifier prix
         new:
           new_price: Nouveau prix
       promotions:
-        form:
-          starts_at_placeholder: Immédiatement
-          expires_at_placeholder: Jamais
-          activation: Activation
-          general: Général
+        actions:
+          calculator_label: Calculé par
+        activations_edit:
+          auto: Toutes les commandes vont tenter d'utiliser cette réduction
+          multiple_codes_html: Cette promotion utilise %{count} codes de réduction
+          single_code_html: 'Cette promotion utilise le code de réduction: <code>%{code}</code>'
         activations_new:
           auto: Appliquer à toutes les commandes
           multiple_codes: Multiples codes de réduction
           path: Chemin URL
           single_code: Code de promotion unique
-        activations_edit:
-          auto: Toutes les commandes vont tenter d'utiliser cette réduction
-          single_code_html: "Cette promotion utilise le code de réduction: <code>%{code}</code>"
-          multiple_codes_html: "Cette promotion utilise %{count} codes de réduction"
-        actions:
-          calculator_label: Calculé par
+        form:
+          activation: Activation
+          expires_at_placeholder: Jamais
+          general: Général
+          starts_at_placeholder: Immédiatement
       stock_locations:
         form:
+          address: Adresse
           general: Général
           settings: Paramètres
-          address: Adresse
       store_credits:
-        add: "Ajouter transation"
+        add: Ajouter transation
         amount_authorized: Autorisé
         amount_credited: Crédité
         amount_used: Montant utilisé
+        back_to_edit: Retour à la modification
+        back_to_store_credit_list: Retour à la liste des transactions
+        back_to_user_list: Retour à la liste des utilisateurs
+        change_amount: Changer le montant
         created_at: Créé à
-        back_to_edit: "Retour à la modification"
-        back_to_user_list: "Retour à la liste des utilisateurs"
-        back_to_store_credit_list: "Retour à la liste des transactions"
-        change_amount: "Changer le montant"
-        created_by: "Créer par"
+        created_by: Créer par
         credit_type: Type
-        memo: Memo
-        current_balance: "Montant actuel:"
-        edit: "Modifier transaction"
-        edit_amount: "Modifier montant de la transation"
-        history: "Historique"
-        invalidate_store_credit: "Invalider transaction"
-        invalidated: "Invalidé"
-        issued_on: "Créé le"
-        new: "Nouvelle transaction"
-        no_store_credit_selected: "Aucune transaction n'a été sélectionnée"
-        payment_originator: "Paiement - commande #%{order_number}"
-        reason_for_updating: "Raison de la mise à jour"
-        refund_originator: "Remboursement - commande #%{order_number}"
-        resource_name: "transactions"
-        user_originator: "Utilisateurs - %{email}"
-        unable_to_create: "Impossible de créer la transaction"
-        unable_to_update: "Impossible de mettre à jour la transaction"
-        unable_to_delete: "Impossible de suppriler la transaction"
-        unable_to_invalidate: "Impossible d'invalider' la transaction"
-        select_reason: "Sélectionner une raison pour cette transaction"
-        select_amount_update_reason: "Sélectionner une raison pour mettre à jour cette transaction"
-        total_unused: "Total inutilisé"
-        type_html_header: "Type de transaction"
-        view: "Voir le bilan de la boutique"
+        current_balance: 'Montant actuel:'
+        edit: Modifier transaction
+        edit_amount: Modifier montant de la transation
         errors:
-          cannot_change_used_store_credit: "Une transaction complétée ne peut pas être modifiée"
-          cannot_be_modified: "ne peut pas être modifié"
-          amount_used_cannot_be_greater: "ne peut pas être supérieur au montant crédité"
           amount_authorized_exceeds_total_credit: " dépasse le montant crédité"
-          amount_used_not_zero: "Est supérieur à 0. Impossible de supprimer la transaction"
-          update_reason_required: "Une raison pour ce changement doit être sélectionnée"
+          amount_used_cannot_be_greater: ne peut pas être supérieur au montant crédité
+          amount_used_not_zero: Est supérieur à 0. Impossible de supprimer la transaction
+          cannot_be_modified: ne peut pas être modifié
+          cannot_change_used_store_credit: Une transaction complétée ne peut pas être modifiée
+          update_reason_required: Une raison pour ce changement doit être sélectionnée
+        history: Historique
+        invalidate_store_credit: Invalider transaction
+        invalidated: Invalidé
+        issued_on: Créé le
+        memo: Memo
+        new: Nouvelle transaction
+        no_store_credit_selected: Aucune transaction n'a été sélectionnée
+        payment_originator: 'Paiement - commande #%{order_number}'
+        reason_for_updating: Raison de la mise à jour
+        refund_originator: 'Remboursement - commande #%{order_number}'
+        resource_name: transactions
+        select_amount_update_reason: Sélectionner une raison pour mettre à jour cette transaction
+        select_reason: Sélectionner une raison pour cette transaction
+        total_unused: Total inutilisé
+        type_html_header: Type de transaction
+        unable_to_create: Impossible de créer la transaction
+        unable_to_delete: Impossible de suppriler la transaction
+        unable_to_invalidate: Impossible d'invalider' la transaction
+        unable_to_update: Impossible de mettre à jour la transaction
+        user_originator: Utilisateurs - %{email}
+        view: Voir le bilan de la boutique
+      stores:
+        form:
+          no_cart_tax_country: Aucunes taxes pour les paniers sans adresse
       tab:
         checkout: Remboursements et retours
         configuration: Configuration
@@ -887,8 +889,8 @@ fr:
         orders: Commandes
         overview: Vue d'ensemble
         products: Produits
-        promotions: Promotions
         promotion_categories: Catégories de réductions
+        promotions: Promotions
         properties: Propriétés
         prototypes: Prototypes
         reports: Statistiques
@@ -911,42 +913,42 @@ fr:
         items: Articles
         items_purchased: Articles achetés
         order_history: Historique des commandes
-        order_num: "Commande #"
+        order_num: 'Commande #'
         orders: Commandes
         store_credit: Transaction
         user_information: Informations de l'utilisateur
       users:
+        edit:
+          api_access: Accès API
+          clear_key: Effacer la clé
+          confirm_clear_key: Voulez vous vraiment effacer cette clé API? Cela va l'invalider.
+          confirm_regenerate_key: Voulez vous vraiment regénérer cette clé API? Cela va l'invalider.
+          generate_key: Générer clé API
+          key: Clé
+          no_key: Pas de clé
+          regenerate_key: Regénérer clé
         user_page_actions:
           create_order: Créer une commande pour cet utilisateur
-        edit:
-          api_access: "Accès API"
-          clear_key: "Effacer la clé"
-          confirm_clear_key: "Voulez vous vraiment effacer cette clé API? Cela va l'invalider."
-          confirm_regenerate_key: "Voulez vous vraiment regénérer cette clé API? Cela va l'invalider."
-          generate_key: "Générer clé API"
-          key: "Clé"
-          no_key: "Pas de clé"
-          regenerate_key: "Regénérer clé"
       variants:
-        table_filter:
-          show_deleted: Voir les variantes supprimées
-        new:
-          new_variant: Nouvelle variante
         edit:
           edit_variant: Modifier variante
         form:
           dimensions: Dimensions
-          use_product_tax_category: Catégorie de taxe à utiliser
           pricing: Prix
           pricing_hint: Ces valeurs sont remplies grâce à la page produit et peuvent être modifiées ci-dessous
+          use_product_tax_category: Catégorie de taxe à utiliser
+        new:
+          new_variant: Nouvelle variante
+        table_filter:
+          show_deleted: Voir les variantes supprimées
     administration: Administration
     advertise: Publiciser
     agree_to_privacy_policy: Accepter l'Engagement de Confidentialité
     agree_to_terms_of_service: Accepter les termes du contrat.
     all: Tous
     all_adjustments_closed: Tous les ajustements ont été fermé avec succès!
-    all_adjustments_opened: Tous les ajustements ont été ouvert avec succès!
     all_adjustments_finalized: Tous les ajustements ont été finalisés avec succès!
+    all_adjustments_opened: Tous les ajustements ont été ouvert avec succès!
     all_adjustments_unfinalized: Tous les ajustements ont été annulés avec succès!
     all_departments: Tous les départements
     all_items_have_been_returned: Tous les articles ont été retournés
@@ -970,7 +972,7 @@ fr:
     approved_at: approuver le
     approver: Approbateur
     are_you_sure: En êtes-vous sûr ?
-    are_you_sure_delete: "Êtes-vous sûr de vouloir supprimer cet enregistrement ?"
+    are_you_sure_delete: Êtes-vous sûr de vouloir supprimer cet enregistrement ?
     associated_adjustment_closed: L'ajustement associé est fermé, et ne sera pas recalculé. Voulez-vous l'ouvrir?
     authorization_failure: Vous n'avez pas les droits nécessaires pour afficher cette section
     authorized: Autorisé
@@ -981,8 +983,8 @@ fr:
     avs_response: Réponse AVS
     back: Retour
     back_end: Gestion
-    back_to_adjustments_list: Retour à la liste des ajustements
     back_to_adjustment_reason_list: Retour à la liste des raisons des ajustements
+    back_to_adjustments_list: Retour à la liste des ajustements
     back_to_countries_list: Retour à la liste des pays
     back_to_customer_return: Revenir au retour utilisateur
     back_to_customer_return_list: Revenir à la liste des retours utilisateurs
@@ -993,14 +995,14 @@ fr:
     back_to_payment_methods_list: Retour à la liste des types de paiment
     back_to_payments_list: Retour à la liste des paiements
     back_to_products_list: Retour à la liste des produits
-    back_to_promotions_list: Retour à la liste des réductions
     back_to_promotion_categories_list: Retour à la liste des catégories de réductions
+    back_to_promotions_list: Retour à la liste des réductions
     back_to_properties_list: Retour à la listes des caractéristiques
-    back_to_reports_list: Report à la liste des statistiques
     back_to_refund_reason_list: Retour à la liste des raisons de remboursement
     back_to_reimbursement_type_list: Retour à la liste des types de remboursement
+    back_to_reports_list: Report à la liste des statistiques
+    back_to_resource_list: Retour à la liste %{resource}
     back_to_return_authorizations_list: Retour à la liste des RMA
-    back_to_resource_list: 'Retour à la liste %{resource}'
     back_to_rma_reason_list: Retour à la liste des RMA
     back_to_shipping_categories: Retour aux catégories de livraison
     back_to_shipping_categories_list: Retour à la liste des catégories de livraison
@@ -1016,8 +1018,8 @@ fr:
     back_to_users_list: Retour à la liste des utilisateurs
     backorderable: Peut être acheté même si le stock est vide
     backorderable_default: Peut être acheté même si le stock est vide (défault)
-    backordered: En rupture de stock
     backorderable_header: En rupture de stock
+    backordered: En rupture de stock
     backorders_allowed: Ruptures de stock autorisées
     balance_due: Solde dû
     base_amount: Montant de base
@@ -1028,17 +1030,18 @@ fr:
     both: Les deux
     calculated_reimbursements: Calcul des remboursements
     calculator: Calculateur
-    calculator_settings_warning: Si vous changez le type de calculateur, vous devez tout d'abord enregistrer avant de pouvoir modifier les paramètres du calculateur.
+    calculator_settings_warning: Si vous changez le type de calculateur, vous devez tout d'abord enregistrer avant de pouvoir modifier les paramètres
+      du calculateur.
     cancel: annuler
     canceled_at: Annulé le
     canceler: Annulateur
     cannot_create_customer_returns: Impossible de créer des retours tant que cette commande n'a pas d'articles expédiés.
-    cannot_create_payment_without_payment_methods: Vous ne pouvez pas créer un paiement pour une commande sans aucun moyen de paiement défini.
     cannot_create_payment_link: Merci de définir tout d'abord un moyen de paiement
+    cannot_create_payment_without_payment_methods: Vous ne pouvez pas créer un paiement pour une commande sans aucun moyen de paiement défini.
     cannot_create_returns: Ne peut créer de retour tant que cette commande n'a pas été expédiée.
+    cannot_perform_operation: Ne peut pas accomplir l'action demandée
     cannot_rebuild_shipments_order_completed: Impossible de changer la livraison d'une commande effectuée.
     cannot_rebuild_shipments_shipments_not_pending: Impossible de changer la livraison d'une commande qui n'est pas en attente.
-    cannot_perform_operation: Ne peut pas accomplir l'action demandée
     cannot_set_shipping_method_without_address: La méthode d'expédition ne peut être définie tant que les données du client ne sont pas spécifiées
     cannot_update_email: Vous n'avez pas l'autorisation de modifier cet email. Merci de la demander à un responsable.
     capture: accepté
@@ -1049,19 +1052,19 @@ fr:
     card_type_is: Le type de la carte est
     cart: Panier
     cart_subtotal:
-      one: 'Sous-total (1 article)'
-      other: 'Sous-total (%{count} articles)'
+      one: Sous-total (1 article)
+      other: Sous-total (%{count} articles)
     carton_external_number: Numéro externe
-    carton_orders: 'Autres commandes dans cette boîte'
+    carton_orders: Autres commandes dans cette boîte
     categories: Catégories
     category: Categorie
     charged: Chargé
     check: Vérifier
-    check_stock_on_transfer: Vérifier le stock au transfert
     check_for_spree_alerts: Recevoir les alertes de Spree
+    check_stock_on_transfer: Vérifier le stock au transfert
     checkout: Passer la commande
     choose_a_customer: Choisissez un client
-    choose_a_taxon_to_sort_products_for: "Choisir une taxon pour organiser les produits pour"
+    choose_a_taxon_to_sort_products_for: Choisir une taxon pour organiser les produits pour
     choose_currency: Choisir la devise
     choose_dashboard_locale: Choisir la langue du tableau de bord
     choose_location: Choisir la localisation
@@ -1072,7 +1075,7 @@ fr:
     clear_cache: Supprimer la cache
     clear_cache_ok: La cache a bien été supprimée
     clear_cache_warning: Supprimer la cache va temporairement réduire les performances de votre boutique.
-    click_and_drag_on_the_products_to_sort_them:  Cliquer et faire glisser les produits pour les organiser.
+    click_and_drag_on_the_products_to_sort_them: Cliquer et faire glisser les produits pour les organiser.
     clone: Cloner
     close: Fermer
     close_all_adjustments: Fermer tous les ajustements
@@ -1115,9 +1118,9 @@ fr:
     create: Créer
     create_a_new_account: Créer un nouveau compte
     create_new_order: Créer une nouvelle commande
+    create_one: Créer un
     create_reimbursement: Créer un remboursement
     created_at: Date de création
-    create_one: Créer un
     created_by: Créé par
     created_successfully: Créé avec succès
     credit: Crédit
@@ -1177,21 +1180,20 @@ fr:
     display_currency: Devise d'affichage
     download_promotion_code_list: Télécharger liste des codes
     edit: Éditer
-    editing_country: Modifier le pays
+    edit_refund_reason: Modifier la raison du remboursement
     editing_adjustment_reason: Modifier la raison de l'ajustement
+    editing_country: Modifier le pays
     editing_option_type: Édition du type d'option
     editing_payment_method: Édition de la méthode de paiement
     editing_product: Édition du produit
     editing_promotion: Édition de la promotion
     editing_promotion_category: Édition de la catégorie de réduction
-    editing_property: Modifier le type de propriété
-    edit_refund_reason: Modifier la raison du remboursement
+    editing_property: Édition de la propriété
+    editing_prototype: Édition du prototype
     editing_refund: Modifier le remboursement
     editing_reimbursement: Modifier le remboursement
     editing_reimbursement_type: Modifier le type de remboursement
     editing_rma_reason: Modifier la raison du RMA
-    editing_property: Édition de la propriété
-    editing_prototype: Édition du prototype
     editing_shipping_category: Édition de la catégorie de livraison
     editing_shipping_method: Édition de la méthode de livraison
     editing_state: Édition de la région
@@ -1233,7 +1235,7 @@ fr:
     errors_prohibited_this_record_from_being_saved:
       one: 1 erreur empêche l'enregistrement de cette entrée
       other: "%{count} erreurs empêchent l'enregistrement de cette entrée"
-    event: "Événements"
+    event: Événements
     events:
       spree:
         cart:
@@ -1248,31 +1250,17 @@ fr:
         user:
           signup: Inscription utilisateur
     exceptions:
-      count_on_hand_setter: Impossible de définir count_on_hand manuellement, tel qu'il est défini automatiquement par le rappel de recalculate_count_on_hand. S'il vous plaît utilisez `update_column (:count_on_hand, value)` à la place.
+      count_on_hand_setter: >-
+        Impossible de définir count_on_hand manuellement, tel qu'il est défini automatiquement par le rappel de recalculate_count_on_hand. S'il
+        vous plaît utilisez `update_column (:count_on_hand, value)` à la place.
     exchange_for: Échange pour
     excl: exclu.
+    existing_shipments: Livraisons existantes
     expected: Attendu
     expected_items: Articles attendus
-    existing_shipments: Livraisons existantes
-    expedited_exchanges_warning:
+    expedited_exchanges_warning: 
     expiration: Expiration
     extension: Prolongation
-    hints:
-      spree/price:
-        country: "Détermine dans quel pays le prix est valide. <br/>Défaut: Tous les pays"
-        master_variant: "Changer le prix de la variante principale ne changera pas le prix des autres variantes mais sera utilisé pour les nouvelles variantes créées"
-        options: "Ces options sont utilisées pour créer des variantes dans l'onglet variantes. Elle peuvent être modifiées dans l'onglet variantes"
-      spree/product:
-        promotionable: "Détermine si une réduction peut être appliquée ou non pour ce produit.<br/>Défaut: Oui"
-        shipping_category: "Détermine le type de livraison nécessaire pour ce produit.<br/> Défaut: Défaut"
-        tax_category: "Détermine le type de taxes appliquées à ce produit.<br/> Défaut: Aucune"
-      spree/promotion:
-        starts_at: "Détermine quand une réduction peut être appliquée aux commandes. <br/> Si rien n'est indiqué, la promotion sera disponible dès maintenant."
-        expires_at: "Détermine quand une réduction expirera. <br/> Si rien n'est indiqué, elle n'expirera jamais."
-      spree/stock_location:
-        active: "Détermine si le stock de ce lieu peut être utilisé pour préparer les commandes.<br/> Défaut: Oui"
-        backorderable_default: "Quand validé, ce lieu de stockage acceptera les ruptures de stocks.<br/> Défaut: Non"
-        propagate_all_variants: "Quand validé, celle créera une variante dans ce lieux de stockage pour chaque variante existante.<br/> Défaut: Oui"
     failed_payment_attempts: Tentatives de paiement échouées
     filename: Nom du fichier
     fill_in_customer_info: Merci de remplir les informations client.
@@ -1304,6 +1292,25 @@ fr:
     has_no_shipped_units: Aucune unité à été livré
     height: Taille
     hide_cents: Cacher les centimes
+    hints:
+      spree/price:
+        country: 'Détermine dans quel pays le prix est valide. <br/>Défaut: Tous les pays'
+        master_variant: Changer le prix de la variante principale ne changera pas le prix des autres variantes mais sera utilisé pour les nouvelles
+          variantes créées
+        options: Ces options sont utilisées pour créer des variantes dans l'onglet variantes. Elle peuvent être modifiées dans l'onglet variantes
+      spree/product:
+        promotionable: 'Détermine si une réduction peut être appliquée ou non pour ce produit.<br/>Défaut: Oui'
+        shipping_category: 'Détermine le type de livraison nécessaire pour ce produit.<br/> Défaut: Défaut'
+        tax_category: 'Détermine le type de taxes appliquées à ce produit.<br/> Défaut: Aucune'
+      spree/promotion:
+        expires_at: Détermine quand une réduction expirera. <br/> Si rien n'est indiqué, elle n'expirera jamais.
+        starts_at: Détermine quand une réduction peut être appliquée aux commandes. <br/> Si rien n'est indiqué, la promotion sera disponible
+          dès maintenant.
+      spree/stock_location:
+        active: 'Détermine si le stock de ce lieu peut être utilisé pour préparer les commandes.<br/> Défaut: Oui'
+        backorderable_default: 'Quand validé, ce lieu de stockage acceptera les ruptures de stocks.<br/> Défaut: Non'
+        propagate_all_variants: 'Quand validé, celle créera une variante dans ce lieux de stockage pour chaque variante existante.<br/> Défaut:
+          Oui'
     home: Accueil
     i18n:
       available_locales: Paramètres régionaux disponibles
@@ -1321,8 +1328,8 @@ fr:
     identifier: Identification
     image: Image
     images: Images
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
     inactive: Inactif
     incl: inclus
     included_in_price: Inclus dans le prix
@@ -1330,16 +1337,17 @@ fr:
     incomplete: Incomplet
     info_number_of_skus_not_shown:
       one: un
-      other: "et %{count} autres"
-    info_product_has_multiple_skus: "Ce produit possède %{count} variantes:"
-    instructions_to_reset_password: 'Remplissez le formulaire ci-dessous et les instructions pour réinitialiser votre mot de passe vous seront envoyées par courriel:'
+      other: et %{count} autres
+    info_product_has_multiple_skus: 'Ce produit possède %{count} variantes:'
+    instructions_to_reset_password: 'Remplissez le formulaire ci-dessous et les instructions pour réinitialiser votre mot de passe vous seront
+      envoyées par courriel:'
     insufficient_stock: Stock disponible insuffisant, il n'en reste seulement que %{on_hand}
     insufficient_stock_lines_present: Nous n'avons pas tous les articles de votre commande dans notre inventaire.
     intercept_email_address: Intercepter l'adresse courriel
     intercept_email_instructions: Remplacer l'adresse courriel de destination par cette adresse
     internal_name: Nom interne
     invalid_credit_card: Carte de crédit invalide
-    invalid_exchange_variant:
+    invalid_exchange_variant: 
     invalid_payment_provider: Fournisseur de paiement invalide.
     invalid_promotion_action: Action de promotion invalide.
     invalid_promotion_rule: Règle de promotion invalide
@@ -1358,10 +1366,11 @@ fr:
         gte: égal ou plus grand que
         lt: plus petit que
         lte: égal ou plus petit que
-    items_cannot_be_shipped: Il nous est impossible de livrer l'article sélectionné à votre adresse de livraison. Veuillez choisir une autre adresse de livraison.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_cannot_be_shipped: Il nous est impossible de livrer l'article sélectionné à votre adresse de livraison. Veuillez choisir une autre adresse
+      de livraison.
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Chemin
@@ -1369,7 +1378,7 @@ fr:
     last_name_begins_with: Le nom commmence par
     learn_more: Pour en savoir plus
     lifetime_stats: Statistiques à vie
-    line_item_adjustments:
+    line_item_adjustments: 
     list: Liste
     loading: Chargement
     locale_changed: Paramètres régionaux changés
@@ -1415,7 +1424,7 @@ fr:
     new_adjustment: Nouvel ajustement
     new_country: Nouveau pays
     new_customer: Nouveau client
-    new_customer_return:
+    new_customer_return: 
     new_image: Nouvelle image
     new_option_type: Nouveau type d'option
     new_order: Nouvelle commande
@@ -1500,8 +1509,8 @@ fr:
         instructions: Votre commande a été ANNULÉE. Veuillez conserver les informations suivantes à propos de votre commande annulée.
         order_summary_canceled: Sommaire de la commande [ANNULÉE]
         subject: Annulation de la commande
-        subtotal: ! 'Sous-total: %{subtotal}'
-        total: ! 'Total de la commande: %{total}'
+        subtotal: 'Sous-total: %{subtotal}'
+        total: 'Total de la commande: %{total}'
       confirm_email:
         dear_customer: Cher client,
         instructions: Veuillez vérifier et sauvegarder les informations suivantes à propos de votre commande.
@@ -1509,7 +1518,7 @@ fr:
         subject: Confirmation de commande
         subtotal: Sous-total de la commande
         thanks: Merci d'avoir fait affaire avec nous.
-        total: ! 'Total de la commande: %{total}'
+        total: 'Total de la commande: %{total}'
     order_not_found: Impossible de trouver votre commande. Merci d'essayer à nouveau.
     order_number: Numéro de commande %{number}
     order_processed_successfully: Votre commande a été traitée avec succès
@@ -1527,16 +1536,16 @@ fr:
       resumed: reprise
       returned: retourné
     order_summary: Résumé de la commande
-    order_sure_want_to: "Êtes-vous certain de vouloir %{event} cette commande ?"
+    order_sure_want_to: Êtes-vous certain de vouloir %{event} cette commande ?
     order_total: Total de la commande
     order_updated: Commande mise à jour
     orders: Commandes
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: En rupture de stock
     overview: Vue d'ensemble
     package_from: Paquet de
     pagination:
-      next_page: "page suivante »"
+      next_page: page suivante »
       previous_page: "« page précédente"
       truncate: "…"
     password: Mot de passe
@@ -1544,8 +1553,8 @@ fr:
     path: Chemin
     pay: payer
     payment: Paiement
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Information sur le paiement
     payment_method: Méthode de paiement
     payment_method_not_supported: Ce méthode de paiement n'est pas supportée
@@ -1553,13 +1562,13 @@ fr:
     payment_processing_failed: Le paiement ne peut être effectué, merci de vérifier les informations fournies
     payment_processor_choose_banner_text: Si vous avez besoin d'aide pour schoisir une méthode de paiement, svp visitez
     payment_processor_choose_link: notre page de paiements
-    payment_state: "État du paiement"
+    payment_state: État du paiement
     payment_states:
       balance_due: solde dû
       checkout: commandé
       completed: terminé
       credit_owed: crédit dû
-      failed: "échec"
+      failed: échec
       paid: payé
       pending: en attente
       processing: en cours
@@ -1575,14 +1584,13 @@ fr:
     please_define_payment_methods: S'il vous plaît définissez d'abord certains modes de paiement.
     populate_get_error: Quelque chose s'est passé mal. Essayez S'il vous plaît d'ajouter l'article de nouveau.
     powered_by: Réalisé avec
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Présentation
     previous: Précédent
-    previous_state_missing:
+    previous_state_missing: 
     price: Prix
     price_range: Prix
     price_sack: Prix du sac
@@ -1614,12 +1622,12 @@ fr:
       create_line_items:
         description: Remplit le panier avec la quantité spécifiée de variante
         name: Créez des lignes d'article
-      give_store_credit:
-        description: Accorde à l'utilisateur un avoir de la quantité indiquée
-        name: Accorder un avoir
       free_shipping:
         description: Livraison gratuite pour la commande.
         name: Livraison gratuite
+      give_store_credit:
+        description: Accorde à l'utilisateur un avoir de la quantité indiquée
+        name: Accorder un avoir
     promotion_actions: Actions
     promotion_form:
       match_policies:
@@ -1630,12 +1638,20 @@ fr:
       first_order:
         description: Doit être la première commande de l'utilisateur
         name: première commande
+      first_repeat_purchase_since:
+        description: Disponible uniquement à l'utilisateur qui n'a pas acheté dans un certain temps
+        form_text: Appliquer cette promotion aux utilisateurs dont dernière commande était plus de X jours
+        name: Répétition première achat depuis
       item_total:
         description: Le total de la commande réponds aux critaires suivants
         name: total de la commande
       landing_page:
         description: Le client doit avoir visité la page spécifiée
         name: Page de destination
+      nth_order:
+        description: Appliquer une promotion à chaque nième commande que l'utilisateur a terminé
+        form_text: Appliquer cette promotion sur Nième commande des utilisateurs
+        name: Nth Commande
       one_use_per_user:
         description: Une seule utilisation par utilisateur
         name: Une utilisation par utilisateur
@@ -1654,24 +1670,17 @@ fr:
       user_logged_in:
         description: Disponible seulement aux utilisateurs enregistrés
         name: Utilisateur connecté
-      nth_order:
-        description: Appliquer une promotion à chaque nième commande que l'utilisateur a terminé
-        name: Nth Commande
-        form_text: Appliquer cette promotion sur Nième commande des utilisateurs
-      first_repeat_purchase_since:
-        description: Disponible uniquement à l'utilisateur qui n'a pas acheté dans un certain temps
-        name: Répétition première achat depuis
-        form_text: Appliquer cette promotion aux utilisateurs dont dernière commande était plus de X jours
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promotions
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Propriétés
     property: Propriété
     prototype: Prototype
     prototypes: Prototypes
     provider: Fournisseur
-    provider_settings_warning: Si vous éditez le type de fournisseur, vous devez d'abord sauvegarder avant de pouvoir éditer les paramètre du fournisseur
+    provider_settings_warning: Si vous éditez le type de fournisseur, vous devez d'abord sauvegarder avant de pouvoir éditer les paramètre du
+      fournisseur
     qty: Qté
     quantity: Quantité
     quantity_returned: Quantité retournée
@@ -1685,7 +1694,7 @@ fr:
     reception_status: Statut de réception
     reference: Référence
     refund: Remboursement
-    refund_amount_must_be_greater_than_zero:
+    refund_amount_must_be_greater_than_zero: 
     refund_reasons: Raisons de remboursement
     refunded_amount: Montant du remboursement
     refunds: Remboursements
@@ -1696,26 +1705,26 @@ fr:
     reimbursement: Remboursement
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
     reimbursement_types: Types de remboursement
     reimbursements: Remboursements
-    reject:
-    rejected:
+    reject: 
+    rejected: 
     remember_me: Se souvenir de moi
     remove: Supprimer
     rename: Renommer
-    report:
+    report: 
     reports: Statistiques
     resend: Renvoyer
     reset_password: Réinitialiser mon mot de passe
@@ -1727,12 +1736,12 @@ fr:
     return_authorization_reasons: Raisons de retour d'autorisation
     return_authorization_updated: Retour d'autorisation mis à jour
     return_authorizations: Retour d'autorisations
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
     return_number: N° de retour
     return_quantity: Quantité de retour
     returned: Retourner
@@ -1761,8 +1770,8 @@ fr:
     secure_connection_type: Type de connexion sécurisée
     security_settings: Paramètres de sécurité
     select: Sélectionner
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Sélectionner d'après le prototype
     select_stock: Sélectionner le stock
     send_copy_of_all_mails_to: Envoyer une copie de tous les courriels à
@@ -1774,8 +1783,8 @@ fr:
     ship_address: Adresse de livraison
     ship_total: Envois Totales
     shipment: Livraison
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Cher client,\n
@@ -1785,7 +1794,7 @@ fr:
         thanks: Merci pour votre activité.
         track_information: 'Suivi de l''Information: %{tracking}'
         track_link: 'Lien du traqueur: %{url}'
-    shipment_state: "État de livraison"
+    shipment_state: État de livraison
     shipment_states:
       backorder: Rupture de stock
       canceled: Annulé
@@ -1793,8 +1802,8 @@ fr:
       pending: En attente
       ready: Prêt
       shipped: Expédié
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Livraisons
     shipped: Livré
     shipping: Frais de livraison
@@ -1818,14 +1827,15 @@ fr:
     show_only_considered_risky: Afficher seulement les commandes considérées à risque
     show_rate_in_label: Montrer les taux dans les legendes
     sku: Code barre
-    skus:
+    skus: 
     slug: Identifiant
     source: Origine
     special_instructions: Instructions spéciales
     split: Diviser
-    spree_gateway_error_flash_for_checkout: Il y a eu un problème avec vos informations de paiement. Merci de bien vouloir les vérifier et de réessayer.
+    spree_gateway_error_flash_for_checkout: Il y a eu un problème avec vos informations de paiement. Merci de bien vouloir les vérifier et de
+      réessayer.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Départ
     state: Province / Région / État
     state_based: Basé sur une région
@@ -1846,10 +1856,10 @@ fr:
       delivery: Livraison
       errored: Erroné
       failed: Échoué
-      given_to_customer:
+      given_to_customer: 
       invalid: Invalide
       manual_intervention_required: Intervention manuelle requis
-      on_hand:
+      on_hand: 
       open: Ouvert
       order: Commande
       payment: Paiement
@@ -1857,18 +1867,18 @@ fr:
       processing: Traitement en cours
       ready: Prêt
       reimbursed: Remboursé
-      resumed:
+      resumed: 
       returned: Renvoyé
       shipped: Expédié
-      void:
+      void: 
     states: Régions
     states_required: Etat / province obligatoire
     status: Statut
-    stock:
+    stock: 
     stock_location: Emplacement de stock
     stock_location_info: Informations sur l'emplacement de stock
     stock_locations: Emplacements de stock
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Gestion de stock
     stock_management_requires_a_stock_location: Veuillez créer un lieu de stockage afin de pouvoir gérer vos stocks
     stock_movements: Mouvements de Stock
@@ -1882,9 +1892,9 @@ fr:
     street_address_2: Adresse (suite)
     subtotal: Sous-total
     subtract: Soustraire
-    success:
+    success: 
     successfully_created: "%{resource} a été crée avec succès!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} a été supprimé avec succès!"
     successfully_signed_up_for_analytics: Vous avez été enregistré avec succès à Spree Analytics.
     successfully_updated: "%{resource} a été modifié avec succès!"
@@ -1892,9 +1902,10 @@ fr:
     tax: TVA
     tax_categories: Catégories de taxes
     tax_category: Catégorie de taxe
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation: Les taux de taxe représentent un nombre décimal pour simplifier les calculs. (i.e. si le taux est  5%, entrer 0.05)
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: Les taux de taxe représentent un nombre décimal pour simplifier les calculs. (i.e. si le taux est  5%, entrer
+      0.05)
     tax_rates: Taux des taxes
     taxon: Arborescence
     taxon_edit: Modifier l'aborescence
@@ -1908,7 +1919,8 @@ fr:
     taxonomies: Arborescences
     taxonomy: Taxonomy
     taxonomy_edit: Modifier l'aborescence
-    taxonomy_tree_error: La modification demandée n'a pas été acceptée et l'arbre a été retourné à son état antérieur, s'il vous plaît essayez de nouveau.
+    taxonomy_tree_error: La modification demandée n'a pas été acceptée et l'arbre a été retourné à son état antérieur, s'il vous plaît essayez
+      de nouveau.
     taxonomy_tree_instruction: Cliquer dans l'arbre avec le bouton droit pour accéder au menu pour ajouter, supprimer et trier une feuille.
     taxons: Arborescences
     test: Test
@@ -1921,24 +1933,24 @@ fr:
     thank_you_for_your_order: Merci de nous avoir fait confiance. Imprimez cette page de confirmation pour vos archives.
     there_are_no_items_for_this_order: Il n'y a aucun article dans cette commande. Veuillez en ajouter un à la commande pour continuer.
     there_were_problems_with_the_following_fields: Il y a eu des problèmes aves les champs suivants
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Vignette
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Temps
     to_add_variants_you_must_first_define: Pour ajouter des variantes, vous devez premièrement définir
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
     total_sales: Somme des ventes
-    track_inventory:
+    track_inventory: 
     tracking: Localiser
     tracking_number: Numéro de suivi
     tracking_url: URL du traqueur
     tracking_url_placeholder: i.e. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Transférer de
     transfer_stock: Transférer le Stock
     transfer_to_location: Transférer vers
@@ -1946,7 +1958,7 @@ fr:
     type: Type
     type_to_search: Type à rechercher
     unable_to_connect_to_gateway: N'arrive pas à se connecter à la méthode de paiement.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Moins de %{price}
     unlock: Déverrouiller
     unrecognized_card_type: Le type de la carte n'est pas reconnu
@@ -1954,7 +1966,7 @@ fr:
     update: Mise à jour
     updating: Mise à jour
     usage_limit: Limite d'utilisation
-    use_app_default:
+    use_app_default: 
     use_billing_address: Utiliser l'adresse de facturation
     use_new_cc: Utiliser une nouvelle carte
     use_s3: Utiliser Amazon S3 pour les Images
@@ -1964,12 +1976,12 @@ fr:
     users: Utilisateurs
     validation:
       cannot_be_less_than_shipped_units: ne peut pas être inférieur à la quantité livrée.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: Surpasse le stock disponible. Merci de vous assurer que les quantités sont valides
       is_too_large: est trop importante -- le stock disponible ne peut pas couvrir la quantité demandée !
       must_be_int: doit être un entier
       must_be_non_negative: doit être une valeur positive ou nulle
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Valeur
     variant: Variante
     variant_placeholder: Choisissez une variante

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,3 +1,4 @@
+---
 id:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ id:
         state: Provinsi
         zipcode: Kode Pos
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -117,12 +118,12 @@ id:
         updated: Updated
         user: User
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
         name: Nama
         seo_title: Judul SEO
-        url:
+        url: 
       spree/tax_category:
         description: Deskripsi
         name: Nama
@@ -157,47 +158,47 @@ id:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Alamat
@@ -208,40 +209,40 @@ id:
       spree/credit_card:
         one: Kartu Kredit
         other: Kartu kredit lainnya
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Satuan Unit
         other: Satuan Unit lainnya
       spree/line_item:
         one: Barang
         other: Barang lainnya
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Pemesanan
         other: Pemesanan lainnya
       spree/payment:
         one: Pembayaran
         other: Pembayaran lainnya
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Produk
         other: Produk lainnya
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
         one: Properti
         other: Properti lainnya
       spree/prototype:
         one: Prototipe
         other: Prototipe lainnya
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Otorisasi Pengembalian
         other: Otorisasi Pengembalian lainnya
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Peran
         other: Peran lainnya
@@ -251,14 +252,14 @@ id:
       spree/shipping_category:
         one: Kategori Pengiriman
         other: Kategori Pengiriman lainnya
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: Provinsi
         other: Provinsi lainnya
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Kategori Pajak
         other: Kategori Pajak lainnya
@@ -271,7 +272,7 @@ id:
       spree/taxonomy:
         one: Taksonomi
         other: Taksonomi lainnya
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: Pengguna
         other: Pengguna lainnya
@@ -283,10 +284,10 @@ id:
         other: Wilayah-wilayah
   spree:
     abbreviation: Singkatan
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Akun
     account_updated: Akun sudah diperbarui!
     action: Aksi
@@ -299,7 +300,7 @@ id:
       list: Daftar
       listing: Daftar
       new: Baru
-      refund:
+      refund: 
       save: Simpan
       update: Pembaharuan
     activate: Aktivasi
@@ -307,7 +308,7 @@ id:
     add: Tambahkan
     add_action_of_type: Tambahkan Aksi Dari Tipe
     add_country: Tambahkan Negara
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Tambahkan Header
     add_new_style: Tambahkan Style Baru
     add_one: Tambahkan satu
@@ -323,7 +324,7 @@ id:
     additional_item: Tambahan Harga Barang
     address1: Alamat
     address2: Alamat (lanjutan)
-    adjustable:
+    adjustable: 
     adjustment: Penyesuaian
     adjustment_amount: Jumlah
     adjustment_successfully_closed: Penyesuaian telah berhasil ditutup!
@@ -332,36 +333,36 @@ id:
     adjustments: Penambahan
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administrasi
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Setuju kepada Kebijakan Privasi
     agree_to_terms_of_service: Setuju kepada Ketentuan Servis
     all: Semua
     all_adjustments_closed: Semua penyesuaian berhasil ditutup!
     all_adjustments_opened: Semua penyesuaian berhasil dibuka!
     all_departments: Semua departemen
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Memperbolehkan SSL untuk development dan test
     allow_ssl_in_production: Memperbolehkan SSL untuk production
     allow_ssl_in_staging: Memperbolehkan SSL untuk staging mode
@@ -383,39 +384,41 @@ id:
     are_you_sure: Anda yakin?
     are_you_sure_delete: Anda yakin mau menghilangkan record berikut?
     associated_adjustment_closed: Penyesuaian yang dimaksud telah ditutup. Apakah Anda mau membukanya?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Gagal Otorisasi
     authorized: Otorisasi
     auto_capture: auto capture
     available_on: Tersedia Pada
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Kembali
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Kembali ke Toko
     back_to_users_list: Kembali ke Daftar User
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Sisa Pelunasan
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Alamat Tagihan
     billing: Penagihan
     billing_address: Alamat Penagihan
     both: Kedua-nya
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Kalkulator
-    calculator_settings_warning: Jika anda sedang mengganti tipe kalkulator, anda harus menyimpan terlebih dahulu sebelum anda dapat mengubah pengaturan kalkulator
+    calculator_settings_warning: Jika anda sedang mengganti tipe kalkulator, anda harus menyimpan terlebih dahulu sebelum anda dapat mengubah
+      pengaturan kalkulator
     cancel: Batal
     canceled_at: Dibatalkan pada
     canceler: Dibatalkan oleh
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: Anda tidak dapat melakukan pembayaran untuk pemesanan, tanpa mendefinisikan metode pembayaran terlebih dahulu
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: Anda tidak dapat melakukan pembayaran untuk pemesanan, tanpa mendefinisikan metode pembayaran
+      terlebih dahulu
     cannot_create_returns: Tidak dapat melakukan pengembalian untuk pemesanan ini karena tidak ada barang yang dikirim
     cannot_perform_operation: Tidak dapat melakukan pekerjaan yang diminta
     cannot_set_shipping_method_without_address: Tidak bisa memilih metode pengiriman sampai detil info pelanggan diberikan.
@@ -440,8 +443,8 @@ id:
     city: Kota
     clear_cache: Clear cache
     clear_cache_ok: clear cache OK
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Gandakan
     close: Tutup
     close_all_adjustments: Tutup Semua Penyesuaian
@@ -458,18 +461,18 @@ id:
     cost_currency: Biaya Mata Uang
     cost_price: Harga Pokok
     could_not_connect_to_jirafe: Tidak dapat terhubung ke Jirafe untuk sinkronisasi data. Akan dicoba kembali secara otomatis.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: Ada masalah saat menyimpan pergerakan stok. Silahkan dicoba kembali.
-    count_on_hand:
+    count_on_hand: 
     countries: Negara
     country: Negara
     country_based: Berdasarkan negara
     country_name: Nama Negara
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Kupon
     coupon_code: Kode kupon
     coupon_code_already_applied: Kode kupon suda diaplikasikan ke pemesanan ini sebelumnya.
@@ -479,7 +482,7 @@ id:
     coupon_code_max_usage: Pemakaian kode kupon telah melewati batas
     coupon_code_not_eligible: Kode kupon tidak bisa digunakan untuk pemesanan ini.
     coupon_code_not_found: Kode kupon yang Anda masukkan tidak tersedia. Silahkan dicoba kembali.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Buat
     create_a_new_account: Buat akun baru
     create_new_order: Bikin order baru
@@ -509,8 +512,8 @@ id:
       jirafe:
         app_id: ID Aplikasi
         app_token: Token Aplikasi
-        currently_unavailable:
-        explanation:
+        currently_unavailable: 
+        explanation: 
         header: Pengaturan Analisis Jirafe
         site_id: ID Situs
         token: Token
@@ -518,16 +521,16 @@ id:
     date: Tanggal
     date_completed: Tanggal Selesai
     date_picker:
-      first_day:
+      first_day: 
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
     date_range: Rentang Tanggal
     default: Nilai Awal
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Nilai Awal Pajak
     default_tax_zone: Wilayah Pajak Awal
     delete: Hapus
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Pengiriman
     depth: Kedalaman
     description: Deskripsi
@@ -538,26 +541,26 @@ id:
     dismiss_banner: Tidak. Terima Kasih! Saya tidak tertarik, jangan tampilkan pesan ini lagi
     display: Tampilan
     display_currency: Tampilan mata uang
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Ubah
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Pengubahan Pengguna
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Email
     empty: Kosong
     empty_cart: Kosongkan Keranjang Belanja
@@ -589,20 +592,20 @@ id:
         user:
           signup: Pendaftaran pengguna
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Waktu kedaluwarsa
     extension: Ektensi
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Nama file
     fill_in_customer_info: Silahkan isi informasi pelanggan
     filter_results: Hasil Filter
     finalize: Penyelesaian
     finalized: Diselesaikan
-    find_a_taxon:
+    find_a_taxon: 
     first_item: Harga Barang Pertama
     first_name: Nama Depan
     first_name_begins_with: Nama Depan Dimulai Dengan
@@ -627,38 +630,38 @@ id:
     hide_cents: Sembunyikan nilai sen
     home: Beranda
     i18n:
-      available_locales:
+      available_locales: 
       language: Bahasa
       localization_settings: Pengaturan Lokalisasi
       this_file_language: Indonesian (ID)
     icon: Ikon
-    identifier:
+    identifier: 
     image: Gambar
     images: Gambar
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Termasuk dalam Harga
     included_price_validation: tidak dapat dipilih jika anda tidak mengatur Area Awal Pajak
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: Isi formulir di bawah ini dan instruksi perubahan kata sandi akan dikirimkan ke email anda
     insufficient_stock: Stok tidak cukup, hanya tersedia %{on_hand} buah
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Ganti email penerima dengan email ini
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Penyedia pembayaran tidak valid
     invalid_promotion_action: Aksi promosi tidak valid
     invalid_promotion_rule: Aturan promosi tidak valid
     inventory: Inventori
     inventory_adjustment: Penyesuaian Inventori
     inventory_error_flash_for_insufficient_quantity: Sebuah barang dalam keranjang Anda menjadi tidak tersedia.
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: tidak tersedia untuk alamat tujuan
     iso_name: Nama ISO
     item: Barang
@@ -668,26 +671,26 @@ id:
       operators:
         gt: lebih besar dari
         gte: lebih besar dari atau sama dengan
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: Nama Belakang
     last_name_begins_with: Nama Belakang Dimulai Dengan
     learn_more: Mengenal Lebih
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Daftar
     loading: Loading
     locale_changed: Bahasa telah terganti
     location: Lokasi
     lock: Kunci
-    log_entries:
+    log_entries: 
     logged_in_as: Login sebagai
     logged_in_succesfully: Login berhasil
     logged_out: Anda telah keluar.
@@ -696,13 +699,13 @@ id:
     login_failed: Otentikasi login gagal.
     login_name: Login
     logout: Keluar
-    logs:
+    logs: 
     look_for_similar_items: Cari barang yang mirip
     make_refund: Melakukan pengembalian
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Harga Master
     match_choices:
       all: Semua
@@ -736,20 +739,20 @@ id:
     new_payment_method: Metode baru pembayaran
     new_product: Produk baru
     new_promotion: Promosi baru
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Properti baru
     new_prototype: Prototipe baru
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Pengembalian baru
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Kategori pengiriman baru
     new_shipping_method: Metode pengiriman baru
     new_state: Provinsi baru
     new_stock_location: Lokasi Stok Baru
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_movement: 
+    new_stock_transfer: 
     new_tax_category: Kategori pajak baru
     new_tax_rate: Tarif pajak baru
     new_taxon: Takson baru
@@ -760,24 +763,24 @@ id:
     new_zone: Daerah baru
     next: Lanjut
     no_actions_added: Tidak ada aksi yang ditambahkan
-    no_payment_found:
-    no_pending_payments:
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: Produk tidak ditemukan
-    no_resource_found:
+    no_resource_found: 
     no_results: Tidak ada hasil
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: Tidak ada aturan tambahan
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
     none: Tidak ada
-    none_selected:
+    none_selected: 
     normal_amount: Jumlah normal
     not: Bukan
     not_available: Tidak tersedia
-    not_enough_stock:
+    not_enough_stock: 
     not_found: "%{resource} tidak ditemukan"
-    note:
+    note: 
     notice_messages:
       product_cloned: Produk telah digandakan
       product_deleted: Produk telah dihapus
@@ -785,12 +788,12 @@ id:
       product_not_deleted: Produk tidak dapat dihapus
       variant_deleted: Varian dapat dihapus
       variant_not_deleted: Varian tidak dapat dihapus
-    num_orders:
+    num_orders: 
     on_hand: Stok yang tersedia
     open: Buka
     open_all_adjustments: Buka Semua Penyesuaian
     option_type: Pilihan tipe
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Pilihan tipe
     option_value: Pilihan nilai
     option_values: Pilihan nilai
@@ -800,9 +803,9 @@ id:
     or_over_price: "%{price} atau lebih"
     order: Pemesanan
     order_adjustments: Penyesuaian pemesanan
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Rincian pemesanan
     order_email_resent: Pengiriman ulang email pemesanan
     order_information: Informasi Pemesanan
@@ -812,20 +815,20 @@ id:
         instructions: Pemesanan anda telah DIBATALKAN.  Silahkan simpan informasi pendaftaran ini untuk catatan anda.
         order_summary_canceled: Rekap pemesanan [DIBATALKAN]
         subject: Pembatalan order
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Untuk pelanggan,\n
         instructions: Silahkan melihat dan menyimpan urutan informasi sebagai berikut untuk catatan anda.
         order_summary: Rekap pemesanan
         subject: Konfirmasi pemesanan
-        subtotal:
+        subtotal: 
         thanks: Terima kasih.
-        total:
+        total: 
     order_not_found: Kami tidak dapat menemukan pemesanan Anda. Silahkan coba lagi.
     order_number: Nomor Pemesanan
     order_processed_successfully: Pemesanan anda telah berhasil diproses
-    order_resumed:
+    order_resumed: 
     order_state:
       address: Alamat
       awaiting_return: Menunggu pengembalian
@@ -843,14 +846,14 @@ id:
     order_total: Total pemesanan
     order_updated: Memperbarui pemesanan
     orders: Pemesanan
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Stok habis
     overview: Keseluruhan
     package_from: paket dari
     pagination:
       first: halaman awal
-      previous: « halaman sebelumnya
       next_page: halaman selanjutnya »
+      previous: "« halaman sebelumnya"
       previous_page: "« halaman sebelumnya"
       truncate: "…"
     password: Kata sandi
@@ -858,11 +861,11 @@ id:
     path: Path
     pay: Membayar
     payment: Pembayaran
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Informasi Pembayaran
     payment_method: Metode Pembayaran
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Metode Pembayaran
     payment_processing_failed: Pembayaran tidak dapat diproses, silahkan periksa rincian yang anda masukan
     payment_processor_choose_banner_text: Jika anda membutuhkan pilihan bantuan untuk proses pembayaran, silahkan kunjungi
@@ -880,7 +883,7 @@ id:
       void: membatalkan
     payment_updated: Pembayaran diperbaharui
     payments: Pembayaran
-    pending:
+    pending: 
     percent: Persen
     percent_per_item: Persentase per barang
     permalink: Permalink
@@ -889,13 +892,13 @@ id:
     please_define_payment_methods: Silahkan mendefinisikan beberapa metode pembayaran pertama.
     populate_get_error: Sesuatu ada yang salah. Silahkan mencoba ulang untuk menambahkan barang.
     powered_by: Didukung oleh
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Presentasi
     previous: Sebelumnya
-    previous_state_missing:
+    previous_state_missing: 
     price: Harga
     price_range: Batasan Harga
     price_sack: price sack
@@ -903,14 +906,14 @@ id:
     product: Produk
     product_details: Rincian Produk
     product_has_no_description: Produk ini tidak memiliki deskripsi
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: Properti Produk
     product_rule:
       choose_products: Pilih produk
-      label:
+      label: 
       match_all: semua
       match_any: Minimal satu
-      match_none:
+      match_none: 
       product_source:
         group: Dari kelompok produk
         manual: Pilih manual
@@ -922,14 +925,14 @@ id:
         description: Membuat penyesuaian kredit promosi pada pembelian
         name: Membuat penyesuaian
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Penuhi keranjang belanja dengan kuantitas varian yang telah ditentukan
         name: Tambah barang baru
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Aksi
     promotion_form:
       match_policies:
@@ -947,27 +950,27 @@ id:
         description: Pelanggan harus telah mengunjungi halaman spesifik
         name: Halaman Arahan
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Pemesanan berisi produk spesifik
         name: Produk
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Hanya tersedia untuk pengguna tertentu
         name: Pengguna
       user_logged_in:
         description: Hanya tersedia untuk pengguna yang telah masuk
         name: Pengguna yang telah masuk
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promosi
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Properti
     property: Properti
     prototype: Prototipe
@@ -982,42 +985,42 @@ id:
     rate: Harga
     reason: Sebab
     receive: Terima
-    receive_stock:
+    receive_stock: 
     received: Telah diterima
-    reception_status:
+    reception_status: 
     reference: Referensi
     refund: Pengembalian Uang
     refund_amount_must_be_greater_than_zero: Pengembalian Uang harus lebih besar dari 0
     refund_reasons: Alasan Pengembalian Uang
-    refunded_amount:
-    refunds:
+    refunded_amount: 
+    refunds: 
     register: Mendaftar sebagai Pengguna Baru
     registration: Pendaftaran
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
     reject: Ditolak
     rejected: Penolakan
     remember_me: Ingat otomatis
     remove: Menghapus
     rename: Menamakan Ulang
-    report:
+    report: 
     reports: Laporan
     resend: Kirim Ulang
     reset_password: atur ulang kata sandi
@@ -1026,19 +1029,19 @@ id:
     resumed: Telah Dilanjutkan
     return: Kembali
     return_authorization: Otorisasi Pengembalian
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Otorisasi Pengembalian telah dirubah
     return_authorizations: Otorisasi Pengembalian
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
     return_items: Pengembalian Barang
-    return_items_cannot_be_associated_with_multiple_orders:
+    return_items_cannot_be_associated_with_multiple_orders: 
     return_number: Nomor Pengembalian Barang
     return_quantity: Jumlah Pengembalian
     returned: Telah Dikembalikan
-    returns:
+    returns: 
     review: Periksa
     risk: Risiko
     risk_analysis: Analisis risiko
@@ -1063,8 +1066,8 @@ id:
     secure_connection_type: Jenis Koneksi Aman
     security_settings: Pengaturan Kemanan
     select: Pilih
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Pilih dari Prototipe
     select_stock: Pilih stok
     send_copy_of_all_mails_to: Kirim Salinan ke semua
@@ -1086,17 +1089,17 @@ id:
         subject: Pemberitahuan Pengiriman
         thanks: Terima kasih untuk bisnis anda
         track_information: 'Informasi Pelacakan: %{tracking}'
-        track_link:
+        track_link: 
     shipment_state: Status Pengiriman
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: 
       partial: Sebagian
       pending: tunda
       ready: siap
       shipped: dikirim
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Pengiriman
     shipped: Dikirim
     shipping: Mengirimkan
@@ -1127,55 +1130,55 @@ id:
     split: Urai
     spree_gateway_error_flash_for_checkout: Terdapat suatu masalah dengan informasi pembayaran anda. Cek informasi anda lagi dan coba lagi.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Mulai
     state: Provinsi
     state_based: Berdasar Provinsi
     state_machine_states:
       accepted: Diterima
       address: Alamat
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Provinsi
     states_required: Memerlukan Provinsi
     status: Status
-    stock:
+    stock: 
     stock_location: Lokasi Stok
     stock_location_info: Informasi lokasi stok
     stock_locations: Lokasi Stok
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Manajemen Stok
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: 
     stock_movements: Pergerakan Stok
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
     stock_transfer: Pemindahan Stok
     stock_transfers: Pemindahan Stok
     stop: Berakhir
@@ -1186,28 +1189,28 @@ id:
     subtract: Kurangi
     success: Sukses
     successfully_created: "%{resource} telah Berhasil Dibuat!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} telah Berhasil Dihapus!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: 
     successfully_updated: "%{resource} telah Berhasil Diubah!"
-    summary:
+    summary: 
     tax: Pajak
     tax_categories: Kategori Pajak
     tax_category: Kategori Pajak
     tax_code: Kode Pajak
     tax_included: Termasuk Pajak
-    tax_rate_amount_explanation:
+    tax_rate_amount_explanation: 
     tax_rates: Tingkat Pajak
     taxon: Takson
     taxon_edit: Ubah Takson
     taxon_placeholder: Placeholder Takson
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taksonomi
-    taxonomy:
+    taxonomy: 
     taxonomy_edit: Edit taksonomy
     taxonomy_tree_error: Permintaan perubahan belum diterima dan susunan kembali kepada pengaturan awal, tolong coba lagi.
     taxonomy_tree_instruction: "* Klik kanan untuk mengakses child di dalam tree untuk menambah, menghapus atau mengurutkan"
@@ -1222,40 +1225,40 @@ id:
     thank_you_for_your_order: Terima kasih atas pemesanan anda. Silahkan cetak salinan dari halaman konfirmasi ini untuk arsip anda.
     there_are_no_items_for_this_order: Tidak ada barang dalam pemesanan ini
     there_were_problems_with_the_following_fields: Terdapat beberapa masalah dengan
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Waktu
     to_add_variants_you_must_first_define: Untuk menambah varian, pertama kali anda harus mendefinisikan
     total: Total
     total_per_item: Total per barang
-    total_pre_tax_refund:
+    total_pre_tax_refund: 
     total_price: Total Harga
-    total_sales:
-    track_inventory:
+    total_sales: 
+    track_inventory: 
     tracking: Pelacakan
     tracking_number: Nomor Pelacakan
-    tracking_url:
+    tracking_url: 
     tracking_url_placeholder: 'contoh: e.g. http://quickship.com/package?num=:tracking'
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
     tree: Susunan
     type: Tipe
     type_to_search: Ketik untuk Mencari
     unable_to_connect_to_gateway: Tidak dapat berkoneksi dengan gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Dibawah %{price}
-    unlock:
+    unlock: 
     unrecognized_card_type: Tipe Kartu tidak dikenal
     unshippable_items: Barang-barang yang Tidak Bisa Dikirim
     update: Perbarui
     updating: Memberbarui
     usage_limit: Batas Penggunaan
-    use_app_default:
+    use_app_default: 
     use_billing_address: Alamat Penagihan
     use_new_cc: Gunakan kartu baru
     use_s3: Pakai Amazon S3 untuk gambar
@@ -1265,12 +1268,12 @@ id:
     users: Pengguna
     validation:
       cannot_be_less_than_shipped_units: tidak bisa kurang dari jumlah barang yang dikirimkan.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: melebihi stok yang tersedia. Silahkan pastikan barang-barang Anda mempunyai jumlah yang benar.
       is_too_large: terlalu besar -- stok tidak dapat memenuhi kuantitas yang telah dipesan!
       must_be_int: Harus berupa integer
       must_be_non_negative: Harus merupakan nilai positif
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Nilai
     variant: Varian
     variant_placeholder: Varian placeholder

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,23 +1,45 @@
+---
 it:
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        cancel: Annulla
+        quantity: Quantità
+        shipment: Spedizione
+        state: Stato
   activerecord:
     attributes:
       spree/address:
         address1: Indirizzo
         address2: Indirizzo (agg.)
         city: Città
+        company: Azienda
         country: Nazione
         firstname: Nome
         lastname: Cognome
         phone: Telefono
         state: Provincia
         zipcode: CAP
-        company: Azienda
+      spree/adjustment:
+        adjustable: Variabile
+        adjustment_reason_id: Motivazione
+        amount: Quantità
+        label: Descrizione
+        name: Nome
+        state: Stato
+      spree/adjustment_reason:
+        active: Attivo
+        code: Codice
+        name: Nome
+        state: Stato
       spree/calculator/tiered_flat_rate:
         preferred_base_amount: Importo Base
         preferred_tiers: Livelli
       spree/calculator/tiered_percent:
         preferred_base_percent: Percentuale Base
         preferred_tiers: Livelli
+      spree/carton:
+        tracking: Tracciamento
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -27,47 +49,63 @@ it:
         states_required: Province o Stati Necessari
       spree/credit_card:
         base: ''
+        card_code: Codice Carta
         cc_type: Tipologia
+        expiration: Scadenza
         month: Mese
         name: Nome
         number: Numero
         verification_value: Codice di Verifica
         year: Anno
-        card_code: Codice Carta
-        expiration: Scadenza
+      spree/customer_return:
+        name: Nome
+        number: Numero Reso
+        pre_tax_total: Totale al lordo delle tasse
+        reimbursement_status: Stato Rimborso
+        total: Totale
+      spree/image:
+        alt: Testo Alternativo
+        attachment: Nome del file
       spree/inventory_unit:
         state: Stato
+      spree/legacy_user:
+        email: Email
+        password: Password
+        password_confirmation: Conferma Password
       spree/line_item:
-        price: Prezzo
-        quantity: Quantità
         description: Descrizione dell'articolo
         name: Nome
+        price: Prezzo
+        quantity: Quantità
         total: Prezzo totale
       spree/option_type:
         name: Nome
         presentation: Presentazione
+      spree/option_value:
+        name: Nome
+        presentation: Presentazione
       spree/order:
+        additional_tax_total: Tassazione
+        approved_at: Approvato il
+        approver_id: Approvatore
+        canceled_at: Annullato il
+        canceler_id: Annullatore
         checkout_complete: Checkout Completato
         completed_at: Completato il
         considered_risky: A rischio
         coupon_code: Codice Coupon
         created_at: Data Ordine
         email: E-Mail Cliente
+        included_tax_total: Tasse (incl.)
         ip_address: Indirizzo IP
         item_total: Totale Articoli
         number: Numero
         payment_state: Stato Pagamento
         shipment_state: Stato Spedizione
+        shipment_total: Totale Spedizione
         special_instructions: Istruzioni Aggiuntive
         state: Stato
         total: Totale
-        additional_tax_total: Tassazione
-        approved_at: Approvato il
-        approver_id: Approvatore
-        canceled_at: Annullato il
-        canceler_id: Annullatore
-        included_tax_total: Tasse (incl.)
-        shipment_total: Totale Spedizione
       spree/order/bill_address:
         address1: Indirizzo di fatturazione
         city: Città di fatturazione
@@ -89,32 +127,34 @@ it:
         response_code: ID transazione
         state: Stato Pagamento
       spree/payment_method:
-        name: Nome
         active: Attivo
         auto_capture: Riscossione Automatica
         description: Descrizione
         display_on: Mostra
+        name: Nome
         type: Fornitore
       spree/product:
         available_on: Disponibile dal
         cost_currency: Valuta Costo
         cost_price: Prezzo di Costo
-        description: Descrizione
-        master_price: Prezzo
-        name: Nome
-        on_hand: Disponibilità
-        shipping_category: Categoria di Spedizione
-        tax_category: Categoria di Tassazione
         depth: Profondità
+        description: Descrizione
         height: Altezza
+        master_price: Prezzo
         meta_description: Meta Description
         meta_keywords: Meta Keywords
         meta_title: Meta Title
+        name: Nome
+        on_hand: Disponibilità
         price: Prezzo principale
         promotionable: Promuovibile
+        shipping_category: Categoria di Spedizione
         slug: Permalink
+        tax_category: Categoria di Tassazione
         weight: Peso
         width: Larghezza
+      spree/product_property:
+        value: Valore
       spree/promotion:
         advertise: Publicizza
         code: Codice
@@ -134,11 +174,58 @@ it:
         presentation: Presentazione
       spree/prototype:
         name: Nome
+      spree/refund:
+        amount: Quantità
+        description: Descrizione
+        refund_reason_id: Motivazione
+      spree/refund_reason:
+        active: Attivo
+        code: Codice
+        name: Nome
+      spree/reimbursement:
+        number: Numero
+        reimbursement_status: Stato
+        total: Totale
+      spree/reimbursement/credit:
+        amount: Quantità
+      spree/reimbursement_type:
+        name: Nome
+        type: Tipo
       spree/return_authorization:
         amount: Quantità
         pre_tax_total: Totale al lordo delle tasse
+      spree/return_item:
+        acceptance_status: Stato Accettazione
+        acceptance_status_errors: Errori Accettazione
+        charged: Addebitato
+        exchange_variant: Cambio per
+        inventory_unit_state: Stato
+        override_reimbursement_type_id: Override Tipologia Rimborso
+        preferred_reimbursement_type_id: Tipologia di rimborso preferita
+        reception_status: 
+        return_reason: Motivazione
+        total: Totale
+      spree/return_reason:
+        active: Attivo
+        memo: Memo
+        name: Nome
+        number: Numero RMA
+        state: Stato
       spree/role:
         name: Nome
+      spree/shipment:
+        tracking: Codice Tracciamento
+      spree/shipping_category:
+        name: Nome
+      spree/shipping_method:
+        admin_name: Nome Interno
+        code: Codice
+        display_on: Mostra
+        name: Nome
+        tracking_url: URL Tracciamento
+      spree/shipping_rate:
+        amount: Quantità
+        tax_rate: Aliquota
       spree/state:
         abbr: Abbreviazione
         name: Nome
@@ -150,142 +237,13 @@ it:
         type: Tipo
         updated: Aggiornato
         user: Utente
-      spree/store:
-        mail_from_address: Indirizzo Mittente Email
-        meta_description: Meta Description
-        meta_keywords: Meta Keywords
-        name: Nome
-        seo_title: Titolo SEO
-        url: URL Sito
-      spree/tax_category:
-        description: Descrizione
-        name: Nome
-        is_default: Default
-        tax_code: Codice Tassa
-      spree/tax_rate:
-        amount: Tasso
-        included_in_price: Incluso nel Prezzo
-        show_rate_in_label: Mostra tasso nell'etichetta
-        name: Nome
-      spree/taxon:
-        name: Nome
-        permalink: Permalink
-        position: Posizione
-        description: Descrizione
-        icon: Icona
-        meta_description: Meta Description
-        meta_keywords: Meta Keywords
-        meta_title: Meta Title
-      spree/taxonomy:
-        name: Nome
-      spree/user:
-        email: Email
-        password: Password
-        password_confirmation: Conferma Password
-      spree/variant:
-        cost_currency: Valuta Costo
-        cost_price: Prezzo di Costo
-        depth: Profondità
-        height: Altezza
-        price: Prezzo
-        sku: SKU
-        weight: Peso
-        width: Larghezza
-      spree/zone:
-        description: Descrizione
-        name: Nome
-        default_tax: Zona di Tassazione di Default
-      spree/adjustment:
-        adjustable: Variabile
-        amount: Quantità
-        label: Descrizione
-        name: Nome
-        state: Stato
-        adjustment_reason_id: Motivazione
-      spree/adjustment_reason:
-        active: Attivo
-        code: Codice
-        name: Nome
-        state: Stato
-      spree/carton:
-        tracking: Tracciamento
-      spree/customer_return:
-        number: Numero Reso
-        pre_tax_total: Totale al lordo delle tasse
-        total: Totale
-        reimbursement_status: Stato Rimborso
-        name: Nome
-      spree/image:
-        alt: Testo Alternativo
-        attachment: Nome del file
-      spree/legacy_user:
-        email: Email
-        password: Password
-        password_confirmation: Conferma Password
-      spree/option_value:
-        name: Nome
-        presentation: Presentazione
-      spree/product_property:
-        value: Valore
-      spree/refund:
-        amount: Quantità
-        description: Descrizione
-        refund_reason_id: Motivazione
-      spree/refund_reason:
-        active: Attivo
-        name: Nome
-        code: Codice
-      spree/reimbursement:
-        number: Numero
-        reimbursement_status: Stato
-        total: Totale
-      spree/reimbursement/credit:
-        amount: Quantità
-      spree/reimbursement_type:
-        name: Nome
-        type: Tipo
-      spree/return_item:
-        acceptance_status: Stato Accettazione
-        acceptance_status_errors: Errori Accettazione
-        charged: Addebitato
-        exchange_variant: Cambio per
-        inventory_unit_state: Stato
-        override_reimbursement_type_id: Override Tipologia Rimborso
-        preferred_reimbursement_type_id: Tipologia di rimborso preferita
-        reception_status:
-        return_reason: Motivazione
-        total: Totale
-      spree/return_reason:
-        name: Nome
-        active: Attivo
-        memo: Memo
-        number: Numero RMA
-        state: Stato
-      spree/shipping_category:
-        name: Nome
-      spree/shipment:
-        tracking: Codice Tracciamento
-      spree/shipping_method:
-        admin_name: Nome Interno
-        code: Codice
-        display_on: Mostra
-        name: Nome
-        tracking_url: URL Tracciamento
-      spree/shipping_rate:
-        tax_rate: Aliquota
-        amount: Quantità
-      spree/store_credit:
-        amount: Quantità
-        memo: Memo
-      spree/store_credit_event:
-        action: Azione
       spree/stock_item:
         count_on_hand: Disponibilità
       spree/stock_location:
-        admin_name: Nome Interno
         active: Attivo
         address1: Indirizzo
         address2: Indirizzo (agg.)
+        admin_name: Nome Interno
         backorderable_default: Ordinabile di default
         city: Città
         code: Codice
@@ -304,9 +262,59 @@ it:
         created_at: Creato Il
         description: Descrizione
         tracking_number: Codice Tracciamento
+      spree/store:
+        mail_from_address: Indirizzo Mittente Email
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        name: Nome
+        seo_title: Titolo SEO
+        url: URL Sito
+      spree/store_credit:
+        amount: Quantità
+        memo: Memo
+      spree/store_credit_event:
+        action: Azione
+      spree/tax_category:
+        description: Descrizione
+        is_default: Default
+        name: Nome
+        tax_code: Codice Tassa
+      spree/tax_rate:
+        amount: Tasso
+        included_in_price: Incluso nel Prezzo
+        name: Nome
+        show_rate_in_label: Mostra tasso nell'etichetta
+      spree/taxon:
+        description: Descrizione
+        icon: Icona
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        meta_title: Meta Title
+        name: Nome
+        permalink: Permalink
+        position: Posizione
+      spree/taxonomy:
+        name: Nome
       spree/tracker:
-        analytics_id: Analytics ID
         active: Attivo
+        analytics_id: Analytics ID
+      spree/user:
+        email: Email
+        password: Password
+        password_confirmation: Conferma Password
+      spree/variant:
+        cost_currency: Valuta Costo
+        cost_price: Prezzo di Costo
+        depth: Profondità
+        height: Altezza
+        price: Prezzo
+        sku: SKU
+        weight: Peso
+        width: Larghezza
+      spree/zone:
+        default_tax: Zona di Tassazione di Default
+        description: Descrizione
+        name: Nome
     errors:
       models:
         spree/calculator/tiered_flat_rate:
@@ -468,31 +476,6 @@ it:
       spree/zone:
         one: Zona
         other: Zone
-  activemodel:
-    attributes:
-      spree/adjustment:
-        one: Variazione
-        other: Variazioni
-      spree/calculator:
-        one: Calcolatore
-      spree/legacy_user:
-        one: Utente
-        other: Utenti
-      spree/log_entry:
-        other: Voci Log
-      spree/order_cancellations:
-        quantity: Quantità
-        state: Stato
-        shipment: Spedizione
-        cancel: Annulla
-      spree/product_property:
-        other: Proprietà del prodotto
-      spree/refund:
-        one: Rimborso
-        other: Rimborsi
-      spree/store_credit_category:
-        one: Categoria
-        other: Categorie
   spree:
     abbreviation: Abbreviazione
     accept: Accetta
@@ -503,22 +486,22 @@ it:
     account_updated: Account aggiornato
     action: Azione
     actions:
+      add: Aggiungi
       cancel: Annulla
       continue: Continua
       create: Crea
+      delete: Elimina
       destroy: Elimina
       edit: Modifica
       list: Lista
       listing: Lista
       new: Nuovo
       refund: Rimborso
-      save: Salva
-      update: Aggiorna
-      add: Aggiungi
-      delete: Elimina
       remove: Rimuovi
+      save: Salva
       ship: spedisci
       split: Diviso
+      update: Aggiorna
     activate: Attiva
     active: Attivo
     add: Aggiungi
@@ -553,6 +536,16 @@ it:
     adjustment_total: Totale Variazione
     adjustments: Variazioni
     admin:
+      prices:
+        any_country: Tutte le nazioni
+        index:
+          amount_greater_than: Quantità maggiore di
+          amount_less_than: Quantità minore di
+          new_price: Nuovo prezzo
+      store_credits:
+        add: Nuovo credito
+        back_to_user_list: Lista utenti
+        select_reason: Motivo
       tab:
         areas: Zone
         checkout: Checkout
@@ -563,7 +556,7 @@ it:
         overview: Quadro generale
         payments: Pagamenti
         products: Prodotti
-        promotion_categories:
+        promotion_categories: 
         promotions: Promozioni
         properties: Proprietà
         prototypes: Prototipi
@@ -578,12 +571,6 @@ it:
         taxonomies: Tassonomie
         taxons: Taxon
         users: Utenti
-        checkout: Checkout
-        general: Generale
-        payments: Pagamenti
-        settings: Impostazioni
-        shipping: Spedizione
-        stock: Stock
       user:
         account: Account
         addresses: Indirizzi
@@ -592,18 +579,8 @@ it:
         order_history: Storia Ordini
         order_num: 'Ordine #'
         orders: Ordini
-        user_information: Informazioni Utente
         store_credit: Credito
-      prices:
-        any_country: Tutte le nazioni
-        index:
-          amount_less_than: Quantità minore di
-          amount_greater_than: Quantità maggiore di
-          new_price: Nuovo prezzo
-      store_credits:
-        add: Nuovo credito
-        back_to_user_list: Lista utenti
-        select_reason: Motivo
+        user_information: Informazioni Utente
     admin_login: Login
     administration: Amministrazione
     advertise: Promuovi
@@ -631,10 +608,10 @@ it:
     and: e
     api:
       access: Accesso
-      key: Chiave
-      no_key: Nessuna Chiave
       clear_key: Elimina Chiave
       generate_key: Genera Chiave
+      key: Chiave
+      no_key: Nessuna Chiave
       regenerate_key: Genera nuova Chiave
     approve: approva
     approved_at: Approvato il
@@ -657,7 +634,7 @@ it:
     back_to_payment: Torna al Pagamento
     back_to_products_list: Lista prodotti
     back_to_reports_list: Lista reports
-    back_to_resource_list: "Torna alla Lista %{resource}"
+    back_to_resource_list: Torna alla Lista %{resource}
     back_to_rma_reason_list: Torna alla Lista Motivazioni RMA
     back_to_shipping_categories: Lista categorie di spedizione
     back_to_shipping_methods_list: Lista metodi di spedizione
@@ -822,10 +799,10 @@ it:
     doesnt_track_inventory: Non tiene traccia dell'inventario
     edit: Modifica
     editing_country: Modifica nazione
-    editing_resource: 'Modifica %{resource}'
+    editing_resource: Modifica %{resource}
     editing_rma_reason: Modifica Motivazione RMA
-    editing_shipping_method: Modifica metodo di spedizione
     editing_shipping_category: Modifica categoria di spedizione
+    editing_shipping_method: Modifica metodo di spedizione
     editing_state: Modifica stati
     editing_stock_location: Modifica magazzino
     editing_tax_category: Modifica catgoria di tassazione
@@ -878,11 +855,15 @@ it:
         user:
           signup: Registrazione dell'utente
     exceptions:
-      count_on_hand_setter: Non è possibile impostare la disponibilità manualmente dato che è calcolata automaticamente dalla callback "recalculate_count_on_hand". Per favore usa il metodo "update_column(:count_on_hand, value)".
+      count_on_hand_setter: >-
+        Non è possibile impostare la disponibilità manualmente dato che è calcolata automaticamente dalla callback "recalculate_count_on_hand".
+        Per favore usa il metodo "update_column(:count_on_hand, value)".
     exchange_for: Cambio per
     excl: escl.
     existing_shipments: Spedizioni esistenti
-    expedited_exchanges_warning: Ogni cambio specificato sarà spedito al cliente immediatamente dopo il salvataggio. Al cliente sarà addebitato l'importo completo dell'articolo se l'articolo originale non verrà restituito entro %{days_window} giorni.
+    expedited_exchanges_warning: >-
+      Ogni cambio specificato sarà spedito al cliente immediatamente dopo il salvataggio. Al cliente sarà addebitato l'importo completo dell'articolo
+      se l'articolo originale non verrà restituito entro %{days_window} giorni.
     expiration: Scadenza
     extension: Estensione
     failed_payment_attempts: Tentativi di Pagamento falliti
@@ -933,8 +914,8 @@ it:
     icon: Icona
     image: Immagine
     images: Immagini
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
     inactive: Inattivo
     incl: incl.
     included_in_price: Incluso nel prezzo
@@ -963,7 +944,6 @@ it:
       canceled: annullato
       returned: restituito
       shipped: spedito
-      on_hand: disponibile
     is_not_available_to_shipment_address: non è disponibile per l'indirizzo di spedizione
     iso_name: Nome Iso
     item: articolo
@@ -1078,7 +1058,7 @@ it:
     no_pending_payments: Nessun pagamento pendente
     no_products_found: Nessun prodotto trovato
     no_resource: Nessuna risorsa
-    no_resource_found: "Nessun %{resource} trovato"
+    no_resource_found: Nessun %{resource} trovato
     no_resource_found_link: Aggiungine Uno
     no_results: Nessun risultato
     no_returns_found: Nessuna restituazione trovata
@@ -1125,18 +1105,14 @@ it:
     order_information: Informazioni sull'Ordine
     order_mailer:
       cancel_email:
-        dear_customer: 'Gentile Cliente,
-
-'
+        dear_customer: Gentile Cliente,
         instructions: Il tuo ordine è stato ANNULLATO. Per favore conserva queste informazioni per attestare l'annullamento.
         order_summary_canceled: Riassunto Ordine [ANNULLATO]
         subject: Annullamento Ordine
         subtotal: 'Subtotale:'
         total: 'Totale Ordine:'
       confirm_email:
-        dear_customer: 'Gentile Cliente,
-
-'
+        dear_customer: Gentile Cliente,
         instructions: Per favore rivedi queste informazioni e conservale come riferimento.
         order_summary: Riassunto Ordine
         subject: Conferma Ordine
@@ -1144,9 +1120,7 @@ it:
         thanks: Grazie per il tuo ordine.
         total: 'Totale Ordine:'
       inventory_cancellation:
-        dear_customer: 'Gentile Cliente,
-
-'
+        dear_customer: Gentile Cliente,
     order_not_found: Non abbiamo trovato il tuo ordine. Per favore riprova ancora.
     order_number: Ordine %{number}
     order_processed_successfully: Il tuo ordine è stato processato con successo
@@ -1168,7 +1142,7 @@ it:
     order_total: Totale Ordine
     order_updated: Ordine Aggiornato
     orders: Ordini
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Non disponibile
     overview: Panoramica
     package_from: pacco da
@@ -1308,7 +1282,7 @@ it:
     receive: ricevi
     receive_stock: Ricevi Scorte
     received: Ricevuto
-    reception_status:
+    reception_status: 
     reference: Riferimento
     refund: Rimborso
     refund_amount_must_be_greater_than_zero: L'importo del rimborso deve essere maggiore di zero
@@ -1405,9 +1379,7 @@ it:
     shipment_details: Da %{stock_location} via %{shipping_method}
     shipment_mailer:
       shipped_email:
-        dear_customer: 'Gentile Cliente,
-
-'
+        dear_customer: Gentile Cliente,
         instructions: Il tuo ordine è stato spedito
         shipment_summary: Riassunto Spedizione
         subject: Notifica di spedizione
@@ -1454,7 +1426,8 @@ it:
     source: Origine
     special_instructions: Istruzioni Speciali
     split: Diviso
-    spree_gateway_error_flash_for_checkout: Si è verificato un problema con le tue informazioni di pagamento. Per favore controlla le tue informazioni e prova ancora.
+    spree_gateway_error_flash_for_checkout: Si è verificato un problema con le tue informazioni di pagamento. Per favore controlla le tue informazioni
+      e prova ancora.
     ssl:
       change_protocol: Per favore passa all'utilizzo di HTTP (invece che HTTPS) e riprova questa richiesta.
     start: Inizio
@@ -1467,22 +1440,22 @@ it:
       awaiting: In Attesa
       awaiting_return: In attesa di reso
       backordered: Arretrato
-      cart: Carrello
       canceled: Annullato
+      cart: Carrello
       checkout: Checkout
-      confirm: Conferma
+      closed: Chiuso
       complete: Completo
       completed: Completato
-      closed: Chiuso
+      confirm: Conferma
       delivery: Spedizione
       errored: In Errore
       failed: Fallito
       given_to_customer: Dato al Cliente
       invalid: Non Valido
       manual_intervention_required: Richiesto intervento manuale
+      on_hand: Disponibile
       open: Aperto
       order: Ordine
-      on_hand: Disponibile
       payment: Pagamento
       pending: In Sospeso
       processing: In Lavorazione
@@ -1534,7 +1507,8 @@ it:
     tax_category: Categoria di Tassazione
     tax_code: Codice Tassa
     tax_included: Tassa (incl.)
-    tax_rate_amount_explanation: Le aliquote sono specificate con valore decimale per facilitare le operazioni, (es. se l'aliquota è al 5% inserisci 0.05)
+    tax_rate_amount_explanation: Le aliquote sono specificate con valore decimale per facilitare le operazioni, (es. se l'aliquota è al 5% inserisci
+      0.05)
     tax_rates: Aliquote
     taxon: Taxon
     taxon_edit: Modifica Taxon
@@ -1586,7 +1560,7 @@ it:
     type_to_search: Digita per cercare
     unable_to_connect_to_gateway: Impossibile connettersi al gateway.
     unable_to_create_reimbursements: Impossibile creare rimborsi perché ci sono articoli in attesa di intervento manuale.
-    under_price: "Inferiore di %{price}"
+    under_price: Inferiore di %{price}
     unfinalize_all_adjustments: Annulla la registrazione
     unlock: Sblocca
     unrecognized_card_type: Carda di credito non riconosciuta
@@ -1605,7 +1579,8 @@ it:
     users: Utenti
     validation:
       cannot_be_less_than_shipped_units: non può essere inferiore al numero di unità spedite.
-      cannot_destroy_line_item_as_inventory_units_have_shipped: Impossibile eliminare le righe d'ordine poiché alcune unità di inventario sono state spedite.
+      cannot_destroy_line_item_as_inventory_units_have_shipped: Impossibile eliminare le righe d'ordine poiché alcune unità di inventario sono
+        state spedite.
       exceeds_available_stock: supera la disponibilità di magazzino. Per favore assicurati che la quantità degli articoli sia valida.
       is_too_large: è troppo grande -- il magazzino non può coprire la quantità richiesta!
       must_be_int: deve essere un intero
@@ -1631,27 +1606,3 @@ it:
     zipcode: Codice Cap
     zone: Zona
     zones: Zone
-    canceled: annullato
-    cannot_create_payment_link: Per favore definisci prima dei metodi di pagamento.
-    inventory_states:
-      canceled: annullato
-      returned: restituito
-      shipped: spedito
-    no_resource_found_link: Aggiungine Uno
-    number: Numero
-    store_credit:
-      display_action:
-        adjustment: Variazione
-        credit: Credito
-        void: Credito
-        admin:
-          authorize: Autorizzato
-    store_credit_category:
-      default: Default
-  activemodel:
-    attributes:
-      spree/order_cancellations:
-        quantity: Quantità
-        state: Stato
-        shipment: Spedizione
-        cancel: Annulla

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,1398 +1,1398 @@
+---
 ja:
   activerecord:
     attributes:
       spree/address:
-        address1: "住所1"
-        address2: "住所2"
-        city: "市区町村"
-        country: "国"
-        firstname: "名前（名）"
-        lastname: "名前（姓）"
-        phone: "電話番号"
-        state: "都道府県（州）"
-        zipcode: "郵便番号"
+        address1: 住所1
+        address2: 住所2
+        city: 市区町村
+        country: 国
+        firstname: 名前（名）
+        lastname: 名前（姓）
+        phone: 電話番号
+        state: 都道府県（州）
+        zipcode: 郵便番号
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount: "基準量"
-        preferred_tiers: "列"
+        preferred_base_amount: 基準量
+        preferred_tiers: 列
       spree/calculator/tiered_percent:
-        preferred_base_percent: "基本％"
-        preferred_tiers: "列"
+        preferred_base_percent: 基本％
+        preferred_tiers: 列
       spree/country:
         iso: ISO
         iso3: ISO3
         iso_name: ISO名
-        name: "名"
+        name: 名
         numcode: ISOコード
       spree/credit_card:
-        base:
-        cc_type: "カード類"
-        month: "月"
-        name: "名前"
-        number: "カード番号"
-        verification_value: "照合コード"
-        year: "年"
+        base: 
+        cc_type: カード類
+        month: 月
+        name: 名前
+        number: カード番号
+        verification_value: 照合コード
+        year: 年
       spree/inventory_unit:
-        state: "都道府県（州）"
+        state: 都道府県（州）
       spree/line_item:
-        price: "価格"
-        quantity: "数量"
+        price: 価格
+        quantity: 数量
       spree/option_type:
-        name: "名称"
-        presentation: "表示"
+        name: 名称
+        presentation: 表示
       spree/order:
-        checkout_complete: "注文の受け付けを完了しました"
-        completed_at: "完了日時"
-        considered_risky: "リスク度"
-        coupon_code: "クーポンコード"
-        created_at: "注文日"
-        email: "メールアドレス"
+        checkout_complete: 注文の受け付けを完了しました
+        completed_at: 完了日時
+        considered_risky: リスク度
+        coupon_code: クーポンコード
+        created_at: 注文日
+        email: メールアドレス
         ip_address: IPアドレス
-        item_total: "合計個数"
-        name: "注文"
-        number: "注文番号"
-        payment_state: "支払い状態"
-        shipment_state: "配送状態"
-        special_instructions: "特記事項"
-        state: "状態"
-        total: "合計"
+        item_total: 合計個数
+        name: 注文
+        number: 注文番号
+        payment_state: 支払い状態
+        shipment_state: 配送状態
+        special_instructions: 特記事項
+        state: 状態
+        total: 合計
       spree/order/bill_address:
-        address1: "請求先の住所"
-        city: "請求先の住所・市"
-        firstname: "請求先の名"
-        lastname: "請求先の姓"
-        phone: "請求先の電話番号"
-        state: "請求先の都道府県(州)"
-        zipcode: "請求先の郵便番号"
+        address1: 請求先の住所
+        city: 請求先の住所・市
+        firstname: 請求先の名
+        lastname: 請求先の姓
+        phone: 請求先の電話番号
+        state: 請求先の都道府県(州)
+        zipcode: 請求先の郵便番号
       spree/order/ship_address:
-        address1: "配送先の住所"
-        city: "配送先の市"
-        firstname: "配送先の名"
-        lastname: "配送先の姓"
-        phone: "配送先の電話番号"
-        state: "配送先の都道府県(州)"
-        zipcode: "配送先の郵便番号"
+        address1: 配送先の住所
+        city: 配送先の市
+        firstname: 配送先の名
+        lastname: 配送先の姓
+        phone: 配送先の電話番号
+        state: 配送先の都道府県(州)
+        zipcode: 配送先の郵便番号
       spree/payment:
-        amount: "金額"
-        number: "数量"
+        amount: 金額
+        number: 数量
       spree/payment_method:
-        name: "名称"
+        name: 名称
       spree/product:
-        available_on: "販売開始日"
-        cost_currency: "コストカレンシー"
-        cost_price: "原価"
-        description: "説明"
-        master_price: "値段"
-        name: "商品名"
-        on_hand: "入荷数"
-        shipping_category: "配達区間"
-        tax_category: "税区"
+        available_on: 販売開始日
+        cost_currency: コストカレンシー
+        cost_price: 原価
+        description: 説明
+        master_price: 値段
+        name: 商品名
+        on_hand: 入荷数
+        shipping_category: 配達区間
+        tax_category: 税区
       spree/promotion:
-        advertise: "表示する"
-        code: "コード"
-        description: "説明"
-        event_name: "イベント名"
-        expires_at: "有効期限"
-        name: "名称"
-        path: "パス"
-        starts_at: "開始日時"
-        usage_limit: "使用可能回数"
+        advertise: 表示する
+        code: コード
+        description: 説明
+        event_name: イベント名
+        expires_at: 有効期限
+        name: 名称
+        path: パス
+        starts_at: 開始日時
+        usage_limit: 使用可能回数
       spree/promotion_category:
-        name: "名前"
+        name: 名前
       spree/property:
-        name: "名称"
-        presentation: "表示"
+        name: 名称
+        presentation: 表示
       spree/prototype:
-        name: "名称"
+        name: 名称
       spree/return_authorization:
-        amount: "合計"
+        amount: 合計
       spree/role:
-        name: "名称"
+        name: 名称
       spree/shipment:
-        number: "数量"
+        number: 数量
       spree/state:
-        abbr: "略語"
-        name: "名称"
+        abbr: 略語
+        name: 名称
       spree/state_change:
-        state_changes: "状態変化"
-        state_from: "状態元"
-        state_to: "状態先"
-        timestamp: "日時"
-        type: "タイプ"
-        updated: "更新"
-        user: "ユーザー"
+        state_changes: 状態変化
+        state_from: 状態元
+        state_to: 状態先
+        timestamp: 日時
+        type: タイプ
+        updated: 更新
+        user: ユーザー
       spree/store:
-        mail_from_address: "メールアドレス"
-        meta_description: "メタ 説明"
-        meta_keywords: "メタ キーワード"
-        name: "サイト名"
-        seo_title: "SEO タイトル"
-        url: "サイトURL"
+        mail_from_address: メールアドレス
+        meta_description: メタ 説明
+        meta_keywords: メタ キーワード
+        name: サイト名
+        seo_title: SEO タイトル
+        url: サイトURL
       spree/tax_category:
-        description: "説明"
-        name: "名称"
+        description: 説明
+        name: 名称
       spree/tax_rate:
-        amount: "率"
-        included_in_price: "税込み"
-        show_rate_in_label: "税率を見る"
+        amount: 率
+        included_in_price: 税込み
+        show_rate_in_label: 税率を見る
       spree/taxon:
-        name: "名称"
-        permalink: "固定リンク"
-        position: "位置"
+        name: 名称
+        permalink: 固定リンク
+        position: 位置
       spree/taxonomy:
-        name: "名称"
+        name: 名称
       spree/user:
         email: Eメール
-        password: "パスワード"
-        password_confirmation: "パスワード（確認）"
+        password: パスワード
+        password_confirmation: パスワード（確認）
       spree/variant:
-        cost_currency: "コストカレンシー"
-        cost_price: "原価"
-        depth: "奥行き"
-        height: "高さ"
-        price: "価格"
-        sku: "品番"
-        weight: "重量"
-        width: "幅"
+        cost_currency: コストカレンシー
+        cost_price: 原価
+        depth: 奥行き
+        height: 高さ
+        price: 価格
+        sku: 品番
+        weight: 重量
+        width: 幅
       spree/zone:
-        description: "説明"
-        name: "名前"
+        description: 説明
+        name: 名前
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: "列キーは0より大きい値でなければなりません。"
+              keys_should_be_positive_number: 列キーは0より大きい値でなければなりません。
             preferred_tiers:
-              should_be_hash: "ハッシュでなければなりません"
+              should_be_hash: ハッシュでなければなりません
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: "列キーは0より大きい値でなければなりません。"
-              values_should_be_percent: "列の値は0%から100%の間でなければなりません。"
+              keys_should_be_positive_number: 列キーは0より大きい値でなければなりません。
+              values_should_be_percent: 列の値は0%から100%の間でなければなりません。
             preferred_tiers:
-              should_be_hash: "ハッシュでなければなりません"
+              should_be_hash: ハッシュでなければなりません
         spree/classification:
           attributes:
             taxon_id:
-              already_linked: "はすでに今プロダクトと連携されています。"
+              already_linked: はすでに今プロダクトと連携されています。
         spree/credit_card:
           attributes:
             base:
-              card_expired: "カードの有効期限が切れています。"
-              expiry_invalid: "カードの有効期限が不正です。"
+              card_expired: カードの有効期限が切れています。
+              expiry_invalid: カードの有効期限が不正です。
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency: "注文貨幣と一致してなければなりません。"
+              must_match_order_currency: 注文貨幣と一致してなければなりません。
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed: "は許容量より大きい値です。"
+              greater_than_allowed: は許容量より大きい値です。
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match: "一つかそれ以上の返品商品が払い戻しとして同じ商品に属されていません。"
+              return_items_order_id_does_not_match: 一つかそれ以上の返品商品が払い戻しとして同じ商品に属されていません。
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists: "は受諾されなかった返品に関連付けられませんでした。"
+              other_completed_return_item_exists: は受諾されなかった返品に関連付けられませんでした。
             reimbursement:
               cannot_be_associated_unless_accepted: "%{inventory_unit_id}はすでに返品%{return_item_id}として使われています。"
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store: "デフォルトの店を削除することはできません。"
+              cannot_destroy_default_store: デフォルトの店を削除することはできません。
       spree/page:
         body: Body
-        foreign_link: "外部URL"
+        foreign_link: 外部URL
         layout: Layout
-        meta_description: "メタ説明"
-        meta_keywords: "メタキーワード"
-        meta_title: "メタタイトル"
-        position: "位置"
-        render_layout_as_partial: "部分的なレイアウトとして表示"
-        show_in_footer: "フッターに表示"
-        show_in_header: "ヘッダーに表示"
-        show_in_sidebar: "サイドバーに表示"
-        slug: "パス(url)"
-        title: "タイトル"
-        visible: "表示"
+        meta_description: メタ説明
+        meta_keywords: メタキーワード
+        meta_title: メタタイトル
+        position: 位置
+        render_layout_as_partial: 部分的なレイアウトとして表示
+        show_in_footer: フッターに表示
+        show_in_header: ヘッダーに表示
+        show_in_sidebar: サイドバーに表示
+        slug: パス(url)
+        title: タイトル
+        visible: 表示
     models:
       spree/address:
-        one: "住所"
-        other: "住所"
+        one: 住所
+        other: 住所
       spree/country:
-        one: "国名"
-        other: "国名"
+        one: 国名
+        other: 国名
       spree/credit_card:
-        one: "クレジットカード"
-        other: "クレジットカード"
+        one: クレジットカード
+        other: クレジットカード
       spree/customer_return:
-        one: "返品"
-        other: "返品"
+        one: 返品
+        other: 返品
       spree/inventory_unit:
-        one: "在庫品単位"
-        other: "在庫品単位"
+        one: 在庫品単位
+        other: 在庫品単位
       spree/line_item:
-        one: "品目"
-        other: "品目"
+        one: 品目
+        other: 品目
       spree/option_type:
-        one: "オプション"
-        other: "オプション"
+        one: オプション
+        other: オプション
       spree/option_value:
-        one: "オプション値"
-        other: "オプション値"
+        one: オプション値
+        other: オプション値
       spree/order:
-        one: "注文"
-        other: "注文"
-      spree/payment:
-        one: "支払い"
-        other: "支払い"
-      spree/payment_method:
-        one: "支払い方法"
-        other: "支払い方法"
-      spree/product:
-        one: "商品"
-        other: "商品"
-      spree/promotion:
-        one: "プロモーション"
-        other: "プロモーション"
-      spree/promotion_category:
-        one: "プロモーションカテゴリ"
-        other: "プロモーションカテゴリ"
-      spree/property:
-        one: "属性"
-        other: "属性"
-      spree/prototype:
-        one: "原型"
-        other: "原型"
-      spree/refund_reason:
-        one: "返金理由"
-        other: "返金理由"
-      spree/reimbursement:
-        one: "払い戻し"
-        other: "払い戻し"
-      spree/reimbursement_type:
-        one: "払い戻し種別"
-        other: "払い戻し種別"
-      spree/return_authorization:
-        one: "返品許可"
-        other: "返品許可"
-      spree/return_authorization_reason:
-        one: "返品理由"
-        other: "返品理由"
-      spree/role:
-        one: "役割"
-        other: "役割"
-      spree/shipment:
-        one: "配送"
-        other: "配送"
-      spree/shipping_category:
-        one: "配送カテゴリ"
-        other: "配送カテゴリ"
-      spree/shipping_method:
-        one: "配送方法"
-        other: "配送方法"
-      spree/state:
-        one: "都道府県（州）"
-        other: "都道府県（州）"
-      spree/state_change:
-        one: "状態変化"
-        other: "状態変化"
-      spree/stock_movement:
-        one: "在庫遷移"
-        other: "在庫遷移"
-      spree/stock_location:
-        one: "在庫場所"
-        other: "在庫場所"
-      spree/stock_transfer:
-        one: "在庫移動"
-        other: "在庫移動"
-      spree/tax_category:
-        one: "税区分"
-        other: "税区分"
-      spree/tax_rate:
-        one: "税率"
-        other: "税率"
-      spree/taxon:
-        one: "ジャンル単位"
-        other: "ジャンル単位"
-      spree/taxonomy:
-        one: "ジャンルツリー"
-        other: "ジャンルツリー"
-      spree/tracker:
-        one: "トラッカー"
-        other: "トラッカー"
-      spree/user:
-        one: "ユーザー"
-        other: "ユーザー"
-      spree/variant:
-        one: "種類"
-        other: "種類"
-      spree/zone:
-        one: "ゾーン"
-        other: "ゾーン"
+        one: 注文
+        other: 注文
       spree/page:
-        one: "特集ページ"
-        other: "特集ページ"
+        one: 特集ページ
+        other: 特集ページ
+      spree/payment:
+        one: 支払い
+        other: 支払い
+      spree/payment_method:
+        one: 支払い方法
+        other: 支払い方法
+      spree/product:
+        one: 商品
+        other: 商品
+      spree/promotion:
+        one: プロモーション
+        other: プロモーション
+      spree/promotion_category:
+        one: プロモーションカテゴリ
+        other: プロモーションカテゴリ
+      spree/property:
+        one: 属性
+        other: 属性
+      spree/prototype:
+        one: 原型
+        other: 原型
+      spree/refund_reason:
+        one: 返金理由
+        other: 返金理由
+      spree/reimbursement:
+        one: 払い戻し
+        other: 払い戻し
+      spree/reimbursement_type:
+        one: 払い戻し種別
+        other: 払い戻し種別
+      spree/return_authorization:
+        one: 返品許可
+        other: 返品許可
+      spree/return_authorization_reason:
+        one: 返品理由
+        other: 返品理由
+      spree/role:
+        one: 役割
+        other: 役割
+      spree/shipment:
+        one: 配送
+        other: 配送
+      spree/shipping_category:
+        one: 配送カテゴリ
+        other: 配送カテゴリ
+      spree/shipping_method:
+        one: 配送方法
+        other: 配送方法
+      spree/state:
+        one: 都道府県（州）
+        other: 都道府県（州）
+      spree/state_change:
+        one: 状態変化
+        other: 状態変化
+      spree/stock_location:
+        one: 在庫場所
+        other: 在庫場所
+      spree/stock_movement:
+        one: 在庫遷移
+        other: 在庫遷移
+      spree/stock_transfer:
+        one: 在庫移動
+        other: 在庫移動
+      spree/tax_category:
+        one: 税区分
+        other: 税区分
+      spree/tax_rate:
+        one: 税率
+        other: 税率
+      spree/taxon:
+        one: ジャンル単位
+        other: ジャンル単位
+      spree/taxonomy:
+        one: ジャンルツリー
+        other: ジャンルツリー
+      spree/tracker:
+        one: トラッカー
+        other: トラッカー
+      spree/user:
+        one: ユーザー
+        other: ユーザー
+      spree/variant:
+        one: 種類
+        other: 種類
+      spree/zone:
+        one: ゾーン
+        other: ゾーン
   spree:
-    abbreviation: "省略"
-    accept: "受付"
-    acceptance_errors: "受諾エラー"
-    acceptance_status: "受諾ステータス"
-    accepted: "受諾"
-    account: "アカウント"
-    account_updated: "アカウントが更新されました。"
-    action: "アクション"
+    abbreviation: 省略
+    accept: 受付
+    acceptance_errors: 受諾エラー
+    acceptance_status: 受諾ステータス
+    accepted: 受諾
+    account: アカウント
+    account_updated: アカウントが更新されました。
+    action: アクション
     actions:
-      cancel: "キャンセル"
-      continue: "続ける"
-      create: "作成"
-      destroy: "削除"
-      edit: "編集"
-      list: "リスト"
-      listing: "一覧"
-      new: "新規"
-      refund: "返金"
-      save: "保存"
-      update: "更新"
-    activate: "アクティベートする"
-    active: "有効"
-    add: "追加"
-    add_action_of_type: "次のタイプのアクションを追加する"
-    add_country: "国の追加"
-    add_coupon_code: "クーポンコードの追加"
-    add_new_header: "新規ヘッダの追加"
-    add_new_style: "新規スタイルの追加"
-    add_one: "新規追加"
-    add_option_value: "オプションの値を追加"
-    add_product: "新規商品の追加"
-    add_product_properties: "商品に属性を追加"
-    add_rule_of_type: "次のタイプのルールを追加する"
-    add_state: "都道府県（州）の追加"
-    add_stock: "ストック追加"
-    add_stock_management:
-    add_to_cart: "カートに追加"
-    add_variant: "変数の追加"
-    additional_item: "追加商品"
-    address: "住所"
-    address1: "住所１"
-    address2: "住所２"
-    adjustable: "調整可能"
-    adjustment: "調整（値引き・追加料金）"
-    adjustment_amount: "量"
-    adjustment_successfully_closed: "調整（値引き・追加料金）のクローズに成功しました。"
-    adjustment_successfully_opened: "調整（値引き・追加料金）の解放に成功しました。"
-    adjustment_total: "調整（値引き・追加料金）総額"
-    adjustments: "調整（値引き・追加料金）"
+      cancel: キャンセル
+      continue: 続ける
+      create: 作成
+      destroy: 削除
+      edit: 編集
+      list: リスト
+      listing: 一覧
+      new: 新規
+      refund: 返金
+      save: 保存
+      update: 更新
+    activate: アクティベートする
+    active: 有効
+    add: 追加
+    add_action_of_type: 次のタイプのアクションを追加する
+    add_country: 国の追加
+    add_coupon_code: クーポンコードの追加
+    add_new_header: 新規ヘッダの追加
+    add_new_style: 新規スタイルの追加
+    add_one: 新規追加
+    add_option_value: オプションの値を追加
+    add_product: 新規商品の追加
+    add_product_properties: 商品に属性を追加
+    add_rule_of_type: 次のタイプのルールを追加する
+    add_state: 都道府県（州）の追加
+    add_stock: ストック追加
+    add_stock_management: 
+    add_to_cart: カートに追加
+    add_variant: 変数の追加
+    additional_item: 追加商品
+    address: 住所
+    address1: 住所１
+    address2: 住所２
+    adjustable: 調整可能
+    adjustment: 調整（値引き・追加料金）
+    adjustment_amount: 量
+    adjustment_successfully_closed: 調整（値引き・追加料金）のクローズに成功しました。
+    adjustment_successfully_opened: 調整（値引き・追加料金）の解放に成功しました。
+    adjustment_total: 調整（値引き・追加料金）総額
+    adjustments: 調整（値引き・追加料金）
     admin:
       tab:
-        configuration: "設定"
-        option_types: "オプション"
-        orders: "注文"
-        overview: "概要"
-        products: "商品"
-        promotions: "プロモーション"
-        promotion_categories: "プロモーションカテゴリ"
-        properties: "属性"
-        prototypes: "原型"
-        reports: "レポート"
-        taxonomies: "ジャンルツリー"
-        taxons: "ジャンル単位"
-        users: "ユーザー"
-        settings: "設定"
-        general: "一般設定"
-        payments: "支払い方法"
-        areas: "ゾーン"
-        taxes: "税金"
-        checkout: "決済"
-        shipping: "配送方法"
-        stock: "在庫"
-        stock_items: "在庫品"
-        stock_transfers: "在庫移動"
+        areas: ゾーン
+        checkout: 決済
+        configuration: 設定
+        general: 一般設定
+        option_types: オプション
+        orders: 注文
+        overview: 概要
+        payments: 支払い方法
+        products: 商品
+        promotion_categories: プロモーションカテゴリ
+        promotions: プロモーション
+        properties: 属性
+        prototypes: 原型
+        reports: レポート
+        settings: 設定
+        shipping: 配送方法
+        stock: 在庫
+        stock_items: 在庫品
+        stock_transfers: 在庫移動
+        taxes: 税金
+        taxonomies: ジャンルツリー
+        taxons: ジャンル単位
+        users: ユーザー
       user:
-        account: "アカウント"
-        addresses: "住所"
-        items: "商品"
-        items_purchased: "購入した商品"
-        order_history: "発注履歴"
-        order_num: "注文 No."
-        orders: "注文"
-        user_information: "ユーザー情報"
-    administration: "管理"
-    advertise: "広告"
-    agree_to_privacy_policy: "年齢制限ポリシー"
-    agree_to_terms_of_service: "利用規約に同意する"
-    all: "全て"
-    all_adjustments_closed: "すべての調整は閉じました。"
-    all_adjustments_opened: "すべての調整を公開しました。"
-    all_departments: "全てのカテゴリ"
-    all_items_have_been_returned: "すべての商品を返しました。"
-    already_signed_up_for_analytics:
-    alt_text: "代替のテキスト"
-    alternative_phone: "代替の電話番号"
-    amount: "金額"
-    analytics_desc_header_1: "Spree 解析"
-    analytics_desc_header_2: "Spreeダッシュボードに統合されたライブ解析"
-    analytics_desc_list_1: "販売情報をリアルタイムで取得する"
-    analytics_desc_list_2: "アカウントをアクティブにするには無料のSpreeアカウントが必要です。"
-    analytics_desc_list_3: "インストールにコードは必要ありません。"
-    analytics_desc_list_4: "すべては無料です！"
-    analytics_trackers: "Google アナリティクス"
-    and: "と"
-    approve: "承認"
-    approver: "承認者"
-    approved_at: "承認日時"
-    are_you_sure: "本当によろしいですか?"
-    are_you_sure_delete: "削除しますか?"
-    associated_adjustment_closed: "関連された調整が閉じられると、再計算しなくなります。それを開きますか？"
-    authorization_failure: "認証に失敗しました"
-    authorized: "認証しました。"
-    auto_capture: "自動キャプチャ"
-    available_on: "発売開始日・入荷日"
-    average_order_value: "平均オーダー値"
-    avs_response: "AVS レスポンス"
-    back: "戻る"
-    back_end: "バックエンド"
-    backordered: "入荷待ち"
+        account: アカウント
+        addresses: 住所
+        items: 商品
+        items_purchased: 購入した商品
+        order_history: 発注履歴
+        order_num: 注文 No.
+        orders: 注文
+        user_information: ユーザー情報
+    administration: 管理
+    advertise: 広告
+    agree_to_privacy_policy: 年齢制限ポリシー
+    agree_to_terms_of_service: 利用規約に同意する
+    all: 全て
+    all_adjustments_closed: すべての調整は閉じました。
+    all_adjustments_opened: すべての調整を公開しました。
+    all_departments: 全てのカテゴリ
+    all_items_have_been_returned: すべての商品を返しました。
+    already_signed_up_for_analytics: 
+    alt_text: 代替のテキスト
+    alternative_phone: 代替の電話番号
+    amount: 金額
+    analytics_desc_header_1: Spree 解析
+    analytics_desc_header_2: Spreeダッシュボードに統合されたライブ解析
+    analytics_desc_list_1: 販売情報をリアルタイムで取得する
+    analytics_desc_list_2: アカウントをアクティブにするには無料のSpreeアカウントが必要です。
+    analytics_desc_list_3: インストールにコードは必要ありません。
+    analytics_desc_list_4: すべては無料です！
+    analytics_trackers: Google アナリティクス
+    and: と
+    approve: 承認
+    approved_at: 承認日時
+    approver: 承認者
+    are_you_sure: 本当によろしいですか?
+    are_you_sure_delete: 削除しますか?
+    associated_adjustment_closed: 関連された調整が閉じられると、再計算しなくなります。それを開きますか？
+    authorization_failure: 認証に失敗しました
+    authorized: 認証しました。
+    auto_capture: 自動キャプチャ
+    available_on: 発売開始日・入荷日
+    average_order_value: 平均オーダー値
+    avs_response: AVS レスポンス
+    back: 戻る
+    back_end: バックエンド
+    back_to_payment: 支払いに戻る
     back_to_resource_list: "%{resource} に戻る"
-    back_to_payment: "支払いに戻る"
-    back_to_rma_reason_list: "商品返品確認番号リストに戻る"
-    back_to_store: "ショップに戻る"
-    back_to_users_list: "ユーザー一覧に戻る"
-    backorderable: "入荷待ち可能"
-    backorderable_default: "入荷待ちデフォルト"
-    backorders_allowed: "入荷待ち許可"
-    balance_due: "未払額"
-    base_amount: "基準量"
-    base_percent: "基準%"
-    bill_address: "請求先住所"
-    billing: "決済"
-    billing_address: "請求先住所"
-    both: "両方とも"
-    calculated_reimbursements: "計算済み返品"
-    calculator: "計算方法"
-    calculator_settings_warning: "計算方法のタイプを変更する場合は、計算方法の設定を編集する前に保存してください。"
-    cancel: "キャンセル"
-    canceler: "キャンセル者"
-    canceled_at: "にキャンセル"
-    cannot_create_payment_without_payment_methods: "支払い方法が選択されていないので、支払いを行うことができません"
-    cannot_create_customer_returns: "まだこの注文は発送単位がないため、顧客返金を作成できません。"
-    cannot_create_returns: "未発送の注文品に対して返品が出来ません。注文をキャンセルし注文を作り直すか問い合わせて下さい。"
-    cannot_perform_operation: "処理出来ませんでした"
-    cannot_set_shipping_method_without_address: "顧客詳細が提供されるまで発送方法を設定できません。"
-    capture: "入金申請（キャプチャリング）"
-    capture_events: "入金イベント"
-    card_code: "カード照合値[セキュリティーコード]"
-    card_number: "カード番号"
-    card_type: "ブランド"
-    card_type_is: "カード類"
-    cart: "カート"
+    back_to_rma_reason_list: 商品返品確認番号リストに戻る
+    back_to_store: ショップに戻る
+    back_to_users_list: ユーザー一覧に戻る
+    backorderable: 入荷待ち可能
+    backorderable_default: 入荷待ちデフォルト
+    backordered: 入荷待ち
+    backorders_allowed: 入荷待ち許可
+    balance_due: 未払額
+    base_amount: 基準量
+    base_percent: 基準%
+    bill_address: 請求先住所
+    billing: 決済
+    billing_address: 請求先住所
+    both: 両方とも
+    calculated_reimbursements: 計算済み返品
+    calculator: 計算方法
+    calculator_settings_warning: 計算方法のタイプを変更する場合は、計算方法の設定を編集する前に保存してください。
+    cancel: キャンセル
+    canceled_at: にキャンセル
+    canceler: キャンセル者
+    cannot_create_customer_returns: まだこの注文は発送単位がないため、顧客返金を作成できません。
+    cannot_create_payment_without_payment_methods: 支払い方法が選択されていないので、支払いを行うことができません
+    cannot_create_returns: 未発送の注文品に対して返品が出来ません。注文をキャンセルし注文を作り直すか問い合わせて下さい。
+    cannot_perform_operation: 処理出来ませんでした
+    cannot_set_shipping_method_without_address: 顧客詳細が提供されるまで発送方法を設定できません。
+    capture: 入金申請（キャプチャリング）
+    capture_events: 入金イベント
+    card_code: カード照合値[セキュリティーコード]
+    card_number: カード番号
+    card_type: ブランド
+    card_type_is: カード類
+    cart: カート
     cart_subtotal:
-      one: '小計 (1つの商品)'
-      other: '小計 (%{count}個の商品)'
-    categories: "カテゴリー"
-    category: "カテゴリー"
-    charged: "支払い済み"
+      one: 小計 (1つの商品)
+      other: 小計 (%{count}個の商品)
+    categories: カテゴリー
+    category: カテゴリー
+    charged: 支払い済み
     check_for_spree_alerts: Spreeアラートの確認
-    checkout: "レジに進む"
-    choose_a_customer: "顧客の選択"
-    choose_a_taxon_to_sort_products_for: "商品を整列するためにジャンル単位を選択"
-    choose_currency: "通貨の選択"
-    choose_dashboard_locale: "言語の選択"
-    choose_location:
-    city: "市区町村"
-    clear_cache: "キャッシュを消去"
-    clear_cache_ok: "キャッシュを消去しました。"
-    clear_cache_warning: "キャッシュのクリアはあなたの店舗のパフォーマンスを一時的に下げます。"
-    click_and_drag_on_the_products_to_sort_them: "整列するには小hんをドラッグ＆ドロップしてください。"
-    clone: "複製"
-    close: "閉じる"
-    close_all_adjustments: "すべての調整を閉じる"
-    code: "コード"
-    company: "会社"
-    complete: "完了"
-    configuration: "設定"
-    configurations: "設定"
-    confirm: "確認する"
-    confirm_delete: "削除を確認"
-    confirm_password: "パスワードの確認"
-    continue: "続ける"
-    continue_shopping: "ショッピングを続ける"
-    cost_currency: "通貨"
-    cost_price: "原価"
-    could_not_connect_to_jirafe: "データをシンクするためにJirafeを繋ぐことができませんでした。後で自動的にリトライします。"
-    could_not_create_customer_return: "顧客返品を作成できませんでした。"
-    could_not_create_stock_movement: "在庫移動を保存するのに問題が発生しました。後でリトライしてください。"
-    count_on_hand: "手計算"
-    countries: "国"
-    country: "国"
-    country_based: "国による区別"
-    country_name: "名前"
+    checkout: レジに進む
+    choose_a_customer: 顧客の選択
+    choose_a_taxon_to_sort_products_for: 商品を整列するためにジャンル単位を選択
+    choose_currency: 通貨の選択
+    choose_dashboard_locale: 言語の選択
+    choose_location: 
+    city: 市区町村
+    clear_cache: キャッシュを消去
+    clear_cache_ok: キャッシュを消去しました。
+    clear_cache_warning: キャッシュのクリアはあなたの店舗のパフォーマンスを一時的に下げます。
+    click_and_drag_on_the_products_to_sort_them: 整列するには小hんをドラッグ＆ドロップしてください。
+    clone: 複製
+    close: 閉じる
+    close_all_adjustments: すべての調整を閉じる
+    code: コード
+    company: 会社
+    complete: 完了
+    configuration: 設定
+    configurations: 設定
+    confirm: 確認する
+    confirm_delete: 削除を確認
+    confirm_password: パスワードの確認
+    continue: 続ける
+    continue_shopping: ショッピングを続ける
+    cost_currency: 通貨
+    cost_price: 原価
+    could_not_connect_to_jirafe: データをシンクするためにJirafeを繋ぐことができませんでした。後で自動的にリトライします。
+    could_not_create_customer_return: 顧客返品を作成できませんでした。
+    could_not_create_stock_movement: 在庫移動を保存するのに問題が発生しました。後でリトライしてください。
+    count_on_hand: 手計算
+    countries: 国
+    country: 国
+    country_based: 国による区別
+    country_name: 名前
     country_names:
-      CA: "カナダ"
-      FRA: "フランス"
-      ITA: "イタリア"
-      US: "アメリカ"
-    coupon: "クーポン"
-    coupon_code: "クーポンコード"
-    coupon_code_already_applied: "そのクーポンはすでにこの注文に適用されています。"
-    coupon_code_applied: "クーポンコードが適応されました。"
-    coupon_code_better_exists: "前回適用したクーポンコードの方がよりよい取引となります。"
-    coupon_code_expired: "クーポンコードは期限切れです。"
-    coupon_code_max_usage: "クーポンコードの利用制限を超えました。"
-    coupon_code_not_eligible: "このクーポンコードはこの注文では適用できません。"
-    coupon_code_not_found: "指定のクーポンコードが見つかりませんでした。"
-    coupon_code_unknown_error: "このクーポンコードは現時点で利用することができません。"
-    create: "作成"
-    create_a_new_account: "新規アカウント作成"
-    create_new_order: "新規注文作成"
-    create_reimbursement: "返品作成"
-    created_at: "作成日時"
-    credit: "債権"
-    credit_card: "クレジットカード"
-    credit_cards: "クレジットカード"
-    credit_owed: "過払い額"
-    credits: "債権"
-    currency: "通貨"
-    currency_settings: "通貨の設定"
-    current: "現在"
-    current_promotion_usage: ! '現在の使用方法: %{count}'
-    customer: "お客様"
-    customer_details: "お客様詳細情報"
-    customer_details_updated: "お客様詳細情報が更新されました。"
-    customer_return: "顧客返品"
-    customer_returns: "顧客返品"
-    customer_search: "お客様の検索"
-    cut: "カット"
-    cvv_response: "CVV の返答"
+      CA: カナダ
+      FRA: フランス
+      ITA: イタリア
+      US: アメリカ
+    coupon: クーポン
+    coupon_code: クーポンコード
+    coupon_code_already_applied: そのクーポンはすでにこの注文に適用されています。
+    coupon_code_applied: クーポンコードが適応されました。
+    coupon_code_better_exists: 前回適用したクーポンコードの方がよりよい取引となります。
+    coupon_code_expired: クーポンコードは期限切れです。
+    coupon_code_max_usage: クーポンコードの利用制限を超えました。
+    coupon_code_not_eligible: このクーポンコードはこの注文では適用できません。
+    coupon_code_not_found: 指定のクーポンコードが見つかりませんでした。
+    coupon_code_unknown_error: このクーポンコードは現時点で利用することができません。
+    create: 作成
+    create_a_new_account: 新規アカウント作成
+    create_new_order: 新規注文作成
+    create_reimbursement: 返品作成
+    created_at: 作成日時
+    credit: 債権
+    credit_card: クレジットカード
+    credit_cards: クレジットカード
+    credit_owed: 過払い額
+    credits: 債権
+    currency: 通貨
+    currency_settings: 通貨の設定
+    current: 現在
+    current_promotion_usage: '現在の使用方法: %{count}'
+    customer: お客様
+    customer_details: お客様詳細情報
+    customer_details_updated: お客様詳細情報が更新されました。
+    customer_return: 顧客返品
+    customer_returns: 顧客返品
+    customer_search: お客様の検索
+    cut: カット
+    cvv_response: CVV の返答
     dash:
       jirafe:
-        app_id: "App ID"
-        app_token: "App Token"
-        currently_unavailable: "Jirafe は現在利用不可です。"
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date: "日時"
-    date_completed: "完了日"
+        app_id: App ID
+        app_token: App Token
+        currently_unavailable: Jirafe は現在利用不可です。
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: 日時
+    date_completed: 完了日
     date_picker:
       first_day: 0
-      format: ! '%Y/%m/%d'
+      format: "%Y/%m/%d"
       js_format: yy/mm/dd
-    date_range: "日範囲"
-    default: "初期設定"
-    default_refund_amount:
-    default_tax: "デフォルトの税"
-    default_tax_zone: "デフォルトのタックスゾーン"
-    delete: "削除"
-    delete_from_taxon: "ジャンル単位から削除"
-    deleted_variants_present: "注文の商品のいくつかが既に購入不可となっています。"
-    delivery: "配送/お届け"
-    depth: "奥行き"
-    details: "詳細"
-    description: "説明"
-    destination: "目的地"
-    destroy: "破壊する"
-    discount_amount: "割引額"
-    dismiss_banner: "いいえ。結構です！興味ありません。再びこのメッセージを表示しないでください。"
-    display: "表示"
-    doesnt_track_inventory: "在庫をトラッキングしません。"
-    edit: "編集"
-    editing_country:
-    editing_adjustment_reason:
-    editing_option_type:
-    editing_payment_method:
-    editing_product: "商品の編集"
-    editing_promotion:
-    editing_promotion_category:
-    editing_property:
-    editing_prototype:
-    edit_refund_reason:
-    editing_refund_reason:
-    editing_reimbursement:
-    editing_reimbursement_type:
+    date_range: 日範囲
+    default: 初期設定
+    default_refund_amount: 
+    default_tax: デフォルトの税
+    default_tax_zone: デフォルトのタックスゾーン
+    delete: 削除
+    delete_from_taxon: ジャンル単位から削除
+    deleted_variants_present: 注文の商品のいくつかが既に購入不可となっています。
+    delivery: 配送/お届け
+    depth: 奥行き
+    description: 説明
+    destination: 目的地
+    destroy: 破壊する
+    details: 詳細
+    discount_amount: 割引額
+    dismiss_banner: いいえ。結構です！興味ありません。再びこのメッセージを表示しないでください。
+    display: 表示
+    doesnt_track_inventory: 在庫をトラッキングしません。
+    edit: 編集
+    edit_refund_reason: 
+    editing_adjustment_reason: 
+    editing_country: 
+    editing_option_type: 
+    editing_payment_method: 
+    editing_product: 商品の編集
+    editing_promotion: 
+    editing_promotion_category: 
+    editing_property: 
+    editing_prototype: 
+    editing_refund_reason: 
+    editing_reimbursement: 
+    editing_reimbursement_type: 
     editing_resource: "%{resource}を編集"
-    editing_rma_reason: "RMA理由を編集"
-    editing_shipping_category:
-    editing_shipping_method:
-    editing_state:
-    editing_stock_location:
-    editing_stock_movement:
-    editing_stock_transfer:
-    editing_tax_category:
-    editing_tax_rate:
-    editing_tracker:
-    editing_user: "ユーザーの編集"
-    editing_zone: "ゾーンの編集"
+    editing_rma_reason: RMA理由を編集
+    editing_shipping_category: 
+    editing_shipping_method: 
+    editing_state: 
+    editing_stock_location: 
+    editing_stock_movement: 
+    editing_stock_transfer: 
+    editing_tax_category: 
+    editing_tax_rate: 
+    editing_tracker: 
+    editing_user: ユーザーの編集
+    editing_zone: ゾーンの編集
     eligibility_errors:
       messages:
-        has_excluded_product: "カート内に適用済みのクーポンコードを妨げる商品が含まれています。"
+        has_excluded_product: カート内に適用済みのクーポンコードを妨げる商品が含まれています。
         item_total_less_than: "%{amount}個より少ない注文でこのクーポンコードを適用することはできません。"
         item_total_less_than_or_equal: "%{amount}個以下の注文でこのクーポンコードを適用することはできません。"
         item_total_more_than: "%{amount}個より多い注文にこのクーポンコードを適用することはできません。"
         item_total_more_than_or_equal: "%{amount}個以上の注文にこのクーポンコードを適用することはできません。"
-        limit_once_per_user: "このクーポンコードは１ユーザーにつき１回までしか利用できません。"
-        missing_product: "このクーポンコードはあなたのカート内に必要なすべての商品がないため適用できません。"
-        missing_taxon: "クーポンコードを適用する前に、必要なすべてのジャンルを商品に追加する必要があります。"
-        no_applicable_products: "このクーポンコードを適用する前に、必要な商品を追加する必要があります。"
-        no_matching_taxons: "このクーポンコードを適用する前に必要なジャンルから商品を追加する必要があります。"
-        no_user_or_email_specified: "このクーポンコードを適用する前にログインもしくはメールアドレスを提供する必要があります。"
-        no_user_specified: "このクーポンコードを適用する前にログインする必要があります。"
-        not_first_order: "このクーポンコードは最初の注文にのみ適用できます。"
+        limit_once_per_user: このクーポンコードは１ユーザーにつき１回までしか利用できません。
+        missing_product: このクーポンコードはあなたのカート内に必要なすべての商品がないため適用できません。
+        missing_taxon: クーポンコードを適用する前に、必要なすべてのジャンルを商品に追加する必要があります。
+        no_applicable_products: このクーポンコードを適用する前に、必要な商品を追加する必要があります。
+        no_matching_taxons: このクーポンコードを適用する前に必要なジャンルから商品を追加する必要があります。
+        no_user_or_email_specified: このクーポンコードを適用する前にログインもしくはメールアドレスを提供する必要があります。
+        no_user_specified: このクーポンコードを適用する前にログインする必要があります。
+        not_first_order: このクーポンコードは最初の注文にのみ適用できます。
     email: Eメール
-    empty: "空"
-    empty_cart: "カートを空にする"
-    enable_mail_delivery: "メールによるお知らせを有効にする/許可する"
-    end: "終わり"
-    ending_in: "末尾の数字"
-    error: "エラー"
+    empty: 空
+    empty_cart: カートを空にする
+    enable_mail_delivery: メールによるお知らせを有効にする/許可する
+    end: 終わり
+    ending_in: 末尾の数字
+    error: エラー
     errors:
       messages:
-        could_not_create_taxon: "ジャンル単位の作成が失敗しました"
-        no_shipping_methods_available: "この場所へ発送可能な配送方法がありませんでした。別の住所を設定するか問い合わせして下さい。"
+        could_not_create_taxon: ジャンル単位の作成が失敗しました
+        no_shipping_methods_available: この場所へ発送可能な配送方法がありませんでした。別の住所を設定するか問い合わせして下さい。
     errors_prohibited_this_record_from_being_saved:
-      one: "エラーにより登録出来ませんでした。"
+      one: エラーにより登録出来ませんでした。
       other: "%{count}つのエラーにより登録出来ませんでした。"
-    event: "イベント"
+    event: イベント
     events:
       spree:
         cart:
-          add: "カートに入れる"
+          add: カートに入れる
         checkout:
-          coupon_code_added: "クーポンコード追加"
+          coupon_code_added: クーポンコード追加
         content:
-          visited: "静的コンテンツページの訪問"
+          visited: 静的コンテンツページの訪問
         order:
-          contents_changed: "注文内容の変更"
-        page_view: "静的ページを見る"
+          contents_changed: 注文内容の変更
+        page_view: 静的ページを見る
         user:
-          signup: "ユーザー登録"
+          signup: ユーザー登録
     exceptions:
-      count_on_hand_setter: "手動で手計算をセットできません。それはrecalculate_count_on_handコールバックで自動的にセットされます。`update_column(:count_on_hand, value)`を代わりに利用してください。"
-    exchange_for: "に変換"
-    expedited_exchanges_warning: "指定したどんな変換も保存後すぐに顧客に反映されます。もし顧客が元の商品を%{days_window}日以内に返さなかった場合、顧客はすべての量の商品に決済されます。"
+      count_on_hand_setter: 手動で手計算をセットできません。それはrecalculate_count_on_handコールバックで自動的にセットされます。`update_column(:count_on_hand, value)`を代わりに利用してください。
+    exchange_for: に変換
     excl: excl.
-    expiration: "有効期限"
-    extension: "拡張"
-    existing_shipments: "現在の発送"
-    failed_payment_attempts: "支払いに失敗"
-    filename: "ファイル名"
-    fill_in_customer_info: "顧客情報を埋めてください。"
-    filter: "検索"
-    filter_results: "検索結果"
-    finalize: "確定"
-    find_a_taxon: "ジャンル単位を見つける"
-    finalized: "確定済み"
-    first_item: "一品目の値段"
-    first_name: "名前（名）"
-    first_name_begins_with: "名前（名）が以下の文字列で始まる"
-    flat_percent: "定率"
-    flat_rate_per_order: "定格(一注文につき)"
-    flexible_rate: "変動料金"
-    forgot_password: "パスワードを忘れた方"
-    free_shipping: "配送料無料"
-    free_shipping_amount:
-    front_end: "フロントエンド"
-    gateway: "ゲートウェイ"
-    gateway_error: "ゲートウェイエラー"
-    general: "一般"
-    general_settings: "一般設定"
-    google_analytics: "Googleアナリティクス"
-    google_analytics_id: "Google アナリティクス ID"
-    guest_checkout: "ゲスト注文"
-    guest_user_account: "登録せずにゲストとして注文する"
-    has_no_shipped_units: "の発送済みユニットはありません"
-    height: "高さ"
-    home: "ホーム"
+    existing_shipments: 現在の発送
+    expedited_exchanges_warning: 指定したどんな変換も保存後すぐに顧客に反映されます。もし顧客が元の商品を%{days_window}日以内に返さなかった場合、顧客はすべての量の商品に決済されます。
+    expiration: 有効期限
+    extension: 拡張
+    failed_payment_attempts: 支払いに失敗
+    filename: ファイル名
+    fill_in_customer_info: 顧客情報を埋めてください。
+    filter: 検索
+    filter_results: 検索結果
+    finalize: 確定
+    finalized: 確定済み
+    find_a_taxon: ジャンル単位を見つける
+    first_item: 一品目の値段
+    first_name: 名前（名）
+    first_name_begins_with: 名前（名）が以下の文字列で始まる
+    flat_percent: 定率
+    flat_rate_per_order: 定格(一注文につき)
+    flexible_rate: 変動料金
+    forgot_password: パスワードを忘れた方
+    free_shipping: 配送料無料
+    free_shipping_amount: 
+    front_end: フロントエンド
+    gateway: ゲートウェイ
+    gateway_error: ゲートウェイエラー
+    general: 一般
+    general_settings: 一般設定
+    google_analytics: Googleアナリティクス
+    google_analytics_id: Google アナリティクス ID
+    guest_checkout: ゲスト注文
+    guest_user_account: 登録せずにゲストとして注文する
+    has_no_shipped_units: の発送済みユニットはありません
+    height: 高さ
+    home: ホーム
     i18n:
-      available_locales: "可能なローケル"
-      fields: "フィールド"
-      language: "言語"
-      locales_displayed_on_frontend_select_box: "フロントのセレクトボックスに設定した言語が表示されます"
-      localization_settings: "言語設定"
-      only_complete: "不完全のみ"
-      only_incomplete: "完全のみ"
-      select_locale: "言語の選択"
-      show_only: "だけ表示"
-      supported_locales: "サポート済み言語"
-      this_file_language: "日本語 (ja-JP)"
-      translations: "翻訳"
-    icon: "アイコン"
-    image: "画像"
-    images: "画像"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive: "非活性"
-    incl:
-    included_in_price: "価格に含まれる"
-    included_price_validation: "はデフォルトのタックスゾーンを設定しない限り選択できません。"
-    incomplete: "不完全"
-    info_product_has_multiple_skus: "この商品は%{count}個あります:"
+      available_locales: 可能なローケル
+      fields: フィールド
+      language: 言語
+      locales_displayed_on_frontend_select_box: フロントのセレクトボックスに設定した言語が表示されます
+      localization_settings: 言語設定
+      only_complete: 不完全のみ
+      only_incomplete: 完全のみ
+      select_locale: 言語の選択
+      show_only: だけ表示
+      supported_locales: サポート済み言語
+      this_file_language: 日本語 (ja-JP)
+      translations: 翻訳
+    icon: アイコン
+    image: 画像
+    images: 画像
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 非活性
+    incl: 
+    included_in_price: 価格に含まれる
+    included_price_validation: はデフォルトのタックスゾーンを設定しない限り選択できません。
+    incomplete: 不完全
     info_number_of_skus_not_shown:
-      one: "ともう一つ"
-      other: "と %{count}個"
-    instructions_to_reset_password: "下のフォームを入力してからパスワードの再設定方法の説明がメールで送信されます。"
-    insufficient_stock: "在庫が十分ではありません。残り%{on_hand}個です。"
-    insufficient_stock_lines_present: "いくつかの注文商品のが不十分です。"
-    intercept_email_address: "置き換え用のメールアドレス"
-    intercept_email_instructions: "メールの宛先をこのアドレスで置き換えます。"
-    internal_name: "内部の名前"
-    invalid_credit_card: "不正なクレジットカード"
-    invalid_exchange_variant: "不正な両替型"
-    invalid_payment_provider: "不正な支払いプロバイダー"
-    invalid_promotion_action: "不正なプロモーションアクション"
-    invalid_promotion_rule: "不正なプロモーションルール"
-    inventory: "在庫"
-    inventory_adjustment: "在庫調整"
-    inventory_error_flash_for_insufficient_quantity: "カート内のアイテムが販売不可となりました。"
-    inventory_state: "在庫状態"
-    is_not_available_to_shipment_address: "はこの配達先では発送出来ません。"
+      one: ともう一つ
+      other: と %{count}個
+    info_product_has_multiple_skus: 'この商品は%{count}個あります:'
+    instructions_to_reset_password: 下のフォームを入力してからパスワードの再設定方法の説明がメールで送信されます。
+    insufficient_stock: 在庫が十分ではありません。残り%{on_hand}個です。
+    insufficient_stock_lines_present: いくつかの注文商品のが不十分です。
+    intercept_email_address: 置き換え用のメールアドレス
+    intercept_email_instructions: メールの宛先をこのアドレスで置き換えます。
+    internal_name: 内部の名前
+    invalid_credit_card: 不正なクレジットカード
+    invalid_exchange_variant: 不正な両替型
+    invalid_payment_provider: 不正な支払いプロバイダー
+    invalid_promotion_action: 不正なプロモーションアクション
+    invalid_promotion_rule: 不正なプロモーションルール
+    inventory: 在庫
+    inventory_adjustment: 在庫調整
+    inventory_error_flash_for_insufficient_quantity: カート内のアイテムが販売不可となりました。
+    inventory_state: 在庫状態
+    is_not_available_to_shipment_address: はこの配達先では発送出来ません。
     iso_name: ISO名
-    item: "アイテム"
-    item_description: "アイテム説明"
-    item_total: "合計"
+    item: アイテム
+    item_description: アイテム説明
+    item_total: 合計
     item_total_rule:
       operators:
-        gt: "より大きい"
-        gte: "以上"
-        lt: "より小さい"
-        lte: "以下"
-    items_cannot_be_shipped: "選択した商品の発送料の計算ができませんでした。"
-    items_in_rmas: "返品認証"
-    items_reimbursed: "返品された商品"
-    items_to_be_reimbursed: "商品は返品されました"
-    jirafe:
+        gt: より大きい
+        gte: 以上
+        lt: より小さい
+        lte: 以下
+    items_cannot_be_shipped: 選択した商品の発送料の計算ができませんでした。
+    items_in_rmas: 返品認証
+    items_reimbursed: 返品された商品
+    items_to_be_reimbursed: 商品は返品されました
+    jirafe: 
     landing_page_rule:
-      path: "パス"
-    last_name: "名前（姓）"
-    last_name_begins_with: "名前（姓）が以下の文字列で始まる"
-    learn_more: "もっと詳しく"
-    lifetime_stats:
-    line_item_adjustments: "商品調整"
-    list: "リスト"
-    listing_countries: "国一覧"
-    listing_orders: "注文一覧"
-    listing_products: "商品一覧"
-    listing_reports: "レポート一覧"
-    listing_tax_categories: "税金カテゴリー一覧"
-    listing_users: "ユーザー一覧"
-    loading: "読み込み中"
-    locale_changed: "ロケールを変更しました"
-    location: "位置"
-    lock: "ロック"
-    log_entries: "ログエントリー"
-    logs: "ログ"
-    logged_in_as: "ログイン"
-    logged_in_succesfully: "ログインに成功しました"
-    logged_out: "ログアウトしました。"
-    login: "ログイン"
-    login_as_existing: "アカウント持ちのお客様ログイン"
-    login_failed: "ログイン認証失敗"
-    login_name: "ログイン名"
-    logout: "ログアウト"
-    look_for_similar_items: "似た商品を探す"
-    make_refund: "返金する"
-    make_sure_the_above_reimbursement_amount_is_correct: "上記の返品量が正しいことを確認してください。"
-    manage_promotion_categories: "プロモーションカテゴリの管理"
-    manage_stock: "在庫管理"
-    manage_variants: "型の管理"
-    manual_intervention_required: "主導介入が必要"
-    master_price: "定価"
+      path: パス
+    last_name: 名前（姓）
+    last_name_begins_with: 名前（姓）が以下の文字列で始まる
+    learn_more: もっと詳しく
+    lifetime_stats: 
+    line_item_adjustments: 商品調整
+    list: リスト
+    listing_countries: 国一覧
+    listing_orders: 注文一覧
+    listing_products: 商品一覧
+    listing_reports: レポート一覧
+    listing_tax_categories: 税金カテゴリー一覧
+    listing_users: ユーザー一覧
+    loading: 読み込み中
+    locale_changed: ロケールを変更しました
+    location: 位置
+    lock: ロック
+    log_entries: ログエントリー
+    logged_in_as: ログイン
+    logged_in_succesfully: ログインに成功しました
+    logged_out: ログアウトしました。
+    login: ログイン
+    login_as_existing: アカウント持ちのお客様ログイン
+    login_failed: ログイン認証失敗
+    login_name: ログイン名
+    logout: ログアウト
+    logs: ログ
+    look_for_similar_items: 似た商品を探す
+    make_refund: 返金する
+    make_sure_the_above_reimbursement_amount_is_correct: 上記の返品量が正しいことを確認してください。
+    manage_promotion_categories: プロモーションカテゴリの管理
+    manage_stock: 在庫管理
+    manage_variants: 型の管理
+    manual_intervention_required: 主導介入が必要
+    master_price: 定価
     match_choices:
-      all: "すべて"
-      none: "なし"
-    max_items: "商品の数の最大限"
-    member_since:
-    memo: "メモ"
-    meta_description: "メタ情報説明"
-    meta_keywords: "メタキーワード"
-    meta_title: "メタタイトル"
-    metadata: "メタデータ"
-    minimal_amount: "最低額"
-    month: "月"
-    more: "さらに"
-    move_stock_between_locations: "位置間の在庫移動"
-    my_account: "アカウント情報"
-    my_orders: "注文情報"
-    name: "名称"
-    name_on_card: "カード名義"
-    name_or_sku: "品名もしくは品番"
-    new: "新規"
-    new_adjustment: "新規の値引き・追加請求"
-    new_customer: "新規顧客"
-    new_customer_return: "新規顧客返品"
-    new_country: "新規国"
-    new_image: "新規画像"
-    new_option_type: "新規オプション"
-    new_order: "新規注文"
-    new_order_completed: "新規注文作成完了"
-    new_payment: "新規の支払い"
-    new_payment_method: "支払い方法を追加"
-    new_product: "新規商品"
-    new_promotion: "新規プロモーション"
-    new_promotion_category: "新規プロモーションカテゴリ"
-    new_property: "新規属性"
-    new_prototype: "新規原型"
-    new_refund: "新規返金"
-    new_refund_reason: "新規返金理由"
-    new_rma_reason: "新規RMA理由"
-    new_return_authorization: "新規返品依頼"
-    new_role: "新規役割"
-    new_shipping_category: "新規配送カテゴリー"
-    new_shipping_method: "新規配送方法"
-    new_shipment_at_location:
-    new_state: "新規都道府県（州）"
-    new_stock_location: "新規在庫場所"
-    new_stock_movement: "新規在庫移動"
-    new_stock_transfer: "新規転移"
-    new_tax_category: "新規税金カテゴリー"
-    new_tax_rate: "新規税率"
-    new_taxon: "新規ジャンル単位"
-    new_taxonomy: "新規ジャンルツリー"
-    new_tracker: "新規アナリティクス"
-    new_user: "新規ユーザー"
-    new_variant: "新規種類"
-    new_zone: "新規ゾーン"
-    next: "次へ"
-    no_actions_added: "アクションなし"
-    no_payment_found: "支払いなし"
-    no_pending_payments: "延滞なし"
-    no_products_found: "商品が見付かりませんでした。"
-    no_results: "検索結果がありませんでした。"
-    no_rules_added: "ルールが追加されていません"
+      all: すべて
+      none: なし
+    max_items: 商品の数の最大限
+    member_since: 
+    memo: メモ
+    meta_description: メタ情報説明
+    meta_keywords: メタキーワード
+    meta_title: メタタイトル
+    metadata: メタデータ
+    minimal_amount: 最低額
+    month: 月
+    more: さらに
+    move_stock_between_locations: 位置間の在庫移動
+    my_account: アカウント情報
+    my_orders: 注文情報
+    name: 名称
+    name_on_card: カード名義
+    name_or_sku: 品名もしくは品番
+    new: 新規
+    new_adjustment: 新規の値引き・追加請求
+    new_country: 新規国
+    new_customer: 新規顧客
+    new_customer_return: 新規顧客返品
+    new_image: 新規画像
+    new_option_type: 新規オプション
+    new_order: 新規注文
+    new_order_completed: 新規注文作成完了
+    new_payment: 新規の支払い
+    new_payment_method: 支払い方法を追加
+    new_product: 新規商品
+    new_promotion: 新規プロモーション
+    new_promotion_category: 新規プロモーションカテゴリ
+    new_property: 新規属性
+    new_prototype: 新規原型
+    new_refund: 新規返金
+    new_refund_reason: 新規返金理由
+    new_return_authorization: 新規返品依頼
+    new_rma_reason: 新規RMA理由
+    new_role: 新規役割
+    new_shipment_at_location: 
+    new_shipping_category: 新規配送カテゴリー
+    new_shipping_method: 新規配送方法
+    new_state: 新規都道府県（州）
+    new_stock_location: 新規在庫場所
+    new_stock_movement: 新規在庫移動
+    new_stock_transfer: 新規転移
+    new_tax_category: 新規税金カテゴリー
+    new_tax_rate: 新規税率
+    new_taxon: 新規ジャンル単位
+    new_taxonomy: 新規ジャンルツリー
+    new_tracker: 新規アナリティクス
+    new_user: 新規ユーザー
+    new_variant: 新規種類
+    new_zone: 新規ゾーン
+    next: 次へ
+    no_actions_added: アクションなし
+    no_payment_found: 支払いなし
+    no_pending_payments: 延滞なし
+    no_products_found: 商品が見付かりませんでした。
     no_resource_found: "%{resource}が見つかりませんでした。"
-    no_returns_found: "返品がありません。"
-    no_shipping_method_selected: "配送方法が選択されていません。"
-    no_state_changes: "まだ状態変化がありません。"
-    no_tracking_present: "トラッキング詳細が提供されていません。"
-    none: "空です"
-    none_selected: "選択なし"
-    normal_amount: "通常価格"
-    not: "非"
+    no_results: 検索結果がありませんでした。
+    no_returns_found: 返品がありません。
+    no_rules_added: ルールが追加されていません
+    no_shipping_method_selected: 配送方法が選択されていません。
+    no_state_changes: まだ状態変化がありません。
+    no_tracking_present: トラッキング詳細が提供されていません。
+    none: 空です
+    none_selected: 選択なし
+    normal_amount: 通常価格
+    not: 非
     not_available: N/A
-    not_enough_stock: "この転移を完了させるのに十分な在庫がありません。"
+    not_enough_stock: この転移を完了させるのに十分な在庫がありません。
     not_found: "%{resource}が見つかりません"
-    note: "ノート"
+    note: ノート
     notice_messages:
-      product_cloned: "商品を複製しました"
-      product_deleted: "商品を削除しました"
-      product_not_cloned: "商品を複製することが出来ませんでした"
-      product_not_deleted: "商品を削除することが出来ませんでした"
-      variant_deleted: "種類を削除しました"
-      variant_not_deleted: "種類を削除することが出来ませんでした"
-    num_orders:
-    on_hand: "入荷数"
-    open: "公開"
-    open_all_adjustments: "すべての調整を開く"
-    option_type: "オプション"
-    option_type_placeholder: "プレイスホルダ"
-    option_types: "オプション"
-    option_value: "オプション値"
-    option_values: "オプション値"
-    optional: "オプショナル"
-    options: "オプション"
-    or: "もしくは"
+      product_cloned: 商品を複製しました
+      product_deleted: 商品を削除しました
+      product_not_cloned: 商品を複製することが出来ませんでした
+      product_not_deleted: 商品を削除することが出来ませんでした
+      variant_deleted: 種類を削除しました
+      variant_not_deleted: 種類を削除することが出来ませんでした
+    num_orders: 
+    on_hand: 入荷数
+    open: 公開
+    open_all_adjustments: すべての調整を開く
+    option_type: オプション
+    option_type_placeholder: プレイスホルダ
+    option_types: オプション
+    option_value: オプション値
+    option_values: オプション値
+    optional: オプショナル
+    options: オプション
+    or: もしくは
     or_over_price: "%{price}以上"
-    order: "注文"
-    order_adjustments: "注文調整"
-    order_already_updated: "その注文は既に更新されています。"
-    order_approved: "注文の承認"
-    order_canceled: "注文のキャンセル"
-    order_details: "注文詳細"
-    order_email_resent: "注文詳細メールを再送信しました"
-    order_information: "注文情報"
-    order_line_items: "品目"
+    order: 注文
+    order_adjustments: 注文調整
+    order_already_updated: その注文は既に更新されています。
+    order_approved: 注文の承認
+    order_canceled: 注文のキャンセル
+    order_details: 注文詳細
+    order_email_resent: 注文詳細メールを再送信しました
+    order_information: 注文情報
+    order_line_items: 品目
     order_mailer:
       cancel_email:
-        dear_customer: "お客様へ"
-        instructions: "注文はキャンセルされました。以下のキャンセル情報を記録として残しておくよう御願い致します。"
-        order_summary_canceled: "注文概要 [キャンセル済み]"
-        subject: "注文のキャンセル"
-        subtotal: "小計: "
-        total: "注文合計: "
+        dear_customer: お客様へ
+        instructions: 注文はキャンセルされました。以下のキャンセル情報を記録として残しておくよう御願い致します。
+        order_summary_canceled: 注文概要 [キャンセル済み]
+        subject: 注文のキャンセル
+        subtotal: '小計: '
+        total: '注文合計: '
       confirm_email:
-        dear_customer: "お客様へ"
-        instructions: "以下の注文情報を記録として残していただくようお願い申し上げます。"
-        order_summary: "注文概要"
-        subject: "注文確認"
-        subtotal: "小計:"
-        thanks: "ご利用ありがとうございました。"
-        total: "合計: "
-    order_not_found: "注文を見つけることができませんでした。リトライしていただくようお願いいたします。"
-    order_number: "注文 %{number}"
-    order_processed_successfully: "注文が完了しました。"
-    order_resumed: "注文の再開"
+        dear_customer: お客様へ
+        instructions: 以下の注文情報を記録として残していただくようお願い申し上げます。
+        order_summary: 注文概要
+        subject: 注文確認
+        subtotal: '小計:'
+        thanks: ご利用ありがとうございました。
+        total: '合計: '
+    order_not_found: 注文を見つけることができませんでした。リトライしていただくようお願いいたします。
+    order_number: 注文 %{number}
+    order_processed_successfully: 注文が完了しました。
+    order_resumed: 注文の再開
     order_state:
-      address: "住所"
-      awaiting_return: "返品待ち"
-      canceled: "キャンセル"
-      cart: "カート"
-      complete: "完了"
-      confirm: "確認"
-      considered_risky: "考えられるリスク"
-      delivery: "配送"
-      payment: "支払い"
-      resumed: "再開"
-      returned: "返品済み"
-    order_summary: "注文サマリー"
-    order_sure_want_to: "本当にこの注文を%{event}しますか？"
-    order_total: "合計"
-    order_updated: "注文内容が更新されました。"
-    orders: "注文"
-    other_items_in_other: "注文の他のアイテム"
-    out_of_stock: "在庫が品切れです"
-    overview: "概要"
-    package_from: "パッケージ元"
+      address: 住所
+      awaiting_return: 返品待ち
+      canceled: キャンセル
+      cart: カート
+      complete: 完了
+      confirm: 確認
+      considered_risky: 考えられるリスク
+      delivery: 配送
+      payment: 支払い
+      resumed: 再開
+      returned: 返品済み
+    order_summary: 注文サマリー
+    order_sure_want_to: 本当にこの注文を%{event}しますか？
+    order_total: 合計
+    order_updated: 注文内容が更新されました。
+    orders: 注文
+    other_items_in_other: 注文の他のアイテム
+    out_of_stock: 在庫が品切れです
+    overview: 概要
+    package_from: パッケージ元
     pagination:
-      next_page: "次のページ »"
+      next_page: 次のページ »
       previous_page: "« 前のページ"
       truncate: "…"
-    password: "パスワード"
+    password: パスワード
     paste: Paste
-    path: "パス"
-    pay: "支払い"
-    payment: "支払い"
-    payment_could_not_be_created: "支払いを作成できませんでした。"
-    payment_information: "支払い情報"
-    payment_method: "支払い方法"
-    payment_methods: "支払い方法"
-    payment_method_not_supported: "その支払い方法はサポートされていません。他のものを選択してください。"
-    payment_processing_failed: "決済が失敗しました。入力した情報を確認してから再び決済を行ってみて下さい。"
-    payment_processor_choose_banner_text: "もし決済処理会社の選択でお困りでしたら、どうぞ"
-    payment_processor_choose_link: "こちらへ"
-    payment_state: "支払い状況"
+    path: パス
+    pay: 支払い
+    payment: 支払い
+    payment_could_not_be_created: 支払いを作成できませんでした。
+    payment_information: 支払い情報
+    payment_method: 支払い方法
+    payment_method_not_supported: その支払い方法はサポートされていません。他のものを選択してください。
+    payment_methods: 支払い方法
+    payment_processing_failed: 決済が失敗しました。入力した情報を確認してから再び決済を行ってみて下さい。
+    payment_processor_choose_banner_text: もし決済処理会社の選択でお困りでしたら、どうぞ
+    payment_processor_choose_link: こちらへ
+    payment_state: 支払い状況
     payment_states:
-      balance_due: "未支払い"
-      checkout: "決算中"
-      completed: "完了"
-      credit_owed: "一部未払"
-      failed: "失敗しました"
-      paid: "支払い済み"
-      pending: "支払い待ち"
-      processing: "処理中"
-      void: "無効"
-    payment_updated: "支払いが更新されました。"
-    payments: "支払い方法"
-    percent: "パーセント"
-    percent_per_item: "アイテムごとのパーセント"
-    permalink: "パーマリンク"
-    pending: "未決定"
-    phone: "電話番号"
-    place_order: "注文を送信する"
-    please_define_payment_methods: "まず支払い方法を定義してください。"
-    please_enter_reasonable_quantity: "適切な量を入力してください。"
-    populate_get_error: "問題が発生しました。もう一度追加してみてください。"
+      balance_due: 未支払い
+      checkout: 決算中
+      completed: 完了
+      credit_owed: 一部未払
+      failed: 失敗しました
+      paid: 支払い済み
+      pending: 支払い待ち
+      processing: 処理中
+      void: 無効
+    payment_updated: 支払いが更新されました。
+    payments: 支払い方法
+    pending: 未決定
+    percent: パーセント
+    percent_per_item: アイテムごとのパーセント
+    permalink: パーマリンク
+    phone: 電話番号
+    place_order: 注文を送信する
+    please_define_payment_methods: まず支払い方法を定義してください。
+    please_enter_reasonable_quantity: 適切な量を入力してください。
+    populate_get_error: 問題が発生しました。もう一度追加してみてください。
     powered_by: Powered by
-    pre_tax_refund_amount: "税前返金料"
-    pre_tax_amount: "税前料金"
-    pre_tax_total: "税前合計"
-    preferred_reimbursement_type: "望ましい返済方法"
-    presentation: "表示名"
-    previous: "前へ"
-    previous_state_missing: "n/a"
-    price: "価格"
-    price_range: "価格帯"
-    price_sack: "プライスサック"
-    process: "処理する"
-    product: "商品"
-    product_details: "商品詳細"
-    product_has_no_description: "この商品に詳細がありません。"
-    product_not_available_in_this_currency: "この商品は選択した通貨では購入できません。"
-    product_properties: "商品情報"
+    pre_tax_amount: 税前料金
+    pre_tax_refund_amount: 税前返金料
+    pre_tax_total: 税前合計
+    preferred_reimbursement_type: 望ましい返済方法
+    presentation: 表示名
+    previous: 前へ
+    previous_state_missing: n/a
+    price: 価格
+    price_range: 価格帯
+    price_sack: プライスサック
+    process: 処理する
+    product: 商品
+    product_details: 商品詳細
+    product_has_no_description: この商品に詳細がありません。
+    product_not_available_in_this_currency: この商品は選択した通貨では購入できません。
+    product_properties: 商品情報
     product_rule:
-      choose_products: "商品を選択してください"
-      label:
-      match_all: "少なくとも一つ"
-      match_any: "すべて"
-      match_none: "なし"
+      choose_products: 商品を選択してください
+      label: 
+      match_all: 少なくとも一つ
+      match_any: すべて
+      match_none: なし
       product_source:
-        group: "商品グループから"
-        manual: "手動で選択"
-    products: "商品"
-    listing_products: "商品一覧"
-    promotion: "プロモーション"
-    promotionable: "プロモーション可能"
-    promotion_action: "プロモーションアクション"
+        group: 商品グループから
+        manual: 手動で選択
+    products: 商品
+    promotion: プロモーション
+    promotion_action: プロモーションアクション
     promotion_action_types:
       create_adjustment:
-        description: "注文に対して値引きする"
-        name: "値引き"
+        description: 注文に対して値引きする
+        name: 値引き
       create_item_adjustments:
-        description: "品目にプロモーションクレジット値引きを作成"
-        name: "品目ごとの値引きを作成"
+        description: 品目にプロモーションクレジット値引きを作成
+        name: 品目ごとの値引きを作成
       create_line_items:
-        description: "特定の種類の商品をカートに加える"
-        name: "商品追加"
+        description: 特定の種類の商品をカートに加える
+        name: 商品追加
       free_shipping:
-        description: "すべての発送を無料にする"
-        name: "発送無料"
-    promotion_actions: "アクション"
-    promotion_category: "プロモーションカテゴリ"
+        description: すべての発送を無料にする
+        name: 発送無料
+    promotion_actions: アクション
+    promotion_category: プロモーションカテゴリ
     promotion_form:
       match_policies:
-        all: "以下のルールすべてに該当する"
-        any: "以下のルールのいずれかに該当する"
-    promotion_rule: "プロモーションルール"
+        all: 以下のルールすべてに該当する
+        any: 以下のルールのいずれかに該当する
+    promotion_rule: プロモーションルール
     promotion_rule_types:
       first_order:
-        description: "最初の注文である"
-        name: "最初の注文"
+        description: 最初の注文である
+        name: 最初の注文
       item_total:
-        description: "合計個数"
-        name: "合計個数"
+        description: 合計個数
+        name: 合計個数
       landing_page:
-        description: "お客様が特定のページを訪問済みである"
-        name: "ランディングページ"
+        description: お客様が特定のページを訪問済みである
+        name: ランディングページ
       one_use_per_user:
-        description: "ユーザーごとに一つ"
-        name: "ユーザーごとに一つ"
+        description: ユーザーごとに一つ
+        name: ユーザーごとに一つ
       option_value:
-        description: "マッチするオプション値を含んだ注文"
-        name: "オプション値"
+        description: マッチするオプション値を含んだ注文
+        name: オプション値
       product:
-        description: "注文に特定の商品を含む"
-        name: "商品"
-      user:
-        description: "特定のユーザー限定"
-        name: "ユーザー"
-      user_logged_in:
-        description: "ログイン中のユーザー限定"
-        name: "ログイン中のユーザー"
+        description: 注文に特定の商品を含む
+        name: 商品
       taxon:
-        description: "指定したジャンル単位のみ"
-        name: "ジャンル単位"
-    promotions: "プロモーション"
-    promotion_uses: "プロモーション"
-    propagate_all_variants:
-    properties: "属性"
-    property: "属性"
-    prototype: "原型"
-    prototypes: "原型"
-    provider: "プロバイダー"
-    provider_settings_warning: "プロバイダータイプを変更する時は、プロバイダー設定を編集する前に保存しなければなりません。"
-    qty: "個数"
-    quantity: "量"
-    quantity_returned: "返送された数"
-    quantity_shipped: "発送された数"
-    quick_search: "クイック検索"
-    rate: "比率"
-    reason: "理由"
-    receive: "受信"
-    receive_stock:
-    received: "受信した"
-    reception_status: "受信したステータス"
-    reference: "参照"
-    reference_contains: "参照含む"
-    refund: "払い戻し"
-    refund_amount_must_be_greater_than_zero: "0以上の返金料"
-    refund_reasons: "返金理由"
-    refunded_amount: "返金料"
-    refunds: "返金"
-    register: "新規ユーザーとして登録"
-    registration: "登録"
-    reimburse: "払い戻す"
-    reimbursed: "払い戻し済み"
-    reimbursement: "払い戻し"
-    reimbursement_perform_failed: "払い戻しが実行できませんでした。 %{error}"
-    reimbursement_status: "払い戻しステータス"
-    reimbursement_type: "払い戻しタイプ"
-    reimbursement_type_override: "払い戻しタイプ上書き"
-    reimbursement_types: "払い戻しタイプ"
-    reimbursements: "払い戻し"
-    reject: "拒否"
-    rejected: "拒否済み"
-    remember_me: "記録する"
-    remove: "削除"
-    rename: "リネーム"
-    report: "レポート"
-    reports: "レポート"
-    resellable: "再販売可能"
-    resend: "再送信"
-    reset_password: "パスワードを再設定する"
-    response_code: "レスポンスコード"
-    resume: "再開"
-    resumed: "再開された"
-    return: "返品"
-    return_authorization: "返品承認"
-    return_authorization_reasons: "返品承認理由"
-    return_authorization_updated: "返品承認が更新されました"
-    return_authorizations: "返品承認"
-    return_item_inventory_unit_ineligible: "返品の在庫ユニットは発送済みでなければなりません。"
-    return_item_inventory_unit_reimbursed: "返品在庫ユニットは既に払い戻し済みです。"
-    return_item_order_not_completed: "返品注文は完了されていなければなりません。"
-    return_item_rma_ineligible: "返品にはRMAが必要です。"
-    return_item_time_period_ineligible: "返品は期限切れです。"
-    return_items: "返品"
-    return_items_cannot_be_associated_with_multiple_orders: "返品商品は複数の注文の注文と関連づけることはできません。"
+        description: 指定したジャンル単位のみ
+        name: ジャンル単位
+      user:
+        description: 特定のユーザー限定
+        name: ユーザー
+      user_logged_in:
+        description: ログイン中のユーザー限定
+        name: ログイン中のユーザー
+    promotion_uses: プロモーション
+    promotionable: プロモーション可能
+    promotions: プロモーション
+    propagate_all_variants: 
+    properties: 属性
+    property: 属性
+    prototype: 原型
+    prototypes: 原型
+    provider: プロバイダー
+    provider_settings_warning: プロバイダータイプを変更する時は、プロバイダー設定を編集する前に保存しなければなりません。
+    qty: 個数
+    quantity: 量
+    quantity_returned: 返送された数
+    quantity_shipped: 発送された数
+    quick_search: クイック検索
+    rate: 比率
+    reason: 理由
+    receive: 受信
+    receive_stock: 
+    received: 受信した
+    reception_status: 受信したステータス
+    reference: 参照
+    reference_contains: 参照含む
+    refund: 払い戻し
+    refund_amount_must_be_greater_than_zero: 0以上の返金料
+    refund_reasons: 返金理由
+    refunded_amount: 返金料
+    refunds: 返金
+    register: 新規ユーザーとして登録
+    registration: 登録
+    reimburse: 払い戻す
+    reimbursed: 払い戻し済み
+    reimbursement: 払い戻し
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send: "交換待ちの商品を送り返すのに%{days}必要です。"
-        dear_customer: "お客様"
-        exchange_summary: "交換概要"
-        for: "for"
-        instructions: "返品が実行されました。"
-        refund_summary: "返品概要"
-        subject: "返品通知"
-        total_refunded: "返金合計: %{total}"
-    return_number: "返品番号"
-    return_quantity: "返品数"
-    returned: "返品済み"
-    returns: "返品"
-    review: "内容を確認する"
-    risk: "リスク"
-    risk_analysis: "リスク解析"
-    risky: "リスクのある"
+        days_to_send: 交換待ちの商品を送り返すのに%{days}必要です。
+        dear_customer: お客様
+        exchange_summary: 交換概要
+        for: for
+        instructions: 返品が実行されました。
+        refund_summary: 返品概要
+        subject: 返品通知
+        total_refunded: '返金合計: %{total}'
+    reimbursement_perform_failed: 払い戻しが実行できませんでした。 %{error}
+    reimbursement_status: 払い戻しステータス
+    reimbursement_type: 払い戻しタイプ
+    reimbursement_type_override: 払い戻しタイプ上書き
+    reimbursement_types: 払い戻しタイプ
+    reimbursements: 払い戻し
+    reject: 拒否
+    rejected: 拒否済み
+    remember_me: 記録する
+    remove: 削除
+    rename: リネーム
+    report: レポート
+    reports: レポート
+    resellable: 再販売可能
+    resend: 再送信
+    reset_password: パスワードを再設定する
+    response_code: レスポンスコード
+    resume: 再開
+    resumed: 再開された
+    return: 返品
+    return_authorization: 返品承認
+    return_authorization_reasons: 返品承認理由
+    return_authorization_updated: 返品承認が更新されました
+    return_authorizations: 返品承認
+    return_item_inventory_unit_ineligible: 返品の在庫ユニットは発送済みでなければなりません。
+    return_item_inventory_unit_reimbursed: 返品在庫ユニットは既に払い戻し済みです。
+    return_item_order_not_completed: 返品注文は完了されていなければなりません。
+    return_item_rma_ineligible: 返品にはRMAが必要です。
+    return_item_time_period_ineligible: 返品は期限切れです。
+    return_items: 返品
+    return_items_cannot_be_associated_with_multiple_orders: 返品商品は複数の注文の注文と関連づけることはできません。
+    return_number: 返品番号
+    return_quantity: 返品数
+    returned: 返品済み
+    returns: 返品
+    review: 内容を確認する
+    risk: リスク
+    risk_analysis: リスク解析
+    risky: リスクのある
     rma_credit: RMAクレジット
     rma_number: RMA番号
     rma_value: RMA値
-    role_id: "役割ID"
-    roles: "役割"
-    rules: "ルール"
-    safe: "安全"
-    sales_total: "売上げ合計"
-    sales_total_description: "全注文の売上合計"
-    sales_totals: "売上合計"
-    save_and_continue: "保存して続行"
-    save_my_address: "住所の保存"
-    say_no: "いいえ"
-    say_yes: "はい"
-    scope: "範囲"
-    search: "検索"
+    role_id: 役割ID
+    roles: 役割
+    rules: ルール
+    safe: 安全
+    sales_total: 売上げ合計
+    sales_total_description: 全注文の売上合計
+    sales_totals: 売上合計
+    save_and_continue: 保存して続行
+    save_my_address: 住所の保存
+    say_no: いいえ
+    say_yes: はい
+    scope: 範囲
+    search: 検索
     search_results: "'%{keywords}' の検索結果"
-    searching: "検索中"
-    secure_connection_type: "接続保護のタイプ"
-    security_settings: "セキュリティの設定"
-    select: "選択"
-    select_from_prototype: "原型から選択"
-    select_a_return_authorization_reason: "返品認証の理由を選択してください"
-    select_a_stock_location: "在庫場所の選択"
-    select_stock: "在庫の選択"
-    selected_quantity_not_available: ! '%{item}の選択は利用不可です。'
-    send_copy_of_all_mails_to: "全てのメールのコピーをこの宛先に送る"
-    send_mails_as: "メール送信者名"
-    server: "サーバ"
-    server_error: "サーバーエラー"
-    settings: "設定"
-    ship: "配送"
-    ship_address: "配送先住所"
-    ship_total: "発送合計"
-    shipment: "発送"
-    shipment_adjustments: "発送値引き"
-    shipment_details: "発送詳細"
+    searching: 検索中
+    secure_connection_type: 接続保護のタイプ
+    security_settings: セキュリティの設定
+    select: 選択
+    select_a_return_authorization_reason: 返品認証の理由を選択してください
+    select_a_stock_location: 在庫場所の選択
+    select_from_prototype: 原型から選択
+    select_stock: 在庫の選択
+    selected_quantity_not_available: "%{item}の選択は利用不可です。"
+    send_copy_of_all_mails_to: 全てのメールのコピーをこの宛先に送る
+    send_mails_as: メール送信者名
+    server: サーバ
+    server_error: サーバーエラー
+    settings: 設定
+    ship: 配送
+    ship_address: 配送先住所
+    ship_total: 発送合計
+    shipment: 発送
+    shipment_adjustments: 発送値引き
+    shipment_details: 発送詳細
     shipment_mailer:
       shipped_email:
-        dear_customer: "お客様"
-        instructions: "注文した商品を発送しました。"
-        shipment_summary: "発送概要"
-        subject: "発送の通知"
-        thanks: "ご利用ありがとうございました。"
-        track_information: "トラック情報 %{tracking}"
+        dear_customer: お客様
+        instructions: 注文した商品を発送しました。
+        shipment_summary: 発送概要
+        subject: 発送の通知
+        thanks: ご利用ありがとうございました。
+        track_information: トラック情報 %{tracking}
         track_link: 'トラックURL: %{url}'
-    shipment_state: "配送状況"
+    shipment_state: 配送状況
     shipment_states:
-      backorder: "入荷待ち"
-      canceled: "キャンセル済み"
-      partial: "一部配送"
-      pending: "配送準備中"
-      ready: "配送可能"
-      shipped: "配送済み"
-    shipment_transfer_success: "種別の移動に成功しました。"
-    shipment_transfer_error: "種別の移動中にエラーが発生しました。"
-    shipments: "配送"
-    shipped: "発送済"
-    shipping: "送料"
-    shipping_address: "配送先"
-    shipping_categories: "配送カテゴリー"
-    shipping_category: "配送カテゴリー"
-    shipping_flat_rate_per_item: "パッケージ商品ごとに均一の比率"
-    shipping_flat_rate_per_order: "均一の比率"
-    shipping_flexible_rate: "パッケージ商品ごとに柔軟な比率"
-    shipping_instructions: "配送に関して"
-    shipping_method: "配送方法"
-    shipping_methods: "配送方法"
-    shipping_price_sack: "袋値段"
-    shipping_total: "配送合計"
+      backorder: 入荷待ち
+      canceled: キャンセル済み
+      partial: 一部配送
+      pending: 配送準備中
+      ready: 配送可能
+      shipped: 配送済み
+    shipment_transfer_error: 種別の移動中にエラーが発生しました。
+    shipment_transfer_success: 種別の移動に成功しました。
+    shipments: 配送
+    shipped: 発送済
+    shipping: 送料
+    shipping_address: 配送先
+    shipping_categories: 配送カテゴリー
+    shipping_category: 配送カテゴリー
+    shipping_flat_rate_per_item: パッケージ商品ごとに均一の比率
+    shipping_flat_rate_per_order: 均一の比率
+    shipping_flexible_rate: パッケージ商品ごとに柔軟な比率
+    shipping_instructions: 配送に関して
+    shipping_method: 配送方法
+    shipping_methods: 配送方法
+    shipping_price_sack: 袋値段
+    shipping_total: 配送合計
     shop_by_taxonomy: "%{taxonomy}"
-    shopping_cart: "ショッピングカート"
-    show: "表示"
-    show_active: "有効のを表示する"
-    show_deleted: "削除済みのを表示"
-    show_only_complete_orders: "処理済みの注文のみを表示"
-    show_only_considered_risky: "リスクのあるオーダーのみ表示"
-    show_rate_in_label: "税率を見る"
-    sku: "品番[SKU]"
-    skus: "品番[SKU]"
-    slug: "スラグ"
-    source: "ソース"
-    special_instructions: "特別な指示"
-    split: "分割"
-    spree_gateway_error_flash_for_checkout: "支払い情報に問題があります。情報をお確かめになり再試行願います。"
+    shopping_cart: ショッピングカート
+    show: 表示
+    show_active: 有効のを表示する
+    show_deleted: 削除済みのを表示
+    show_only_complete_orders: 処理済みの注文のみを表示
+    show_only_considered_risky: リスクのあるオーダーのみ表示
+    show_rate_in_label: 税率を見る
+    sku: 品番[SKU]
+    skus: 品番[SKU]
+    slug: スラグ
+    source: ソース
+    special_instructions: 特別な指示
+    split: 分割
+    spree_gateway_error_flash_for_checkout: 支払い情報に問題があります。情報をお確かめになり再試行願います。
     ssl:
-      change_protocol: "HTTPSではなくHTTPプロトコルに切り替えて再度リクエストしてください。"
-    start: "始め"
-    state: "都道府県（州）"
-    state_based: "都道府県（州）による区別"
-    states: "都道府県（州）"
+      change_protocol: HTTPSではなくHTTPプロトコルに切り替えて再度リクエストしてください。
+    start: 始め
+    state: 都道府県（州）
+    state_based: 都道府県（州）による区別
     state_machine_states:
-      accepted: "受付"
-      address: "住所"
-      authorized: "認可済み"
-      awaiting: "待ち"
-      awaiting_return: "返品待ち"
-      backordered: "オーダー済み"
-      canceled: "キャンセル済み"
-      cart: "カート"
-      checkout: "チェックアウト"
-      closed: "閉鎖"
-      complete: "完了"
-      completed: "完了済み"
-      confirm: "確認"
-      delivery: "配送"
-      errored: "エラー"
-      failed: "失敗"
-      given_to_customer: "ふさわしい顧客"
-      invalid: "不正"
-      manual_intervention_required: "手動介入が必要"
-      open: "公開"
-      order: "注文"
-      on_hand: "主導"
-      payment: "支払い"
-      pending: "停止"
-      processing: "処理中"
-      ready: "準備完了"
-      reimbursed: "返品済み"
-      resumed: "再開"
-      returned: "返品"
-      shipped: "配送済み"
-      void: "空"
-    states_required: "必須"
-    status: "状況"
-    stock: "在庫"
-    stock_location: "在庫位置"
-    stock_location_info: "在庫位置情報"
-    stock_locations: "在庫位置"
-    stock_locations_need_a_default_country: "在庫位置を作成する前にデフォルトの国を作る必要があります。"
-    stock_management: "在庫管理"
-    stock_management_requires_a_stock_location: "在庫を管理するために在庫位置を作成してください。"
-    stock_movements: "在庫移動"
+      accepted: 受付
+      address: 住所
+      authorized: 認可済み
+      awaiting: 待ち
+      awaiting_return: 返品待ち
+      backordered: オーダー済み
+      canceled: キャンセル済み
+      cart: カート
+      checkout: チェックアウト
+      closed: 閉鎖
+      complete: 完了
+      completed: 完了済み
+      confirm: 確認
+      delivery: 配送
+      errored: エラー
+      failed: 失敗
+      given_to_customer: ふさわしい顧客
+      invalid: 不正
+      manual_intervention_required: 手動介入が必要
+      on_hand: 主導
+      open: 公開
+      order: 注文
+      payment: 支払い
+      pending: 停止
+      processing: 処理中
+      ready: 準備完了
+      reimbursed: 返品済み
+      resumed: 再開
+      returned: 返品
+      shipped: 配送済み
+      void: 空
+    states: 都道府県（州）
+    states_required: 必須
+    status: 状況
+    stock: 在庫
+    stock_location: 在庫位置
+    stock_location_info: 在庫位置情報
+    stock_locations: 在庫位置
+    stock_locations_need_a_default_country: 在庫位置を作成する前にデフォルトの国を作る必要があります。
+    stock_management: 在庫管理
+    stock_management_requires_a_stock_location: 在庫を管理するために在庫位置を作成してください。
+    stock_movements: 在庫移動
     stock_movements_for_stock_location: "%{stock_location_name}への在庫移動"
     stock_successfully_transferred: 在庫の在庫地館での移動が完了しました。""
-    stock_transfer: "在庫移動"
-    stock_transfers: "在庫移動"
-    stop: "終わり"
-    store: "ストア"
-    street_address: "住所"
-    street_address_2: "住所の続き"
-    subtotal: "合計"
-    subtract: "引く"
-    success: "成功"
+    stock_transfer: 在庫移動
+    stock_transfers: 在庫移動
+    stop: 終わり
+    store: ストア
+    street_address: 住所
+    street_address_2: 住所の続き
+    subtotal: 合計
+    subtract: 引く
+    success: 成功
     successfully_created: "%{resource}が作成されました!"
     successfully_refunded: "%{resource}は返金されました！"
     successfully_removed: "%{resource}が削除されました!"
-    successfully_signed_up_for_analytics: "Spree解析のログインに成功しました"
+    successfully_signed_up_for_analytics: Spree解析のログインに成功しました
     successfully_updated: "%{resource}が更新されました!"
-    summary: "概要"
-    tax: "税金"
-    tax_included: "税金 (incl.)"
-    tax_categories: "税金カテゴリー"
-    tax_category: "税金カテゴリー"
-    tax_code: "税金コード"
-    tax_rate_amount_explanation: "税率は5%のとき、0.05と入力します。"
-    tax_rates: "税率"
-    taxon: "ジャンル単位"
-    taxon_edit: "ジャンル単位を編集"
-    taxon_placeholder: "ジャンル単位プレイスホルダ"
+    summary: 概要
+    tax: 税金
+    tax_categories: 税金カテゴリー
+    tax_category: 税金カテゴリー
+    tax_code: 税金コード
+    tax_included: 税金 (incl.)
+    tax_rate_amount_explanation: 税率は5%のとき、0.05と入力します。
+    tax_rates: 税率
+    taxon: ジャンル単位
+    taxon_edit: ジャンル単位を編集
+    taxon_placeholder: ジャンル単位プレイスホルダ
     taxon_rule:
-      choose_taxons: "ジャンル単位の選択"
-      label: "注文はこれらの分類単位を含まなければなりません。"
-      match_all: "すべて"
-      match_any: "最低一つ"
-    taxonomies: "ジャンルツリー"
-    taxonomy: "ジャンルツリー"
-    taxonomy_edit: "ジャンルツリーを編集する"
-    taxonomy_tree_error: "要求された変更は受け付けられず、ツリーは以前の状態に戻っています。再度お試しください。"
+      choose_taxons: ジャンル単位の選択
+      label: 注文はこれらの分類単位を含まなければなりません。
+      match_all: すべて
+      match_any: 最低一つ
+    taxonomies: ジャンルツリー
+    taxonomy: ジャンルツリー
+    taxonomy_edit: ジャンルツリーを編集する
+    taxonomy_tree_error: 要求された変更は受け付けられず、ツリーは以前の状態に戻っています。再度お試しください。
     taxonomy_tree_instruction: "* 追加・削除・ソートなどのメニューを選択するには、ツリーのノードを右クリックしてください。"
-    taxons: "ジャンル単位"
-    test: "テスト"
+    taxons: ジャンル単位
+    test: テスト
     test_mailer:
       test_email:
-        greeting: "おめでとうございます！"
-        message: "もしこのメールを受け取ったのなら、あなたのメール設定は正しいです。"
-        subject: "テストメール"
-    test_mode: "テストモード"
-    thank_you_for_your_order: "ご注文ありがとうございます。この確認画面を控えとして印刷してください。"
-    there_are_no_items_for_this_order: "この注文に商品が一つもありません。続けるには商品を追加してください。"
-    there_were_problems_with_the_following_fields: "以下の入力欄で問題がありました"
-    this_order_has_already_received_a_refund: "この注文は既に返金受け取り済みです。"
-    thumbnail: "サムネイル"
-    tiers: "列"
-    tiered_flat_rate: "列の均一料金"
-    tiered_percent: "列パーセント"
-    time: "時間"
-    to_add_variants_you_must_first_define: "種類を追加するには、まず以下を定義する必要があります。"
-    total: "合計"
-    total_per_item: "商品ごとの合計"
-    total_pre_tax_refund: "税引き前の返金合計"
-    total_price: "合計金額"
-    total_sales: "合計売上"
-    track_inventory: "在庫を追跡"
-    tracking: "追跡"
-    tracking_number: "追跡ナンバー"
-    tracking_url: "追跡URL"
-    tracking_url_placeholder: "e.g.http://quickship.com/package?num=:tracking"
-    transaction_id: "取引ID"
-    transfer_from_location: "移動(From)"
-    transfer_stock: "在庫の移動"
-    transfer_to_location: "移動(To)"
-    tree: "ツリー"
-    type: "支払い方法"
-    type_to_search: "何か入力すると検索します"
-    unable_to_connect_to_gateway: "ゲートウェイに接続できません。"
-    unable_to_create_reimbursements: "手動介入で停止中の商品があるため、返品の作成ができませんでした。"
+        greeting: おめでとうございます！
+        message: もしこのメールを受け取ったのなら、あなたのメール設定は正しいです。
+        subject: テストメール
+    test_mode: テストモード
+    thank_you_for_your_order: ご注文ありがとうございます。この確認画面を控えとして印刷してください。
+    there_are_no_items_for_this_order: この注文に商品が一つもありません。続けるには商品を追加してください。
+    there_were_problems_with_the_following_fields: 以下の入力欄で問題がありました
+    this_order_has_already_received_a_refund: この注文は既に返金受け取り済みです。
+    thumbnail: サムネイル
+    tiered_flat_rate: 列の均一料金
+    tiered_percent: 列パーセント
+    tiers: 列
+    time: 時間
+    to_add_variants_you_must_first_define: 種類を追加するには、まず以下を定義する必要があります。
+    total: 合計
+    total_per_item: 商品ごとの合計
+    total_pre_tax_refund: 税引き前の返金合計
+    total_price: 合計金額
+    total_sales: 合計売上
+    track_inventory: 在庫を追跡
+    tracking: 追跡
+    tracking_number: 追跡ナンバー
+    tracking_url: 追跡URL
+    tracking_url_placeholder: e.g.http://quickship.com/package?num=:tracking
+    transaction_id: 取引ID
+    transfer_from_location: 移動(From)
+    transfer_stock: 在庫の移動
+    transfer_to_location: 移動(To)
+    tree: ツリー
+    type: 支払い方法
+    type_to_search: 何か入力すると検索します
+    unable_to_connect_to_gateway: ゲートウェイに接続できません。
+    unable_to_create_reimbursements: 手動介入で停止中の商品があるため、返品の作成ができませんでした。
     under_price: "%{price}より安い"
-    unlock: "ロック解除"
-    unrecognized_card_type: "認識できないカードタイプ"
-    unshippable_items: "配送不可の商品"
-    update: "更新"
-    updating: "更新中"
-    usage_limit: "使用制限"
-    use_app_default: "App デフォルトを利用する"
-    use_billing_address: "請求先住所を使用する"
-    use_existing_cc: "保存済みカード情報を利用する"
-    use_new_cc: "新しいカードを使用する"
-    use_new_cc_or_payment_method: "新しいカードを利用 / 支払い方法"
-    use_s3: "商品画像の保存にAmazon S3を使用する"
-    user: "ユーザー"
+    unlock: ロック解除
+    unrecognized_card_type: 認識できないカードタイプ
+    unshippable_items: 配送不可の商品
+    update: 更新
+    updating: 更新中
+    usage_limit: 使用制限
+    use_app_default: App デフォルトを利用する
+    use_billing_address: 請求先住所を使用する
+    use_existing_cc: 保存済みカード情報を利用する
+    use_new_cc: 新しいカードを使用する
+    use_new_cc_or_payment_method: 新しいカードを利用 / 支払い方法
+    use_s3: 商品画像の保存にAmazon S3を使用する
+    user: ユーザー
     user_rule:
-      choose_users: "ユーザーの選択"
-    users: "ユーザー"
+      choose_users: ユーザーの選択
+    users: ユーザー
     validation:
-      unpaid_amount_not_zero: "量を完全に返品できません。 Still due: %{amount}"
-      cannot_be_less_than_shipped_units: "配送ユニットの個数より小さくはできません"
-      cannot_destroy_line_item_as_inventory_units_have_shipped: "いくつかの在庫が発送されたため項目を削除できません。"
-      exceeds_available_stock: "可能な在庫数を上回っています。項目の個数が正しく入力されていることを確認してください。"
-      is_too_large: "要求された量は在庫を超えています。"
-      must_be_int: "整数であることが必要です"
-      must_be_non_negative: "0以上の数字が必要です"
-    value: "値"
-    variant: "種類"
-    variant_search_placeholder: "品名もしくは品番[SKU]"
-    variant_placeholder: "種類プレイスホルダ"
-    variants: "種類"
-    version: "バージョン"
-    void: "無効"
-    weight: "重量"
-    what_is_a_cvv: "カード照合値(CVV)とは?"
-    what_is_this: "これは何?"
-    width: "横幅"
-    year: "年"
-    you_have_no_orders_yet: "まだ注文がありません。"
-    your_cart_is_empty: "カートは空です"
-    your_order_is_empty_add_product: "注文が空です。検索し商品を追加してください。"
-    zip: "郵便番号"
-    zipcode: "郵便番号コード"
-    zone: "ゾーン"
-    zones: "ゾーン"
+      cannot_be_less_than_shipped_units: 配送ユニットの個数より小さくはできません
+      cannot_destroy_line_item_as_inventory_units_have_shipped: いくつかの在庫が発送されたため項目を削除できません。
+      exceeds_available_stock: 可能な在庫数を上回っています。項目の個数が正しく入力されていることを確認してください。
+      is_too_large: 要求された量は在庫を超えています。
+      must_be_int: 整数であることが必要です
+      must_be_non_negative: 0以上の数字が必要です
+      unpaid_amount_not_zero: '量を完全に返品できません。 Still due: %{amount}'
+    value: 値
+    variant: 種類
+    variant_placeholder: 種類プレイスホルダ
+    variant_search_placeholder: 品名もしくは品番[SKU]
+    variants: 種類
+    version: バージョン
+    void: 無効
+    weight: 重量
+    what_is_a_cvv: カード照合値(CVV)とは?
+    what_is_this: これは何?
+    width: 横幅
+    year: 年
+    you_have_no_orders_yet: まだ注文がありません。
+    your_cart_is_empty: カートは空です
+    your_order_is_empty_add_product: 注文が空です。検索し商品を追加してください。
+    zip: 郵便番号
+    zipcode: 郵便番号コード
+    zone: ゾーン
+    zones: ゾーン

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,1250 +1,1251 @@
+---
 ko:
   activerecord:
     attributes:
       spree/address:
-        address1:
-        address2:
-        city:
-        country:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        address2: 
+        city: 
+        country: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
-        iso:
-        iso3:
-        iso_name:
-        name:
-        numcode:
+        iso: 
+        iso3: 
+        iso_name: 
+        name: 
+        numcode: 
       spree/credit_card:
-        base:
-        cc_type:
-        month:
-        name:
-        number:
-        verification_value:
-        year:
+        base: 
+        cc_type: 
+        month: 
+        name: 
+        number: 
+        verification_value: 
+        year: 
       spree/inventory_unit:
-        state:
+        state: 
       spree/line_item:
-        price:
-        quantity:
+        price: 
+        quantity: 
       spree/option_type:
-        name:
-        presentation:
+        name: 
+        presentation: 
       spree/order:
-        checkout_complete:
-        completed_at:
-        considered_risky:
-        coupon_code:
-        created_at:
-        email:
-        ip_address:
-        item_total:
-        number:
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
-        total:
+        checkout_complete: 
+        completed_at: 
+        considered_risky: 
+        coupon_code: 
+        created_at: 
+        email: 
+        ip_address: 
+        item_total: 
+        number: 
+        payment_state: 
+        shipment_state: 
+        special_instructions: 
+        state: 
+        total: 
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/payment:
-        amount:
+        amount: 
       spree/payment_method:
-        name:
+        name: 
       spree/product:
-        available_on:
-        cost_currency:
-        cost_price:
-        description:
-        master_price:
-        name:
-        on_hand:
-        shipping_category:
-        tax_category:
+        available_on: 
+        cost_currency: 
+        cost_price: 
+        description: 
+        master_price: 
+        name: 
+        on_hand: 
+        shipping_category: 
+        tax_category: 
       spree/promotion:
-        advertise:
-        code:
-        description:
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        advertise: 
+        code: 
+        description: 
+        event_name: 
+        expires_at: 
+        name: 
+        path: 
+        starts_at: 
+        usage_limit: 
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
-        name:
-        presentation:
+        name: 
+        presentation: 
       spree/prototype:
-        name:
+        name: 
       spree/return_authorization:
-        amount:
+        amount: 
       spree/role:
-        name:
+        name: 
       spree/state:
-        abbr:
-        name:
+        abbr: 
+        name: 
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
-        description:
-        name:
+        description: 
+        name: 
       spree/tax_rate:
-        amount:
-        included_in_price:
-        show_rate_in_label:
+        amount: 
+        included_in_price: 
+        show_rate_in_label: 
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: 
+        permalink: 
+        position: 
       spree/taxonomy:
-        name:
+        name: 
       spree/user:
-        email:
-        password:
-        password_confirmation:
+        email: 
+        password: 
+        password_confirmation: 
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_currency: 
+        cost_price: 
+        depth: 
+        height: 
+        price: 
+        sku: 
+        weight: 
+        width: 
       spree/zone:
-        description:
-        name:
+        description: 
+        name: 
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
-      spree/address:
-      spree/country:
-      spree/credit_card:
-      spree/customer_return:
-      spree/inventory_unit:
-      spree/line_item:
-      spree/option_type:
-      spree/option_value:
-      spree/order:
-      spree/payment:
-      spree/payment_method:
-      spree/product:
-      spree/promotion:
-      spree/promotion_category:
-      spree/property:
-      spree/prototype:
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
-      spree/return_authorization:
-      spree/return_authorization_reason:
-      spree/role:
-      spree/shipment:
-      spree/shipping_category:
-      spree/shipping_method:
-      spree/state:
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
-      spree/tax_category:
-      spree/tax_rate:
-      spree/taxon:
-      spree/taxonomy:
-      spree/tracker:
-      spree/user:
-      spree/variant:
-      spree/zone:
+      spree/address: 
+      spree/country: 
+      spree/credit_card: 
+      spree/customer_return: 
+      spree/inventory_unit: 
+      spree/line_item: 
+      spree/option_type: 
+      spree/option_value: 
+      spree/order: 
+      spree/payment: 
+      spree/payment_method: 
+      spree/product: 
+      spree/promotion: 
+      spree/promotion_category: 
+      spree/property: 
+      spree/prototype: 
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
+      spree/return_authorization: 
+      spree/return_authorization_reason: 
+      spree/role: 
+      spree/shipment: 
+      spree/shipping_category: 
+      spree/shipping_method: 
+      spree/state: 
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
+      spree/tax_category: 
+      spree/tax_rate: 
+      spree/taxon: 
+      spree/taxonomy: 
+      spree/tracker: 
+      spree/user: 
+      spree/variant: 
+      spree/zone: 
   spree:
-    abbreviation: "생략"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
-    account: "계정"
-    account_updated: "계정 정보가 수정되었습니다!"
-    action: "행동"
+    abbreviation: 생략
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
+    account: 계정
+    account_updated: 계정 정보가 수정되었습니다!
+    action: 행동
     actions:
-      cancel: "취소"
-      continue:
-      create: "생성"
-      destroy: "삭제"
-      edit:
-      list: "목록"
-      listing: "목록"
-      new:
-      refund:
-      save:
-      update: "수정"
-    activate:
-    active: "활성"
-    add: "추가"
-    add_action_of_type:
-    add_country: "국가 추가"
-    add_coupon_code:
-    add_new_header:
-    add_new_style:
-    add_one:
-    add_option_value: "옵션 값 추가"
-    add_product: "상품 추가"
-    add_product_properties: "상품 속성 추가"
-    add_rule_of_type:
-    add_state:
-    add_stock:
-    add_stock_management:
-    add_to_cart: "장바구니에 추가"
-    add_variant:
-    additional_item: "추가 된 아이템 비용"
-    address1:
-    address2:
-    adjustable:
-    adjustment: "정산"
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
-    adjustment_total: "정산 합계"
-    adjustments: "정산"
+      cancel: 취소
+      continue: 
+      create: 생성
+      destroy: 삭제
+      edit: 
+      list: 목록
+      listing: 목록
+      new: 
+      refund: 
+      save: 
+      update: 수정
+    activate: 
+    active: 활성
+    add: 추가
+    add_action_of_type: 
+    add_country: 국가 추가
+    add_coupon_code: 
+    add_new_header: 
+    add_new_style: 
+    add_one: 
+    add_option_value: 옵션 값 추가
+    add_product: 상품 추가
+    add_product_properties: 상품 속성 추가
+    add_rule_of_type: 
+    add_state: 
+    add_stock: 
+    add_stock_management: 
+    add_to_cart: 장바구니에 추가
+    add_variant: 
+    additional_item: 추가 된 아이템 비용
+    address1: 
+    address2: 
+    adjustable: 
+    adjustment: 정산
+    adjustment_amount: 
+    adjustment_successfully_closed: 
+    adjustment_successfully_opened: 
+    adjustment_total: 정산 합계
+    adjustments: 정산
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
-    administration: "관리"
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
-    all: "전체"
-    all_adjustments_closed:
-    all_adjustments_opened:
-    all_departments:
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
-    alt_text: "대체 텍스트"
-    alternative_phone: "휴대폰 번호"
-    amount: "액수"
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
-    analytics_trackers: "애날리틱스 트래커"
-    and:
-    approve:
-    approved_at:
-    approver:
-    are_you_sure: "확실합니까?"
-    are_you_sure_delete: "기록을 삭제하시겠습니까?"
-    associated_adjustment_closed:
-    at_symbol: '@'
-    authorization_failure: "인증 실패"
-    authorized:
-    auto_capture:
-    available_on: "시작일"
-    average_order_value:
-    avs_response:
-    back: "뒤로"
-    back_end:
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
-    back_to_store: "스토어로 돌아가기"
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
-    balance_due: "부족"
-    base_amount:
-    base_percent:
-    bill_address: "청구서 주소"
-    billing: "청구서"
-    billing_address: "청구서 주소"
-    both: "양 쪽 모두"
-    calculated_reimbursements:
-    calculator: "계산기"
-    calculator_settings_warning:
-    cancel: "취소"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
-    cannot_create_returns:
-    cannot_perform_operation: "요청한 명령을 실핼 할 수 없습니다"
-    cannot_set_shipping_method_without_address:
-    capture: "캡쳐"
-    capture_events:
-    card_code: "카드 코드"
-    card_number: "카드 번호"
-    card_type:
-    card_type_is: "카드 종료는 입니다"
-    cart: "장바구니"
-    cart_subtotal:
-    categories:
-    category:
-    charged:
-    check_for_spree_alerts:
-    checkout:
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
-    city:
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
-    clone: "복사"
-    close:
-    close_all_adjustments:
-    code: "코드"
-    company:
-    complete: "완료"
-    configuration: "설정"
-    configurations: "설정"
-    confirm: "확인"
-    confirm_delete:
-    confirm_password: "비밀번호 확인"
-    continue: "계속"
-    continue_shopping: "계속 쇼핑"
-    cost_currency:
-    cost_price: "비용"
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
-    country: "국가"
-    country_based: "국가 기반"
-    country_name:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
+    administration: 관리
+    advertise: 
+    agree_to_privacy_policy: 
+    agree_to_terms_of_service: 
+    all: 전체
+    all_adjustments_closed: 
+    all_adjustments_opened: 
+    all_departments: 
+    all_items_have_been_returned: 
+    allow_ssl_in_development_and_test: 
+    allow_ssl_in_production: 
+    allow_ssl_in_staging: 
+    already_signed_up_for_analytics: 
+    alt_text: 대체 텍스트
+    alternative_phone: 휴대폰 번호
+    amount: 액수
+    analytics_desc_header_1: 
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
+    analytics_trackers: 애날리틱스 트래커
+    and: 
+    approve: 
+    approved_at: 
+    approver: 
+    are_you_sure: 확실합니까?
+    are_you_sure_delete: 기록을 삭제하시겠습니까?
+    associated_adjustment_closed: 
+    at_symbol: "@"
+    authorization_failure: 인증 실패
+    authorized: 
+    auto_capture: 
+    available_on: 시작일
+    average_order_value: 
+    avs_response: 
+    back: 뒤로
+    back_end: 
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
+    back_to_store: 스토어로 돌아가기
+    back_to_users_list: 
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
+    balance_due: 부족
+    base_amount: 
+    base_percent: 
+    bill_address: 청구서 주소
+    billing: 청구서
+    billing_address: 청구서 주소
+    both: 양 쪽 모두
+    calculated_reimbursements: 
+    calculator: 계산기
+    calculator_settings_warning: 
+    cancel: 취소
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: 
+    cannot_create_returns: 
+    cannot_perform_operation: 요청한 명령을 실핼 할 수 없습니다
+    cannot_set_shipping_method_without_address: 
+    capture: 캡쳐
+    capture_events: 
+    card_code: 카드 코드
+    card_number: 카드 번호
+    card_type: 
+    card_type_is: 카드 종료는 입니다
+    cart: 장바구니
+    cart_subtotal: 
+    categories: 
+    category: 
+    charged: 
+    check_for_spree_alerts: 
+    checkout: 
+    choose_a_customer: 
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 
+    choose_dashboard_locale: 
+    choose_location: 
+    city: 
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
+    clone: 복사
+    close: 
+    close_all_adjustments: 
+    code: 코드
+    company: 
+    complete: 완료
+    configuration: 설정
+    configurations: 설정
+    confirm: 확인
+    confirm_delete: 
+    confirm_password: 비밀번호 확인
+    continue: 계속
+    continue_shopping: 계속 쇼핑
+    cost_currency: 
+    cost_price: 비용
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
+    countries: 
+    country: 국가
+    country_based: 국가 기반
+    country_name: 
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon: "쿠폰"
-    coupon_code: "쿠폰 코드"
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
-    create: "생성"
-    create_a_new_account: "새 계정 생성"
-    create_new_order:
-    create_reimbursement:
-    created_at:
-    credit:
-    credit_card: "신용카드"
-    credit_cards:
-    credit_owed:
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
-    current: "현재"
-    current_promotion_usage:
-    customer: "고객"
-    customer_details: "고객 정보"
-    customer_details_updated:
-    customer_return:
-    customer_returns:
-    customer_search: "고객 검색"
-    cut:
-    cvv_response:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
+    coupon: 쿠폰
+    coupon_code: 쿠폰 코드
+    coupon_code_already_applied: 
+    coupon_code_applied: 
+    coupon_code_better_exists: 
+    coupon_code_expired: 
+    coupon_code_max_usage: 
+    coupon_code_not_eligible: 
+    coupon_code_not_found: 
+    coupon_code_unknown_error: 
+    create: 생성
+    create_a_new_account: 새 계정 생성
+    create_new_order: 
+    create_reimbursement: 
+    created_at: 
+    credit: 
+    credit_card: 신용카드
+    credit_cards: 
+    credit_owed: 
+    credits: 
+    currency: 
+    currency_decimal_mark: 
+    currency_settings: 
+    currency_symbol_position: 
+    currency_thousands_separator: 
+    current: 현재
+    current_promotion_usage: 
+    customer: 고객
+    customer_details: 고객 정보
+    customer_details_updated: 
+    customer_return: 
+    customer_returns: 
+    customer_search: 고객 검색
+    cut: 
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
-    date_completed:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: 
+    date_completed: 
     date_picker:
-      first_day:
-      format:
-      js_format:
-    date_range: "날짜 범위"
-    default: "기본"
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
-    delete: "삭제"
-    deleted_variants_present:
-    delivery:
-    depth: "높이"
-    description: "설명"
-    destination:
-    destroy: "삭제"
-    details:
-    discount_amount: "할인액"
-    dismiss_banner:
-    display: "표시"
-    display_currency:
-    doesnt_track_inventory:
-    edit: "편집"
-    editing_resource:
-    editing_rma_reason:
-    editing_user: "사용자 편집"
+      first_day: 
+      format: 
+      js_format: 
+    date_range: 날짜 범위
+    default: 기본
+    default_refund_amount: 
+    default_tax: 
+    default_tax_zone: 
+    delete: 삭제
+    deleted_variants_present: 
+    delivery: 
+    depth: 높이
+    description: 설명
+    destination: 
+    destroy: 삭제
+    details: 
+    discount_amount: 할인액
+    dismiss_banner: 
+    display: 표시
+    display_currency: 
+    doesnt_track_inventory: 
+    edit: 편집
+    editing_resource: 
+    editing_rma_reason: 
+    editing_user: 사용자 편집
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email: "이메일"
-    empty:
-    empty_cart: "장바구니 비우기"
-    enable_mail_delivery:
-    end:
-    ending_in:
-    environment: "환경"
-    error: "에러"
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
+    email: 이메일
+    empty: 
+    empty_cart: 장바구니 비우기
+    enable_mail_delivery: 
+    end: 
+    ending_in: 
+    environment: 환경
+    error: 에러
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available:
-        no_shipping_methods_available:
+        could_not_create_taxon: 
+        no_payment_methods_available: 
+        no_shipping_methods_available: 
     errors_prohibited_this_record_from_being_saved:
-      one: "저장하는 중에 문제가 발생했습니다."
-      other: "저장하는 중에 문제가 %{count}개 발생했습니다."
-    event: "이벤트"
+      one: 저장하는 중에 문제가 발생했습니다.
+      other: 저장하는 중에 문제가 %{count}개 발생했습니다.
+    event: 이벤트
     events:
       spree:
         cart:
-          add:
+          add: 
         checkout:
-          coupon_code_added:
+          coupon_code_added: 
         content:
-          visited:
+          visited: 
         order:
-          contents_changed:
-        page_view:
+          contents_changed: 
+        page_view: 
         user:
-          signup:
+          signup: 
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
-    expiration: "유효 기간"
-    extension: "확장"
-    failed_payment_attempts:
-    filename: "파일이름"
-    fill_in_customer_info:
-    filter_results:
-    finalize:
-    finalized:
-    find_a_taxon:
-    first_item: "첫 아이템 비용"
-    first_name: "이름"
-    first_name_begins_with: "이름으로 시작"
-    flat_percent:
-    flat_rate_per_order:
-    flexible_rate:
-    forgot_password:
-    free_shipping: "무료 배송"
-    free_shipping_amount:
-    front_end:
-    gateway: "게이트웨이"
-    gateway_config_unavailable:
-    gateway_error: "게이트웨이 에러"
-    general:
-    general_settings: "일반 설정"
-    google_analytics: "구글 애날리스틱"
-    google_analytics_id: "애날리스틱 ID"
-    guest_checkout: "비회원 주문"
-    guest_user_account: "비회원으로 결제"
-    has_no_shipped_units:
-    height: "세로"
-    hide_cents:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
+    expiration: 유효 기간
+    extension: 확장
+    failed_payment_attempts: 
+    filename: 파일이름
+    fill_in_customer_info: 
+    filter_results: 
+    finalize: 
+    finalized: 
+    find_a_taxon: 
+    first_item: 첫 아이템 비용
+    first_name: 이름
+    first_name_begins_with: 이름으로 시작
+    flat_percent: 
+    flat_rate_per_order: 
+    flexible_rate: 
+    forgot_password: 
+    free_shipping: 무료 배송
+    free_shipping_amount: 
+    front_end: 
+    gateway: 게이트웨이
+    gateway_config_unavailable: 
+    gateway_error: 게이트웨이 에러
+    general: 
+    general_settings: 일반 설정
+    google_analytics: 구글 애날리스틱
+    google_analytics_id: 애날리스틱 ID
+    guest_checkout: 비회원 주문
+    guest_user_account: 비회원으로 결제
+    has_no_shipped_units: 
+    height: 세로
+    hide_cents: 
     home: Home
     i18n:
-      available_locales:
-      language:
-      localization_settings:
-      this_file_language: "한국어 (KO)"
-    icon: "아이콘"
-    identifier:
-    image: "이미지"
-    images: "이미지"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password:
-    insufficient_stock:
-    insufficient_stock_lines_present:
-    intercept_email_address:
-    intercept_email_instructions:
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
-    inventory: "인벤토리"
-    inventory_adjustment: "인벤토리 정산"
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
-    is_not_available_to_shipment_address:
-    iso_name:
-    item: "아이템"
-    item_description: "아이템 설명"
-    item_total: "아이템 합계"
+      available_locales: 
+      language: 
+      localization_settings: 
+      this_file_language: 한국어 (KO)
+    icon: 아이콘
+    identifier: 
+    image: 이미지
+    images: 이미지
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: 
+    included_price_validation: 
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
+    instructions_to_reset_password: 
+    insufficient_stock: 
+    insufficient_stock_lines_present: 
+    intercept_email_address: 
+    intercept_email_instructions: 
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 
+    invalid_promotion_action: 
+    invalid_promotion_rule: 
+    inventory: 인벤토리
+    inventory_adjustment: 인벤토리 정산
+    inventory_error_flash_for_insufficient_quantity: 
+    inventory_state: 
+    is_not_available_to_shipment_address: 
+    iso_name: 
+    item: 아이템
+    item_description: 아이템 설명
+    item_total: 아이템 합계
     item_total_rule:
       operators:
-        gt: "보다 큰"
-        gte: "보다 크거나 같은"
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        gt: 보다 큰
+        gte: 보다 크거나 같은
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
+    jirafe: 
     landing_page_rule:
       path: Path
-    last_name: "성"
-    last_name_begins_with: "성으로 시작"
+    last_name: 성
+    last_name_begins_with: 성으로 시작
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
-    list: "목록"
-    loading: "로딩"
-    locale_changed: "지역이 변경됨"
-    location:
-    lock:
-    log_entries:
-    logged_in_as:
-    logged_in_succesfully: "로그인 성공"
-    logged_out: "로그아웃 되었습니다."
-    login: "로그인"
-    login_as_existing:
-    login_failed:
-    login_name: "로그인"
-    logout: "로그아웃"
-    logs:
-    look_for_similar_items: "비슷한 상품들"
-    make_refund:
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
-    master_price: "기본 가격"
+    lifetime_stats: 
+    line_item_adjustments: 
+    list: 목록
+    loading: 로딩
+    locale_changed: 지역이 변경됨
+    location: 
+    lock: 
+    log_entries: 
+    logged_in_as: 
+    logged_in_succesfully: 로그인 성공
+    logged_out: 로그아웃 되었습니다.
+    login: 로그인
+    login_as_existing: 
+    login_failed: 
+    login_name: 로그인
+    logout: 로그아웃
+    logs: 
+    look_for_similar_items: 비슷한 상품들
+    make_refund: 
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
+    master_price: 기본 가격
     match_choices:
-      all:
-      none:
-    max_items: "최대 아이템"
-    member_since:
-    memo:
-    meta_description: "메타 설명"
-    meta_keywords: "메타 키워드"
-    meta_title:
-    metadata: "메타데이터"
-    minimal_amount: "최소량"
-    month:
-    more:
-    move_stock_between_locations:
-    my_account: "내 계정"
-    my_orders: "내 주문"
-    name: "이름"
-    name_on_card:
-    name_or_sku: "이름 또는 SKU"
-    new:
-    new_adjustment: "새 정산"
-    new_country:
-    new_customer: "새 고객"
-    new_customer_return:
-    new_image: "새 이미지"
-    new_option_type: "새 옵션 타입"
-    new_order: "새 주문"
-    new_order_completed:
-    new_payment: "새 결제"
-    new_payment_method: "새 결제 방법"
-    new_product: "새 상품"
-    new_promotion: "새 프로모션"
-    new_promotion_category:
-    new_property: "새 속성"
-    new_prototype: "새 견본"
-    new_refund:
-    new_refund_reason:
-    new_return_authorization:
-    new_rma_reason:
-    new_shipment_at_location:
-    new_shipping_category:
-    new_shipping_method:
-    new_state:
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
-    new_tax_category: "새 세금 분류"
-    new_tax_rate: "새로운 세율"
-    new_taxon: "새 분류군"
-    new_taxonomy: "새 분류계"
-    new_tracker: "새 트랙커"
-    new_user: "새 사용자"
-    new_variant: "새 품종"
-    new_zone: "새 지역"
-    next: "다음"
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
-    no_products_found: "찾는 상품이 없음"
-    no_resource_found:
-    no_results: "결과가 없음"
-    no_returns_found:
-    no_rules_added: "추가 된 규칙이 없음"
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
-    none: "없음"
-    none_selected:
-    normal_amount:
-    not:
-    not_available:
-    not_enough_stock:
-    not_found:
-    note:
+      all: 
+      none: 
+    max_items: 최대 아이템
+    member_since: 
+    memo: 
+    meta_description: 메타 설명
+    meta_keywords: 메타 키워드
+    meta_title: 
+    metadata: 메타데이터
+    minimal_amount: 최소량
+    month: 
+    more: 
+    move_stock_between_locations: 
+    my_account: 내 계정
+    my_orders: 내 주문
+    name: 이름
+    name_on_card: 
+    name_or_sku: 이름 또는 SKU
+    new: 
+    new_adjustment: 새 정산
+    new_country: 
+    new_customer: 새 고객
+    new_customer_return: 
+    new_image: 새 이미지
+    new_option_type: 새 옵션 타입
+    new_order: 새 주문
+    new_order_completed: 
+    new_payment: 새 결제
+    new_payment_method: 새 결제 방법
+    new_product: 새 상품
+    new_promotion: 새 프로모션
+    new_promotion_category: 
+    new_property: 새 속성
+    new_prototype: 새 견본
+    new_refund: 
+    new_refund_reason: 
+    new_return_authorization: 
+    new_rma_reason: 
+    new_shipment_at_location: 
+    new_shipping_category: 
+    new_shipping_method: 
+    new_state: 
+    new_stock_location: 
+    new_stock_movement: 
+    new_stock_transfer: 
+    new_tax_category: 새 세금 분류
+    new_tax_rate: 새로운 세율
+    new_taxon: 새 분류군
+    new_taxonomy: 새 분류계
+    new_tracker: 새 트랙커
+    new_user: 새 사용자
+    new_variant: 새 품종
+    new_zone: 새 지역
+    next: 다음
+    no_actions_added: 
+    no_payment_found: 
+    no_pending_payments: 
+    no_products_found: 찾는 상품이 없음
+    no_resource_found: 
+    no_results: 결과가 없음
+    no_returns_found: 
+    no_rules_added: 추가 된 규칙이 없음
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
+    none: 없음
+    none_selected: 
+    normal_amount: 
+    not: 
+    not_available: 
+    not_enough_stock: 
+    not_found: 
+    note: 
     notice_messages:
-      product_cloned:
-      product_deleted:
-      product_not_cloned:
-      product_not_deleted:
-      variant_deleted: "품종이 삭제됐습니다"
-      variant_not_deleted: "품종을 삭제할 수 없습니다"
-    num_orders:
-    on_hand: "재고"
-    open:
-    open_all_adjustments:
-    option_type: "옵션 타입"
-    option_type_placeholder:
-    option_types: "옵션 타입"
-    option_value: "옵션 값"
-    option_values: "옵션 값"
-    optional:
-    options: "옵션"
-    or: "또는"
-    or_over_price:
-    order: "주문"
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
-    order_details: "주문 상세"
-    order_email_resent: "주문 확인 메일 재발송"
-    order_information:
+      product_cloned: 
+      product_deleted: 
+      product_not_cloned: 
+      product_not_deleted: 
+      variant_deleted: 품종이 삭제됐습니다
+      variant_not_deleted: 품종을 삭제할 수 없습니다
+    num_orders: 
+    on_hand: 재고
+    open: 
+    open_all_adjustments: 
+    option_type: 옵션 타입
+    option_type_placeholder: 
+    option_types: 옵션 타입
+    option_value: 옵션 값
+    option_values: 옵션 값
+    optional: 
+    options: 옵션
+    or: 또는
+    or_over_price: 
+    order: 주문
+    order_adjustments: 
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
+    order_details: 주문 상세
+    order_email_resent: 주문 확인 메일 재발송
+    order_information: 
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject: "주문 취소"
-        subtotal:
-        total:
+        dear_customer: 
+        instructions: 
+        order_summary_canceled: 
+        subject: 주문 취소
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject: "주문 확인"
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: 
+        instructions: 
+        order_summary: 
+        subject: 주문 확인
+        subtotal: 
+        thanks: 
+        total: 
+    order_not_found: 
+    order_number: 
     order_populator:
-      out_of_stock:
-      please_enter_reasonable_quantity:
-      selected_quantity_not_available:
-    order_processed_successfully:
-    order_resumed:
+      out_of_stock: 
+      please_enter_reasonable_quantity: 
+      selected_quantity_not_available: 
+    order_processed_successfully: 
+    order_resumed: 
     order_state:
-      address: "주소"
-      awaiting_return:
-      canceled: "취소됨"
-      cart: "장바구니"
-      complete: "완료"
-      confirm: "확인"
-      considered_risky:
-      delivery:
-      payment: "지불"
-      resumed:
-      returned:
-    order_summary: "주문 요약"
-    order_sure_want_to:
-    order_total: "주문 합계"
-    order_updated: "주문이 수정됨"
-    orders: "주문"
-    other_items_in_other:
-    out_of_stock: "품절"
+      address: 주소
+      awaiting_return: 
+      canceled: 취소됨
+      cart: 장바구니
+      complete: 완료
+      confirm: 확인
+      considered_risky: 
+      delivery: 
+      payment: 지불
+      resumed: 
+      returned: 
+    order_summary: 주문 요약
+    order_sure_want_to: 
+    order_total: 주문 합계
+    order_updated: 주문이 수정됨
+    orders: 주문
+    other_items_in_other: 
+    out_of_stock: 품절
     overview: Overiew
-    package_from:
+    package_from: 
     pagination:
-      next_page:
-      previous_page:
+      next_page: 
+      previous_page: 
       truncate: "…"
-    password: "비밀번호"
-    paste:
-    path: "경로"
-    pay:
-    payment: "지불"
-    payment_could_not_be_created:
-    payment_identifier:
-    payment_information: "지불 정보"
-    payment_method: "결제 방법"
-    payment_method_not_supported:
-    payment_methods: "결제 방법"
-    payment_processing_failed: "결제 중에 문제가 발생했습니다. 잠시 후에 다시 해보시기 바랍니다."
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
-    payment_state: "지불 상태"
+    password: 비밀번호
+    paste: 
+    path: 경로
+    pay: 
+    payment: 지불
+    payment_could_not_be_created: 
+    payment_identifier: 
+    payment_information: 지불 정보
+    payment_method: 결제 방법
+    payment_method_not_supported: 
+    payment_methods: 결제 방법
+    payment_processing_failed: 결제 중에 문제가 발생했습니다. 잠시 후에 다시 해보시기 바랍니다.
+    payment_processor_choose_banner_text: 
+    payment_processor_choose_link: 
+    payment_state: 지불 상태
     payment_states:
-      balance_due: "부족"
-      checkout:
-      completed: "완료"
-      credit_owed:
-      failed:
-      paid: "지불"
-      pending: "보류"
-      processing:
-      void:
-    payment_updated:
-    payments: "지불"
-    pending:
-    percent:
-    percent_per_item:
-    permalink: "퍼마링크"
-    phone: "전화번호"
-    place_order:
-    please_define_payment_methods:
-    populate_get_error:
-    powered_by:
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
-    presentation: "표시"
-    previous: "이전"
-    previous_state_missing:
-    price: "가격"
-    price_range:
-    price_sack:
-    process: "과정"
-    product: "상품"
-    product_details: "상품 상세"
-    product_has_no_description:
-    product_not_available_in_this_currency:
-    product_properties: "상품 속성"
+      balance_due: 부족
+      checkout: 
+      completed: 완료
+      credit_owed: 
+      failed: 
+      paid: 지불
+      pending: 보류
+      processing: 
+      void: 
+    payment_updated: 
+    payments: 지불
+    pending: 
+    percent: 
+    percent_per_item: 
+    permalink: 퍼마링크
+    phone: 전화번호
+    place_order: 
+    please_define_payment_methods: 
+    populate_get_error: 
+    powered_by: 
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
+    presentation: 표시
+    previous: 이전
+    previous_state_missing: 
+    price: 가격
+    price_range: 
+    price_sack: 
+    process: 과정
+    product: 상품
+    product_details: 상품 상세
+    product_has_no_description: 
+    product_not_available_in_this_currency: 
+    product_properties: 상품 속성
     product_rule:
-      choose_products: "상품 선택"
-      label:
-      match_all: "모두"
-      match_any: "최소 하나"
-      match_none:
+      choose_products: 상품 선택
+      label: 
+      match_all: 모두
+      match_any: 최소 하나
+      match_none: 
       product_source:
-        group: "상품군에서"
-        manual:
-    products: "상품"
-    promotion:
-    promotion_action:
+        group: 상품군에서
+        manual: 
+    products: 상품
+    promotion: 
+    promotion_action: 
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: 
+        name: 
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: 
+        name: 
+    promotion_actions: 
     promotion_form:
       match_policies:
-        all: "이 규칙에 모두 일치"
-        any: "이 규칙에 하나라도 일치"
+        all: 이 규칙에 모두 일치
+        any: 이 규칙에 하나라도 일치
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
-        description:
-        name: "첫 주문"
+        description: 
+        name: 첫 주문
       item_total:
-        description:
-        name:
+        description: 
+        name: 
       landing_page:
-        description:
-        name:
+        description: 
+        name: 
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description:
-        name:
+        description: 
+        name: 
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
-        description:
-        name:
+        description: 
+        name: 
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
-    promotions:
-    propagate_all_variants:
-    properties: "속성"
-    property: "속성"
-    prototype: "견본"
-    prototypes: "견본"
-    provider: "제공자"
-    provider_settings_warning:
-    qty: "수량"
-    quantity:
-    quantity_returned:
-    quantity_shipped:
-    quick_search:
-    rate:
-    reason: "이유"
-    receive:
-    receive_stock:
-    received:
-    reception_status:
-    reference:
-    refund:
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
-    register:
-    registration: "등록"
-    reimburse:
-    reimbursed:
-    reimbursement:
+        description: 
+        name: 
+    promotion_uses: 
+    promotionable: 
+    promotions: 
+    propagate_all_variants: 
+    properties: 속성
+    property: 속성
+    prototype: 견본
+    prototypes: 견본
+    provider: 제공자
+    provider_settings_warning: 
+    qty: 수량
+    quantity: 
+    quantity_returned: 
+    quantity_shipped: 
+    quick_search: 
+    rate: 
+    reason: 이유
+    receive: 
+    receive_stock: 
+    received: 
+    reception_status: 
+    reference: 
+    refund: 
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
+    register: 
+    registration: 등록
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
-    remember_me: "이메일 저장"
-    remove: "삭제"
-    rename:
-    report:
-    reports: "리포트"
-    resend: "재발송"
-    reset_password: "비밀번호 재설정"
-    response_code: "응답 코드"
-    resume:
-    resumed:
-    return:
-    return_authorization:
-    return_authorization_reasons:
-    return_authorization_updated:
-    return_authorizations:
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity:
-    returned:
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit:
-    rma_number: "RMA 번호"
-    rma_value: "RMA 값"
-    roles:
-    rules: "규칙"
-    safe:
-    sales_total:
-    sales_total_description:
-    sales_totals:
-    save_and_continue: "저장하고 계속"
-    save_my_address:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
+    remember_me: 이메일 저장
+    remove: 삭제
+    rename: 
+    report: 
+    reports: 리포트
+    resend: 재발송
+    reset_password: 비밀번호 재설정
+    response_code: 응답 코드
+    resume: 
+    resumed: 
+    return: 
+    return_authorization: 
+    return_authorization_reasons: 
+    return_authorization_updated: 
+    return_authorizations: 
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
+    return_quantity: 
+    returned: 
+    returns: 
+    review: 
+    risk: 
+    risk_analysis: 
+    risky: 
+    rma_credit: 
+    rma_number: RMA 번호
+    rma_value: RMA 값
+    roles: 
+    rules: 규칙
+    safe: 
+    sales_total: 
+    sales_total_description: 
+    sales_totals: 
+    save_and_continue: 저장하고 계속
+    save_my_address: 
     say_no: false
     say_yes: true
-    scope: "범위"
-    search: "검색"
+    scope: 범위
+    search: 검색
     search_results: "%{keywords}의 검색 결과"
-    searching: "검색중"
-    secure_connection_type:
-    security_settings:
-    select: "선택"
-    select_a_return_authorization_reason:
-    select_a_stock_location:
-    select_from_prototype: "견본에서 선택"
-    select_stock:
-    send_copy_of_all_mails_to: "모든 메일 사본을 다음 주소로 보냄"
-    send_mails_as:
-    server: "서버"
-    server_error:
-    settings: "설정"
-    ship:
-    ship_address: "배송 주소"
-    ship_total:
-    shipment: "배송"
-    shipment_adjustments:
-    shipment_details:
+    searching: 검색중
+    secure_connection_type: 
+    security_settings: 
+    select: 선택
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
+    select_from_prototype: 견본에서 선택
+    select_stock: 
+    send_copy_of_all_mails_to: 모든 메일 사본을 다음 주소로 보냄
+    send_mails_as: 
+    server: 서버
+    server_error: 
+    settings: 설정
+    ship: 
+    ship_address: 배송 주소
+    ship_total: 
+    shipment: 배송
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
-    shipment_state: "배송 상태"
+        dear_customer: 
+        instructions: 
+        shipment_summary: 
+        subject: 
+        thanks: 
+        track_information: 
+        track_link: 
+    shipment_state: 배송 상태
     shipment_states:
-      backorder:
-      canceled:
-      partial:
-      pending: "보류"
-      ready: "대기"
-      shipped:
-    shipment_transfer_error:
-    shipment_transfer_success:
-    shipments: "배송"
-    shipped: "배송됨"
-    shipping: "배송료"
-    shipping_address: "배송 주소"
-    shipping_categories: "배송 분류"
-    shipping_category: "배송 분류"
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
-    shipping_instructions:
-    shipping_method:
-    shipping_methods:
-    shipping_price_sack:
-    shipping_total:
-    shop_by_taxonomy:
-    shopping_cart: "장바구니"
-    show: "보기"
-    show_active:
-    show_deleted: "삭제 된 상품까지 보기"
-    show_only_complete_orders: "완료 된 주문만 보기"
-    show_only_considered_risky:
-    show_rate_in_label:
-    sku:
-    skus:
-    slug:
-    source:
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+      backorder: 
+      canceled: 
+      partial: 
+      pending: 보류
+      ready: 대기
+      shipped: 
+    shipment_transfer_error: 
+    shipment_transfer_success: 
+    shipments: 배송
+    shipped: 배송됨
+    shipping: 배송료
+    shipping_address: 배송 주소
+    shipping_categories: 배송 분류
+    shipping_category: 배송 분류
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
+    shipping_instructions: 
+    shipping_method: 
+    shipping_methods: 
+    shipping_price_sack: 
+    shipping_total: 
+    shop_by_taxonomy: 
+    shopping_cart: 장바구니
+    show: 보기
+    show_active: 
+    show_deleted: 삭제 된 상품까지 보기
+    show_only_complete_orders: 완료 된 주문만 보기
+    show_only_considered_risky: 
+    show_rate_in_label: 
+    sku: 
+    skus: 
+    slug: 
+    source: 
+    special_instructions: 
+    split: 
+    spree_gateway_error_flash_for_checkout: 
     ssl:
-      change_protocol:
-    start: "시작"
-    state:
-    state_based:
+      change_protocol: 
+    start: 시작
+    state: 
+    state_based: 
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states:
-    states_required:
-    status: "상태"
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
-    stop: "끝"
-    store: "상점"
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
+    states: 
+    states_required: 
+    status: 상태
+    stock: 
+    stock_location: 
+    stock_location_info: 
+    stock_locations: 
+    stock_locations_need_a_default_country: 
+    stock_management: 
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
+    stock_transfer: 
+    stock_transfers: 
+    stop: 끝
+    store: 상점
     street_address: Street 주소
     street_address_2: Street 주소 (cont'd)
-    subtotal:
-    subtract:
-    success:
-    successfully_created:
-    successfully_refunded:
-    successfully_removed:
-    successfully_signed_up_for_analytics:
-    successfully_updated:
-    summary:
-    tax: "세금"
-    tax_categories: "세금 분류"
-    tax_category: "세금 분류"
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
-    tax_rates: "세율"
-    taxon: "분류군"
-    taxon_edit: "분류군 편집"
-    taxon_placeholder:
+    subtotal: 
+    subtract: 
+    success: 
+    successfully_created: 
+    successfully_refunded: 
+    successfully_removed: 
+    successfully_signed_up_for_analytics: 
+    successfully_updated: 
+    summary: 
+    tax: 세금
+    tax_categories: 세금 분류
+    tax_category: 세금 분류
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
+    tax_rates: 세율
+    taxon: 분류군
+    taxon_edit: 분류군 편집
+    taxon_placeholder: 
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
-    taxonomies: "분류계"
-    taxonomy: "분류군"
-    taxonomy_edit:
-    taxonomy_tree_error:
-    taxonomy_tree_instruction:
-    taxons: "종류"
-    test: "테스트"
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
+    taxonomies: 분류계
+    taxonomy: 분류군
+    taxonomy_edit: 
+    taxonomy_tree_error: 
+    taxonomy_tree_instruction: 
+    taxons: 종류
+    test: 테스트
     test_mailer:
       test_email:
-        greeting:
-        message:
-        subject:
-    test_mode: "테스트 모드"
-    thank_you_for_your_order:
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields: "다음 값들에 문제가 있습니다"
-    this_order_has_already_received_a_refund:
-    thumbnail: "미리보기"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
-    to_add_variants_you_must_first_define: "품종을 추가하려면 먼저 정의해야 합니다"
-    total: "합계"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
-    tracking:
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
-    tree:
-    type:
-    type_to_search:
-    unable_to_connect_to_gateway:
-    unable_to_create_reimbursements:
-    under_price:
-    unlock:
-    unrecognized_card_type:
-    unshippable_items:
-    update: "수정"
-    updating:
-    usage_limit:
-    use_app_default:
-    use_billing_address: "배송받으실 분이 주문자와 동일합니다."
-    use_new_cc:
-    use_s3:
-    user: "사용자"
+        greeting: 
+        message: 
+        subject: 
+    test_mode: 테스트 모드
+    thank_you_for_your_order: 
+    there_are_no_items_for_this_order: 
+    there_were_problems_with_the_following_fields: 다음 값들에 문제가 있습니다
+    this_order_has_already_received_a_refund: 
+    thumbnail: 미리보기
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: 
+    to_add_variants_you_must_first_define: 품종을 추가하려면 먼저 정의해야 합니다
+    total: 합계
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
+    tracking: 
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
+    tree: 
+    type: 
+    type_to_search: 
+    unable_to_connect_to_gateway: 
+    unable_to_create_reimbursements: 
+    under_price: 
+    unlock: 
+    unrecognized_card_type: 
+    unshippable_items: 
+    update: 수정
+    updating: 
+    usage_limit: 
+    use_app_default: 
+    use_billing_address: 배송받으실 분이 주문자와 동일합니다.
+    use_new_cc: 
+    use_s3: 
+    user: 사용자
     user_rule:
-      choose_users:
-    users: "사용자"
+      choose_users: 
+    users: 사용자
     validation:
-      cannot_be_less_than_shipped_units:
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
-      is_too_large:
-      must_be_int:
-      must_be_non_negative:
-      unpaid_amount_not_zero:
-    value: "값"
-    variant:
-    variant_placeholder:
-    variants: "품종"
-    version: "버전"
-    void:
-    weight: "무게"
-    what_is_a_cvv: "신용카드 코드(CVV)란?"
-    what_is_this:
-    width: "가로"
-    year: "년"
-    you_have_no_orders_yet:
-    your_cart_is_empty: "장바구니가 비었습니다"
-    your_order_is_empty_add_product:
-    zip: "우편번호"
-    zipcode: "우편번호"
-    zone: "지역"
-    zones: "지역"
+      cannot_be_less_than_shipped_units: 
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 
+      is_too_large: 
+      must_be_int: 
+      must_be_non_negative: 
+      unpaid_amount_not_zero: 
+    value: 값
+    variant: 
+    variant_placeholder: 
+    variants: 품종
+    version: 버전
+    void: 
+    weight: 무게
+    what_is_a_cvv: 신용카드 코드(CVV)란?
+    what_is_this: 
+    width: 가로
+    year: 년
+    you_have_no_orders_yet: 
+    your_cart_is_empty: 장바구니가 비었습니다
+    your_order_is_empty_add_product: 
+    zip: 우편번호
+    zipcode: 우편번호
+    zone: 지역
+    zones: 지역

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1,3 +1,4 @@
+---
 lv:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ lv:
         state: Rajons
         zipcode: Pasta indekss
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,12 +25,12 @@ lv:
         name: Nosaukums
         numcode: ISO kods
       spree/credit_card:
-        base:
+        base: 
         cc_type: Tips
         month: Mēnesis
-        name:
+        name: 
         number: Numurs
-        verification_value:
+        verification_value: 
         year: Gads
       spree/inventory_unit:
         state: Apgabals
@@ -40,43 +41,43 @@ lv:
         name: Nosaukums
         presentation: Presentation
       spree/order:
-        checkout_complete:
-        completed_at:
-        considered_risky:
+        checkout_complete: 
+        completed_at: 
+        considered_risky: 
         coupon_code: Kupona Kods
-        created_at:
-        email:
-        ip_address:
-        item_total:
-        number:
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
-        total:
+        created_at: 
+        email: 
+        ip_address: 
+        item_total: 
+        number: 
+        payment_state: 
+        shipment_state: 
+        special_instructions: 
+        state: 
+        total: 
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/payment:
-        amount:
+        amount: 
       spree/payment_method:
-        name:
+        name: 
       spree/product:
         available_on: Pieejams pēc
-        cost_currency:
+        cost_currency: 
         cost_price: Pašizmaksa
         description: Apraksts
         master_price: Gala cena/Master Price
@@ -85,17 +86,17 @@ lv:
         shipping_category: Piegādes kategorija
         tax_category: Nodokļu kategorija
       spree/promotion:
-        advertise:
-        code:
-        description:
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        advertise: 
+        code: 
+        description: 
+        event_name: 
+        expires_at: 
+        name: 
+        path: 
+        starts_at: 
+        usage_limit: 
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Nosaukums
         presentation: Prezentācija
@@ -109,20 +110,20 @@ lv:
         abbr: Saīsinājums
         name: Nosaukums
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Apraksts
         name: Nosaukums
@@ -141,7 +142,7 @@ lv:
         password: Parole
         password_confirmation: Password Confirmation
       spree/variant:
-        cost_currency:
+        cost_currency: 
         cost_price: Pašizmaksa
         depth: Biezums
         height: Augstums
@@ -157,47 +158,47 @@ lv:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Adrese
@@ -208,40 +209,40 @@ lv:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Krājuma vienība
         other: Krājuma vienības
       spree/line_item:
         one: Pozīcijas vienība
         other: Pozīcijas vienības
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Pasūtījums
         other: Pasūtījumi
       spree/payment:
         one: Maksājums
         other: Maksājumi
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Produkts
         other: Produkti
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
         one: Property
         other: Properties
       spree/prototype:
         one: Prototips
         other: Prototipi
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Atgriešanas autorizācija
         other: Atgriešanas autorizācijas
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Loma
         other: Lomas
@@ -251,197 +252,197 @@ lv:
       spree/shipping_category:
         one: Piegādes kategorija
         other: Piegādes kategorijas
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
-        one: "Štats"
-        other: "Štati"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+        one: Štats
+        other: Štati
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Nodokļu kategorija
         other: Nodokļu kategorijas
       spree/tax_rate:
         one: Nodokļu likme
         other: Nodokļu likmes
-      spree/taxon:
-      spree/taxonomy:
-      spree/tracker:
+      spree/taxon: 
+      spree/taxonomy: 
+      spree/tracker: 
       spree/user:
         one: Lietotājs
         other: Lietotāji
-      spree/variant:
+      spree/variant: 
       spree/zone:
         one: Zona
         other: Zonas
   spree:
     abbreviation: Saīsinājums
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Konts
     account_updated: Konts izmainīts!
     action: Darbība
     actions:
       cancel: Atcelt
-      continue:
+      continue: 
       create: Izveidot
       destroy: Dzēst
-      edit:
+      edit: 
       list: Saraksts
       listing: Saraksts
       new: Jauns
-      refund:
-      save:
+      refund: 
+      save: 
       update: Atjauninājums
     activate: Activate
     active: Aktīvs
     add: Pievienot
     add_action_of_type: Add action of type
     add_country: Pievienot valsti
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: 
     add_option_value: Pievienot opcijas vērtību
     add_product: Pievienot produktu
     add_product_properties: Pievienot produkta īpašības
     add_rule_of_type: Add rule of type
     add_state: Pievienot rajonu
-    add_stock:
-    add_stock_management:
+    add_stock: 
+    add_stock_management: 
     add_to_cart: Pievienot grozam
-    add_variant:
+    add_variant: 
     additional_item: Papildus vienības maksa
-    address1:
-    address2:
-    adjustable:
+    address1: 
+    address2: 
+    adjustable: 
     adjustment: Piemērošana
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: 
+    adjustment_successfully_closed: 
+    adjustment_successfully_opened: 
     adjustment_total: Adjustment Total
     adjustments: Piemērošanas
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administrēšana
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: 
+    agree_to_privacy_policy: 
+    agree_to_terms_of_service: 
     all: Visi
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: 
+    all_adjustments_opened: 
     all_departments: Visas nodaļas
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
+    all_items_have_been_returned: 
+    allow_ssl_in_development_and_test: 
+    allow_ssl_in_production: 
+    allow_ssl_in_staging: 
+    already_signed_up_for_analytics: 
     alt_text: Cits teksts
     alternative_phone: Cits telefons
     amount: Summa
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
-    analytics_trackers:
-    and:
-    approve:
-    approved_at:
-    approver:
+    analytics_desc_header_1: 
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
+    analytics_trackers: 
+    and: 
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Vai esiet pārliecināts?
     are_you_sure_delete: Vai esiet pārliecināts, ka vēlaties dzēst šo ierakstu?
-    associated_adjustment_closed:
-    at_symbol: '@'
+    associated_adjustment_closed: 
+    at_symbol: "@"
     authorization_failure: Autorizācija neizdevās
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Pieejams no
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Atpakaļ
-    back_end:
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_end: 
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Atgriezties veikalā
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_users_list: 
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Atlikums
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Rēķina adrese
     billing: Rēķins
     billing_address: Rēķina adrese
     both: Abi
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Kalkulātors
     calculator_settings_warning: Ja tu maini kalkulatora tipu, vispirms saglabā esošos datus, pirms maini kalkulatora iestatījumus
     cancel: Atcelt
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: 
     cannot_create_returns: Nevar izveidot atgriešanu, jo šis pasūtījums vēl nav izsūtīts.
-    cannot_perform_operation:
-    cannot_set_shipping_method_without_address:
+    cannot_perform_operation: 
+    cannot_set_shipping_method_without_address: 
     capture: Capture
-    capture_events:
+    capture_events: 
     card_code: Kartes kods
     card_number: Kartes numurs
-    card_type:
+    card_type: 
     card_type_is: Kartes tips ir
     cart: Grozs
-    cart_subtotal:
+    cart_subtotal: 
     categories: Kategorijas
     category: Kategorija
-    charged:
-    check_for_spree_alerts:
+    charged: 
+    check_for_spree_alerts: 
     checkout: Pasūtīt
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: 
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 
+    choose_dashboard_locale: 
+    choose_location: 
     city: Pilsēta
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Klonēt
-    close:
-    close_all_adjustments:
+    close: 
+    close_all_adjustments: 
     code: Kods
-    company:
+    company: 
     complete: Pabeigts
     configuration: Konfigurācija
     configurations: Konfigurācijas
@@ -450,122 +451,122 @@ lv:
     confirm_password: Paroles apstiprinājums
     continue: Turpināt
     continue_shopping: Turpināt iepirkšanos
-    cost_currency:
+    cost_currency: 
     cost_price: Pašizmaksa
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
+    countries: 
     country: Valsts
     country_based: Valsts
-    country_name:
+    country_name: 
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Kupons
     coupon_code: Kupona kods
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
+    coupon_code_already_applied: 
+    coupon_code_applied: 
+    coupon_code_better_exists: 
+    coupon_code_expired: 
+    coupon_code_max_usage: 
+    coupon_code_not_eligible: 
     coupon_code_not_found: Ievadītais kupona kods neeksistē. Lūdzu, mēģiniet vēlreiz.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Izveidot
     create_a_new_account: Izveidot jaunu kontu
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: 
+    create_reimbursement: 
+    created_at: 
     credit: Kredīts
     credit_card: Kredītkarte
-    credit_cards:
+    credit_cards: 
     credit_owed: Kredīta parāds
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
+    credits: 
+    currency: 
+    currency_decimal_mark: 
+    currency_settings: 
     currency_symbol_position: Put currency symbol before or after dollar amount?
-    currency_thousands_separator:
+    currency_thousands_separator: 
     current: Tagadējais
-    current_promotion_usage:
+    current_promotion_usage: 
     customer: Klients
     customer_details: Klienta detaļas
-    customer_details_updated:
-    customer_return:
-    customer_returns:
+    customer_details_updated: 
+    customer_return: 
+    customer_returns: 
     customer_search: Klienta meklēšana
-    cut:
-    cvv_response:
+    cut: 
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
-    date_completed:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: 
+    date_completed: 
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 
+      format: 
+      js_format: 
     date_range: Datuma diapazons
-    default:
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default: 
+    default_refund_amount: 
+    default_tax: 
+    default_tax_zone: 
     delete: Izdzēst
-    deleted_variants_present:
-    delivery:
+    deleted_variants_present: 
+    delivery: 
     depth: Dziļums
     description: Apraksts
-    destination:
+    destination: 
     destroy: Izdzēst
-    details:
-    discount_amount:
-    dismiss_banner:
+    details: 
+    discount_amount: 
+    dismiss_banner: 
     display: Rādīt
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: 
+    doesnt_track_inventory: 
     edit: Rediģēt
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Rediģēt lietotāju
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: E-pasts
-    empty:
+    empty: 
     empty_cart: Iztukšot grozu
     enable_mail_delivery: Atļaut pasta sūtīšanu
-    end:
-    ending_in:
+    end: 
+    ending_in: 
     environment: Vide
     error: Kļūda
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available:
-        no_shipping_methods_available:
+        could_not_create_taxon: 
+        no_payment_methods_available: 
+        no_shipping_methods_available: 
     errors_prohibited_this_record_from_being_saved:
       one: Dēļ 1 kļūdas ieraksts netika saglabāts
       other: Dēļ %{count} kļūdām ieraksts netika saglabāts
@@ -573,31 +574,31 @@ lv:
     events:
       spree:
         cart:
-          add:
+          add: 
         checkout:
-          coupon_code_added:
+          coupon_code_added: 
         content:
-          visited:
+          visited: 
         order:
-          contents_changed:
-        page_view:
+          contents_changed: 
+        page_view: 
         user:
-          signup:
+          signup: 
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Izbeigšanās
     extension: Paplašinājums
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Faila nosaukums
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: 
+    filter_results: 
     finalize: Pabeigt
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: Pirmās vienības maksājums
     first_name: Vārds
     first_name_begins_with: Vārds sākas ar
@@ -605,8 +606,8 @@ lv:
     flat_rate_per_order: Pamatlikme (par pasūtījumu)
     flexible_rate: Elastīga likme
     forgot_password: Parole aizmirsta
-    free_shipping:
-    free_shipping_amount:
+    free_shipping: 
+    free_shipping_amount: 
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -619,110 +620,110 @@ lv:
     guest_user_account: Izrakstīties kā ciemiņam
     has_no_shipped_units: Nav nosūtītu vienību
     height: Augstums
-    hide_cents:
+    hide_cents: 
     home: Mājas
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: Latvijas (LV)
     icon: Icon
-    identifier:
+    identifier: 
     image: Attēls
     images: Attēli
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: 
+    included_price_validation: 
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Aizpildiet formu zemāk un uz e-pastu tiks nosūtīta instrukcija kā atjaunot paroli:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
-    intercept_email_address:
-    intercept_email_instructions:
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    insufficient_stock_lines_present: 
+    intercept_email_address: 
+    intercept_email_instructions: 
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 
+    invalid_promotion_action: 
+    invalid_promotion_rule: 
     inventory: Inventūra
     inventory_adjustment: Inventūras korekcija
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: 
+    inventory_state: 
     is_not_available_to_shipment_address: nav pieejams sūtīšanas adresei
-    iso_name:
+    iso_name: 
     item: Vienība
     item_description: Vienības apraksts
     item_total: Kopējā vienība
     item_total_rule:
       operators:
-        gt:
-        gte:
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        gt: 
+        gte: 
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
+    jirafe: 
     landing_page_rule:
-      path:
+      path: 
     last_name: Uzvārds
     last_name_begins_with: Uzvārds sākas ar
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Saraksts
     loading: Lādējās
     locale_changed: Valoda nomainīta
-    location:
-    lock:
-    log_entries:
+    location: 
+    lock: 
+    log_entries: 
     logged_in_as: Pieslēgties kā
     logged_in_succesfully: Pieslēgšanās veiksmīga
     logged_out: Jūs esat atslēgts no sistēmas.
-    login:
+    login: 
     login_as_existing: Pieslēgties kā esošais klients
     login_failed: Pieslēgšanās sistēmai neizdevās.
     login_name: Pieslēgties
     logout: Atslēgties
-    logs:
+    logs: 
     look_for_similar_items: Meklēt līdzīgas preces
-    make_refund:
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
-    master_price:
+    make_refund: 
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
+    master_price: 
     match_choices:
-      all:
-      none:
-    max_items:
-    member_since:
-    memo:
+      all: 
+      none: 
+    max_items: 
+    member_since: 
+    memo: 
     meta_description: Meta apraksts
     meta_keywords: Meta atslēgas vārdi
-    meta_title:
-    metadata:
-    minimal_amount:
+    meta_title: 
+    metadata: 
+    minimal_amount: 
     month: Mēnesis
-    more:
-    move_stock_between_locations:
+    more: 
+    move_stock_between_locations: 
     my_account: Mans konts
     my_orders: Mani pasūtījumi
     name: Nosaukums
-    name_on_card:
+    name_on_card: 
     name_or_sku: Vārds vai SKU
     new: Jauns
     new_adjustment: Jauns pielāgojums
-    new_country:
+    new_country: 
     new_customer: Jauns klients
-    new_customer_return:
+    new_customer_return: 
     new_image: Jauns attēls
     new_option_type: Jauns opciju tips
     new_order: Jauns pasūtījums
@@ -730,21 +731,21 @@ lv:
     new_payment: Jauns maksājums
     new_payment_method: Jauna maksājuma metode
     new_product: Jauns produkts
-    new_promotion:
-    new_promotion_category:
-    new_property:
+    new_promotion: 
+    new_promotion_category: 
+    new_property: 
     new_prototype: Jauns prototips
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: New Return Authorization
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Jauna sūtījuma kategorija
     new_shipping_method: Jauna sūtījuma metode
     new_state: Jauns rajons
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: 
+    new_stock_movement: 
+    new_stock_transfer: 
     new_tax_category: Jauna nodokļu kategorija
     new_tax_rate: Jauna nodokļu likme
     new_taxon: New Taxon
@@ -754,25 +755,25 @@ lv:
     new_variant: Jauns variants
     new_zone: Jauna zona
     next: Nākamais
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: 
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: Neviens produkts netika atrasts
-    no_resource_found:
-    no_results:
-    no_returns_found:
-    no_rules_added:
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_resource_found: 
+    no_results: 
+    no_returns_found: 
+    no_rules_added: 
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
     none: Nekas
-    none_selected:
-    normal_amount:
-    not:
+    none_selected: 
+    normal_amount: 
+    not: 
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: 
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
       product_cloned: Produkts ir klonēts
       product_deleted: Produkts ir izdzēsts
@@ -780,187 +781,187 @@ lv:
       product_not_deleted: Produktu neizdevās izdzēst
       variant_deleted: Variants ir izdzēsts
       variant_not_deleted: Variants nav izdzēsts
-    num_orders:
+    num_orders: 
     on_hand: Ir uz vietas
-    open:
-    open_all_adjustments:
+    open: 
+    open_all_adjustments: 
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Opciju tips
     option_value: Option Value
     option_values: Opciju vērtība
-    optional:
+    optional: 
     options: Iespējas
     or: vai
     or_over_price: "%{price} or over"
     order: Pasūtījums
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Pasūtījuma detaļas
     order_email_resent: Pasūtījuma e-pasts vēlreiz pārsūtīts
-    order_information:
+    order_information: 
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: 
+        instructions: 
+        order_summary_canceled: 
+        subject: 
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: 
+        instructions: 
+        order_summary: 
+        subject: 
+        subtotal: 
+        thanks: 
+        total: 
+    order_not_found: 
+    order_number: 
     order_processed_successfully: Jūsu pasūtījums ir apstrādāts veiksmīgi
-    order_resumed:
+    order_resumed: 
     order_state:
-      address:
-      awaiting_return:
-      canceled:
-      cart:
-      complete:
-      confirm:
-      considered_risky:
-      delivery:
-      payment:
-      resumed:
-      returned:
+      address: 
+      awaiting_return: 
+      canceled: 
+      cart: 
+      complete: 
+      confirm: 
+      considered_risky: 
+      delivery: 
+      payment: 
+      resumed: 
+      returned: 
     order_summary: Pasūtījuma apkopojums
     order_sure_want_to: Vai esiet pārliecināts, ka vēlaties %{event} šo pasūtījumu?
     order_total: Kopējais pasūtījums
     order_updated: Pasūtījums atjaunots
     orders: Pasūtījumi
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Izpārdots
     overview: Pārskats
-    package_from:
+    package_from: 
     pagination:
-      next_page:
-      previous_page:
+      next_page: 
+      previous_page: 
       truncate: "…"
     password: Parole
     paste: Paste
     path: Ceļš
     pay: maksā
     payment: Maksājums
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Maksājumu informācija
     payment_method: Maksājuma metode
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Maksājuma metodes
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
+    payment_processing_failed: 
+    payment_processor_choose_banner_text: 
+    payment_processor_choose_link: 
     payment_state: Maksājuma statuss
     payment_states:
-      balance_due:
-      checkout:
-      completed:
-      credit_owed:
-      failed:
-      paid:
-      pending:
-      processing:
-      void:
+      balance_due: 
+      checkout: 
+      completed: 
+      credit_owed: 
+      failed: 
+      paid: 
+      pending: 
+      processing: 
+      void: 
     payment_updated: Maksājums atjaunots
     payments: Maksājumi
-    pending:
-    percent:
-    percent_per_item:
-    permalink:
+    pending: 
+    percent: 
+    percent_per_item: 
+    permalink: 
     phone: Telefons
     place_order: Veikt pasūtījumu
-    please_define_payment_methods:
-    populate_get_error:
-    powered_by:
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    please_define_payment_methods: 
+    populate_get_error: 
+    powered_by: 
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Prezentācija
     previous: Iepriekšējais
-    previous_state_missing:
+    previous_state_missing: 
     price: Cena
     price_range: Price Range
     price_sack: Price Sack
     process: Apstrādāt
     product: Produkts
     product_details: Produkta detaļas
-    product_has_no_description: "Šim produktam nav nosaukuma"
-    product_not_available_in_this_currency:
+    product_has_no_description: Šim produktam nav nosaukuma
+    product_not_available_in_this_currency: 
     product_properties: Produkta īpašības
     product_rule:
-      choose_products:
-      label:
-      match_all:
-      match_any:
-      match_none:
+      choose_products: 
+      label: 
+      match_all: 
+      match_any: 
+      match_none: 
       product_source:
-        group:
-        manual:
+        group: 
+        manual: 
     products: Produkti
-    promotion:
-    promotion_action:
+    promotion: 
+    promotion_action: 
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: 
+        name: 
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: 
+        name: 
+    promotion_actions: 
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: 
+        any: 
+    promotion_rule: 
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: 
+        name: 
       item_total:
-        description:
-        name:
+        description: 
+        name: 
       landing_page:
-        description:
-        name:
+        description: 
+        name: 
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description:
-        name:
+        description: 
+        name: 
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
-        description:
-        name:
+        description: 
+        name: 
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
+        description: 
+        name: 
+    promotion_uses: 
+    promotionable: 
     promotions: Akcijas
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Parametri
     property: Parametrs
     prototype: Prototips
@@ -968,49 +969,49 @@ lv:
     provider: Piegādātājs
     provider_settings_warning: Ja tu maini piegādātāja tipu, tev vajag vispirms saglabāt pirms veikt izmaiņas piegādātāja uzstādījumiem
     qty: Daudzums
-    quantity:
+    quantity: 
     quantity_returned: Quantity Returned
     quantity_shipped: Daudzums nosūtīts
-    quick_search:
+    quick_search: 
     rate: Tarifs
     reason: Iemesls
     receive: saņemt
-    receive_stock:
+    receive_stock: 
     received: Saņemts
-    reception_status:
-    reference:
+    reception_status: 
+    reference: 
     refund: Atmaksāt
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Reģistrēties kā jauns lietotājs
     registration: Reģistrācija
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Atcerēties mani
-    remove:
-    rename:
-    report:
+    remove: 
+    rename: 
+    report: 
     reports: Atskaites
     resend: Pārsūtīt
     reset_password: Nomainīt manu paroli
@@ -1018,37 +1019,37 @@ lv:
     resume: atsākt
     resumed: Atsākts
     return: atgriezties
-    return_authorization:
-    return_authorization_reasons:
-    return_authorization_updated:
-    return_authorizations:
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity:
+    return_authorization: 
+    return_authorization_reasons: 
+    return_authorization_updated: 
+    return_authorizations: 
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
+    return_quantity: 
     returned: Atgriezts
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
+    returns: 
+    review: 
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA Credit
     rma_number: RMA numurs
     rma_value: RMA vērtība
-    roles:
-    rules:
-    safe:
+    roles: 
+    rules: 
+    safe: 
     sales_total: Kopējā realizācija
     sales_total_description: Sales Total For All Orders
-    sales_totals:
+    sales_totals: 
     save_and_continue: Saglabāt un turpināt
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: 
+    say_no: 
+    say_yes: 
     scope: Scope
     search: Meklēšana
     search_results: Meklēšanas rezultāti '%{keywords}'
@@ -1056,10 +1057,10 @@ lv:
     secure_connection_type: Secure Connection Type
     security_settings: Security Settings
     select: Izvēlēties
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Izvēlēties no prototipiem
-    select_stock:
+    select_stock: 
     send_copy_of_all_mails_to: Sūtīt visu vēstuļu kopijas uz
     send_mails_as: Sūtīt vēstules kā
     server: Servers
@@ -1067,218 +1068,218 @@ lv:
     settings: Uzstādījumi
     ship: sūtīt
     ship_address: Nosūtīšanas adrese
-    ship_total:
+    ship_total: 
     shipment: Sūtījums
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
+        dear_customer: 
+        instructions: 
+        shipment_summary: 
+        subject: 
+        thanks: 
+        track_information: 
+        track_link: 
     shipment_state: Piegādes statuss
     shipment_states:
-      backorder:
-      canceled:
-      partial:
-      pending:
-      ready:
-      shipped:
-    shipment_transfer_error:
-    shipment_transfer_success:
+      backorder: 
+      canceled: 
+      partial: 
+      pending: 
+      ready: 
+      shipped: 
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Sūtījumi
     shipped: Nosūtīts
     shipping: Sūtās
     shipping_address: Nosūtīšanas adrese
     shipping_categories: Sūtīšanas kategorijas
     shipping_category: Sūtīšanas kategorija
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
     shipping_instructions: Sūtīšanas instrukcijas
     shipping_method: Sūtīšanas metode
     shipping_methods: Sūtīšanas metodes
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: 
+    shipping_total: 
     shop_by_taxonomy: Pirkt pēc %{taxonomy}
     shopping_cart: Iepirkuma grozs
     show: Parādīt
     show_active: Parādīt aktīvos
     show_deleted: Parādīt izdzēstos
     show_only_complete_orders: Parādīt tikai pabeigtos pasūtījumus
-    show_only_considered_risky:
-    show_rate_in_label:
-    sku:
-    skus:
-    slug:
-    source:
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+    show_only_considered_risky: 
+    show_rate_in_label: 
+    sku: 
+    skus: 
+    slug: 
+    source: 
+    special_instructions: 
+    split: 
+    spree_gateway_error_flash_for_checkout: 
     ssl:
-      change_protocol:
-    start:
+      change_protocol: 
+    start: 
     state: Stāvoklis
-    state_based:
+    state_based: 
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states:
-    states_required:
-    status:
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
-    stop:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
+    states: 
+    states_required: 
+    status: 
+    stock: 
+    stock_location: 
+    stock_location_info: 
+    stock_locations: 
+    stock_locations_need_a_default_country: 
+    stock_management: 
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
+    stock_transfer: 
+    stock_transfers: 
+    stop: 
     store: Saglabāt
     street_address: Ielas adrese
     street_address_2: Ielas adrese (turpinājums)
     subtotal: Starpsumma
     subtract: Atskaitīt
-    success:
+    success: 
     successfully_created: "%{resource} tika veiksmīgi izveidots(-a)!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} tika veiksmīgi izdzēsts(-a)!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: 
     successfully_updated: "%{resource} tika veiksmīgi saglabāts(-a)!"
-    summary:
+    summary: 
     tax: Nodokļi
     tax_categories: Nodokļu kategorijas
     tax_category: Nodokļu kategorija
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
     tax_rates: Nodokļu likmes
-    taxon:
-    taxon_edit:
-    taxon_placeholder:
+    taxon: 
+    taxon_edit: 
+    taxon_placeholder: 
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Klasifikatori
-    taxonomy:
+    taxonomy: 
     taxonomy_edit: Labot klasifikatoru
     taxonomy_tree_error: Prasītās izmaiņas nav pieņemtas un koks ir atgriezts iepriekšējā stāvoklī, lūdzu, mēģiniet vēlreiz.
     taxonomy_tree_instruction: "* Ar labo peli uzklikšķiniet kokā, lai piekļūtu izvēlei: pievienošanai, izdzēšanai vai sortēšanai."
-    taxons:
-    test:
+    taxons: 
+    test: 
     test_mailer:
       test_email:
-        greeting:
-        message:
-        subject:
-    test_mode:
+        greeting: 
+        message: 
+        subject: 
+    test_mode: 
     thank_you_for_your_order: Paldies par sadarbību. Lūdzu, izdrukājiet šo apstiprinājumu savai zināšanai.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: Problēmas ar sekojošiem laukiem
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: 
     to_add_variants_you_must_first_define: Lai pievienotu variantu, vispirms definējiet
     total: Kopā
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Tracking
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
     tree: Koks
     type: Tips
     type_to_search: Type to search
     unable_to_connect_to_gateway: Nav spējīgs pievienoties gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
-    unlock:
+    unlock: 
     unrecognized_card_type: Neatpazīstams kartes tips
-    unshippable_items:
+    unshippable_items: 
     update: Atjaunot
     updating: Atjaunojas
     usage_limit: Lietotāja limits
-    use_app_default:
+    use_app_default: 
     use_billing_address: Lietot rēķina adresi
     use_new_cc: Izmntot jaunu karti
-    use_s3:
+    use_s3: 
     user: Lietotājs
     user_rule:
-      choose_users:
+      choose_users: 
     users: Lietotāji
     validation:
       cannot_be_less_than_shipped_units: nevar būt mazāks par izsūtītām vienībām.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 
       is_too_large: ir par lielu - pieejamais daudzums nevar nodrošināt prasīto daudzumu!
       must_be_int: must be an integer
       must_be_non_negative: ir jābūt pozitīvai vērtībai
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Vērtība
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: 
     variants: Varianti
     version: Versija
     void: Void
-    weight:
+    weight: 
     what_is_a_cvv: Kas ir (CVV) kredītkartes kods?
     what_is_this: Kas tas ir?
     width: Platums
     year: Gads
-    you_have_no_orders_yet:
+    you_have_no_orders_yet: 
     your_cart_is_empty: Jūsu iepirkuma grozs ir tukšs
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: 
     zip: Pasta indekss
-    zipcode:
+    zipcode: 
     zone: Zona
     zones: Zonas

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -1,3 +1,4 @@
+---
 nb:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ nb:
         state: Fylke
         zipcode: Postnummer
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -27,10 +28,10 @@ nb:
         base: Base
         cc_type: Type
         month: Måned
-        name:
+        name: 
         number: Nummer
-        verification_value:
-        year: "År"
+        verification_value: 
+        year: År
       spree/inventory_unit:
         state: status
       spree/line_item:
@@ -95,7 +96,7 @@ nb:
         starts_at: Starter ved
         usage_limit: Bruksgrense
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Navn
         presentation: Presentasjon
@@ -109,20 +110,20 @@ nb:
         abbr: Forkortelse
         name: Navn
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Beskrivelse
         name: Navn
@@ -139,9 +140,9 @@ nb:
       spree/user:
         email: Epost
         password: Passord
-        password_confirmation:
+        password_confirmation: 
       spree/variant:
-        cost_currency:
+        cost_currency: 
         cost_price: Kostpris
         depth: Dybde
         height: Høyde
@@ -157,47 +158,47 @@ nb:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: Utløpsdato
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Adresse
@@ -208,40 +209,40 @@ nb:
       spree/credit_card:
         one: Kredittkort
         other: Kredittkort
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Lagerenhet
         other: Lagerenheter
       spree/line_item:
         one: Varelinje
         other: Varelinjer
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Ordre
         other: Ordrer
       spree/payment:
         one: Betaling
         other: Betalinger
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Produkt
         other: Produkter
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
         one: Egenskap
         other: Egenskaper
       spree/prototype:
         one: Prototype
         other: Prototyper
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Returautorisasjon
         other: Returautorisasjoner
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Rolle
         other: Roller
@@ -251,13 +252,13 @@ nb:
       spree/shipping_category:
         one: Forsendelseskategori
         other: Forsendelseskategorier
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: Status
         other: Statuser
-      spree/state_change:
+      spree/state_change: 
       spree/stock_location: Lagerlokasjon
-      spree/stock_movement:
+      spree/stock_movement: 
       spree/stock_transfer: Beholdningsendring
       spree/tax_category:
         one: Avgiftskategori
@@ -271,7 +272,7 @@ nb:
       spree/taxonomy:
         one: Gruppering
         other: Grupperinger
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: Bruker
         other: Brukere
@@ -283,10 +284,10 @@ nb:
         other: Soner
   spree:
     abbreviation: Fortkortelse
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Konto
     account_updated: Konto oppdatert!
     action: Hendelse
@@ -299,7 +300,7 @@ nb:
       list: List opp
       listing: Viser
       new: Ny
-      refund:
+      refund: 
       save: Lagre
       update: Oppdater
     activate: Aktiver
@@ -307,7 +308,7 @@ nb:
     add: Legg til
     add_action_of_type: Legg til hendelsestype
     add_country: Legg til land
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Legg til nytt hode
     add_new_style: Legg til ny stil
     add_one: Legg til en
@@ -323,7 +324,7 @@ nb:
     additional_item: Tillegskostnad
     address1: Adresselinje 1
     address2: Adresselinje 2
-    adjustable:
+    adjustable: 
     adjustment: Justering
     adjustment_amount: Justeringsbeløp
     adjustment_successfully_closed: Justering lukket vellykket
@@ -333,36 +334,36 @@ nb:
     admin:
       tab:
         configuration: Oppsett
-        option_types:
+        option_types: 
         orders: Ordrer
         overview: Oversikt
         products: Produkter
+        promotion_categories: 
         promotions: Kampanjer
-        promotion_categories:
-        properties:
-        prototypes:
+        properties: 
+        prototypes: 
         reports: Rapporter
-        taxonomies:
-        taxons:
+        taxonomies: 
+        taxons: 
         users: Brukere
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administrasjon
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Godta personvernsregler
     agree_to_terms_of_service: Godta bruksregler
     all: Alle
     all_adjustments_closed: Alle justeringer lukket
     all_adjustments_opened: Alle justeringer åpne
     all_departments: Alle avdelinger
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Tillat bruk av SSL i utviklings- og testmiljø
     allow_ssl_in_production: Tillat bruk av SSL i produksjonsmiljø
     allow_ssl_in_staging: Tillatt bruk av SSL i stagingmiljø
@@ -370,12 +371,12 @@ nb:
     alt_text: Alternativ tekst
     alternative_phone: Alternativ telefon
     amount: Beløp
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: 
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
     analytics_trackers: Analytics Trackers
     and: og
     approve: godkjenne
@@ -383,69 +384,69 @@ nb:
     approver: Godkjent av
     are_you_sure: Er du sikker
     are_you_sure_delete: Er du sikker på at du vil slette denne?
-    associated_adjustment_closed:
-    at_symbol: '@'
+    associated_adjustment_closed: 
+    at_symbol: "@"
     authorization_failure: Autorisering feilet
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Tilgjengelig fra
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Tilbake
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Tilbake til butikken
     back_to_users_list: Tilbake til brukere
     backorderable: Restordre
-    backorderable_default:
+    backorderable_default: 
     backordered: I restordre
     backorders_allowed: Kan settes på restordre
     balance_due: Forfallsdato
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Fakturaadresse
     billing: Fakturering
     billing_address: Fakturaadresse
     both: Begge
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Kalkulator
     calculator_settings_warning: Hvis du endrer kalkulasjonsmåte, må du lagre før du kan endre kalkulasjonsinstillinger
     cancel: Avbryt
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: Du kan ikke opprette en betaling for en ordre før det er definert en betalingsmåte
     cannot_create_returns: Kan ikke opprette retur, da denne ordren ikke er sendt ennå
     cannot_perform_operation: Kan ikke utføre handlingen
     cannot_set_shipping_method_without_address: Kan ikke sette fraktmåte uten adresse
     capture: Utfør
-    capture_events:
+    capture_events: 
     card_code: CVV-kode
     card_number: Kortnummer
-    card_type:
+    card_type: 
     card_type_is: Korttype er
     cart: Handlekurv
-    cart_subtotal:
+    cart_subtotal: 
     categories: Kategorier
     category: Kategori
-    charged:
-    check_for_spree_alerts:
+    charged: 
+    check_for_spree_alerts: 
     checkout: Til kassen
     choose_a_customer: Velg kunde
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Velg valuta
-    choose_dashboard_locale:
+    choose_dashboard_locale: 
     choose_location: Velg lokasjon
     city: Sted
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Klon
     close: Lukk
-    close_all_adjustments:
+    close_all_adjustments: 
     code: Code
     company: Firma
     complete: Fullført
@@ -456,109 +457,109 @@ nb:
     confirm_password: Bekreft passord
     continue: Fortsett
     continue_shopping: Fortsett å handle
-    cost_currency:
+    cost_currency: 
     cost_price: Kostpris
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
     countries: Land
     country: Land
     country_based: Landsbasert
     country_name: Landnavn
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Rabattkupong
     coupon_code: Rabattkode
     coupon_code_already_applied: Rabattkupong er allerede brukt
     coupon_code_applied: Rabattkupong ble lagt til på ordren
-    coupon_code_better_exists:
+    coupon_code_better_exists: 
     coupon_code_expired: Rabattkoden er utgått på dato
     coupon_code_max_usage: Maksgrensen for rabattkupongen er nådd
     coupon_code_not_eligible: Rabattkoden er ikke gyldig
     coupon_code_not_found: Rabattkoden ble ikke funnet
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Opprett
     create_a_new_account: Opprett ny konto
-    create_new_order:
-    create_reimbursement:
+    create_new_order: 
+    create_reimbursement: 
     created_at: Opprettet
     credit: Kreditt
     credit_card: Kredittkort
     credit_cards: Kredittkort
     credit_owed: Skyldig kreditt
-    credits:
+    credits: 
     currency: Valuta
     currency_decimal_mark: Valuta kommaplassering
     currency_settings: Valuttainstillinger
     currency_symbol_position: Plasser valutasymbol foran eller etter beløp?
     currency_thousands_separator: Separator for tusenedeler
     current: Nå
-    current_promotion_usage:
+    current_promotion_usage: 
     customer: Kunde
     customer_details: Kundedetaljer
     customer_details_updated: Kundedetaljer
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Kundesøk
     cut: Klipp up
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
     date: dato
     date_completed: Fullføringsdato
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 
+      format: 
+      js_format: 
     date_range: Datoområde
     default: Default
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Standardavgift
     default_tax_zone: Standard avgiftsnivå
     delete: Slett
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Levering
     depth: Dybde
     description: Beskrivelse
     destination: Destinasjon
     destroy: Fjern
-    details:
+    details: 
     discount_amount: Rabattbeløp
     dismiss_banner: Nei takk! Ikke vis dette igjen, takk!
     display: Vis
     display_currency: Vis valutta
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Endre
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Endre bruker
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Epost
     empty: Tom
     empty_cart: Tøm handlekurv
@@ -590,20 +591,20 @@ nb:
         user:
           signup: Brukerregistrering
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Utgår
     extension: Utvidelse
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Filnavn
     fill_in_customer_info: Fyll ut kundeinformasjon
     filter: Filter
     filter_results: Filtrer resultater
     finalize: Ferdigstill
-    finalized:
+    finalized: 
     find_a_taxon: Finn en gruppe
     first_item: Pris på første vare
     first_name: Fornavn
@@ -613,7 +614,7 @@ nb:
     flexible_rate: Varierende pris
     forgot_password: Glemt Passord
     free_shipping: Gratis frakt
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Front end
     gateway: Tjeneste
     gateway_config_unavailable: Tilganstjenesten utilgjengelig for miljøet
@@ -629,38 +630,38 @@ nb:
     hide_cents: Hele kroner?
     home: Hjem
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: Norsk
     icon: Ikon
-    identifier:
+    identifier: 
     image: Bilde
     images: Bilder
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Inkludert i pris
     included_price_validation: kan ikke velges med mindre du har definert en standard avgiftsområde
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Fyll ut skjemaet under og du vil motta instruksjoner for hvordan du tilbakestiller passordet ditt per epost:'
     insufficient_stock: Manglende lagerbeholdning, kun %{on_hand} gjenstår
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Overstyr epostadresse
     intercept_email_instructions: Overstyr epostmottaker og bytt ut med følgende adresse.
     internal_name: Internt navn
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Ugyldig betalingsleverandør
     invalid_promotion_action: Ugyldig kampanjehendelse
     invalid_promotion_rule: Ugyldig kampanjeregel
     inventory: Varelager
     inventory_adjustment: Justering av varelager
     inventory_error_flash_for_insufficient_quantity: Ikke nok beholdning
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: er ikke tilgjengelig for levering
     iso_name: ISO Navn
     item: Artikkel
@@ -670,26 +671,26 @@ nb:
       operators:
         gt: større enn
         gte: større enn, eller er lik
-        lt:
-        lte:
+        lt: 
+        lte: 
     items_cannot_be_shipped: Varene kan ikke sendes!
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
+    jirafe: 
     landing_page_rule:
       path: Path
     last_name: Etternavn
     last_name_begins_with: Etternavn begynner med
     learn_more: Finn ut mer
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Liste
     loading: Laster
     locale_changed: Endret språk
     location: Lokasjon
     lock: Låst
-    log_entries:
+    log_entries: 
     logged_in_as: Innlogget som
     logged_in_succesfully: Logget inn
     logged_out: Du har blitt utlogget.
@@ -698,23 +699,23 @@ nb:
     login_failed: Brukerautentisering feilet.
     login_name: Brukernavn
     logout: Logg ut
-    logs:
+    logs: 
     look_for_similar_items: Finn lignende varer
     make_refund: Opprett refusjon
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Ordinær pris
     match_choices:
       all: Alle
       none: Ingen
     max_items: Maks antall
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Metabeskrivelse
     meta_keywords: Metanøkkelord
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Minimumsantall
     month: Måned
@@ -723,13 +724,13 @@ nb:
     my_account: Min konto
     my_orders: Mine ordrer
     name: Navn
-    name_on_card:
+    name_on_card: 
     name_or_sku: Navn eller varenr
     new: Ny
     new_adjustment: Ny justering
-    new_country:
+    new_country: 
     new_customer: Ny kunde
-    new_customer_return:
+    new_customer_return: 
     new_image: Nytt bilde
     new_option_type: Ny variasjonstype
     new_order: Ny ordre
@@ -738,14 +739,14 @@ nb:
     new_payment_method: Ny betalingsmåte
     new_product: Nytt produkt
     new_promotion: Ny kampanje
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Ny egenskap
     new_prototype: Ny prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Ny returgodkjenning
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Ny fraktkategori
     new_shipping_method: Ny leveransemåte
     new_state: Nytt fylke
@@ -765,21 +766,21 @@ nb:
     no_payment_found: Ingen betalinger funnet
     no_pending_payments: Ingen utestående betalinger
     no_products_found: Ingen produkter tilgjengelig
-    no_resource_found:
+    no_resource_found: 
     no_results: Ingen resultat
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: Ingen regler lagt til
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: Sporing ikke tilgjengelig
     none: Ingen
-    none_selected:
+    none_selected: 
     normal_amount: Normalt antall
     not: ikke
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: 
     not_found: "%{resource} ble ikke funnet"
-    note:
+    note: 
     notice_messages:
       product_cloned: Produktet ble kopiert
       product_deleted: Produktet ble slettet
@@ -787,10 +788,10 @@ nb:
       product_not_deleted: Produktet kunne ikke slettes
       variant_deleted: Variant ble slettet
       variant_not_deleted: Variant kunne ikke slettes
-    num_orders:
+    num_orders: 
     on_hand: Tilgjengelig
-    open: "Åpen"
-    open_all_adjustments: "Åpne alle justeringer"
+    open: Åpen
+    open_all_adjustments: Åpne alle justeringer
     option_type: Variasjon
     option_type_placeholder: Variasjoner
     option_types: Variasjonstyper
@@ -802,12 +803,12 @@ nb:
     or_over_price: "%{price} eller høyere"
     order: Ordre
     order_adjustments: Ordrejustering
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Ordredetaljer
     order_email_resent: Ordre-epost sent på nytt
-    order_information:
+    order_information: 
     order_mailer:
       cancel_email:
         dear_customer: Kjære kunde,
@@ -827,11 +828,11 @@ nb:
     order_not_found: Ordren ble ikke funnet
     order_number: Ordre %{number}
     order_populator:
-      out_of_stock:
+      out_of_stock: 
       please_enter_reasonable_quantity: Vennligst oppgi et fornuftig antall
-      selected_quantity_not_available:
+      selected_quantity_not_available: 
     order_processed_successfully: Din ordre har blitt behandlet
-    order_resumed:
+    order_resumed: 
     order_state:
       address: adresse
       awaiting_return: venter på retur
@@ -839,7 +840,7 @@ nb:
       cart: handlekurv
       complete: ferdig
       confirm: bekreftelse
-      considered_risky:
+      considered_risky: 
       delivery: levering
       payment: betaling
       resumed: gjenopptatt
@@ -849,7 +850,7 @@ nb:
     order_total: Ordresum
     order_updated: Ordre oppdatert
     orders: Ordrer
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Ikke på lager
     overview: Oversikt
     package_from: Pakke fra
@@ -862,8 +863,8 @@ nb:
     path: Sti
     pay: betal
     payment: Betaling
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Betalingsinformasjon
     payment_method: Betalingsform
     payment_method_not_supported: Betalingsformen er ikke støttet
@@ -884,7 +885,7 @@ nb:
       void: Avvis
     payment_updated: Betaling oppdatert
     payments: Betalinger
-    pending:
+    pending: 
     percent: prosent
     percent_per_item: Prosent per enhet
     permalink: Permalenke
@@ -893,13 +894,13 @@ nb:
     please_define_payment_methods: Vennligst legg til betalingsmetode først.
     populate_get_error: Noe gikk galt. Prøv å legg til igjen.
     powered_by: Bygget på
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Presentasjon
     previous: Forrige
-    previous_state_missing:
+    previous_state_missing: 
     price: Pris
     price_range: Prisområde
     price_sack: Price Sack
@@ -907,14 +908,14 @@ nb:
     product: Produkt
     product_details: Produktdetaljer
     product_has_no_description: Product has not description
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: Produktegenskaper
     product_rule:
       choose_products: Velg produkter
-      label:
+      label: 
       match_all: alle
       match_any: minst en
-      match_none:
+      match_none: 
       product_source:
         group: Fra produktgruppe
         manual: Velg manuelt
@@ -926,14 +927,14 @@ nb:
         description: Opprett en kampanjekreditt på ordren
         name: Opprett en justering
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Fyller handlekurv med det spesifiserte antallet av varianten
         name: Opprett varelinjer
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Handling
     promotion_form:
       match_policies:
@@ -951,27 +952,27 @@ nb:
         description: Kunden må ha besøkt den spesifiserte siden
         name: Landingsiden
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Ordren inkluderer spesifikke produkt(er)
         name: Produkt(er)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Tilgjengelig kun for spesifiserte brukere
         name: Brukere
       user_logged_in:
         description: Kun tilgjengelig for innloggede brukere
         name: Bruker innlogget
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Kampanjer
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Egenskaper
     property: Egenskap
     prototype: Prototype
@@ -979,7 +980,7 @@ nb:
     provider: Tilbyder
     provider_settings_warning: Hvis du endrer tilbydertype, må du lagre før du kan endre tilbyderinstillingene
     qty: Antall
-    quantity:
+    quantity: 
     quantity_returned: Antall returnert
     quantity_shipped: Antall sendt
     quick_search: Hurtigsøk..
@@ -988,40 +989,40 @@ nb:
     receive: motta
     receive_stock: Varemottak
     received: Motatt
-    reception_status:
+    reception_status: 
     reference: Referansje
     refund: Refusjon
-    refund_amount_must_be_greater_than_zero:
+    refund_amount_must_be_greater_than_zero: 
     refund_reasons: Refusjonsgrunner
-    refunded_amount:
-    refunds:
+    refunded_amount: 
+    refunds: 
     register: Registrer som ny bruker
     registration: Registrering
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Husk meg
     remove: Fjern
     rename: Gi nytt navn
-    report:
+    report: 
     reports: Rapporter
     resend: Send på nytt
     reset_password: Nullstill passord
@@ -1033,16 +1034,16 @@ nb:
     return_authorization_reasons: Grunner for returautorisasjon
     return_authorization_updated: Returautorisasjon oppdatert
     return_authorizations: Returautorisasjoner
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Returantall
     returned: Returnert
-    returns:
+    returns: 
     review: Omtale
     risk: Risko
     risk_analysis: Risikoanalyse
@@ -1070,7 +1071,7 @@ nb:
     select_a_return_authorization_reason: Grunnlag for retur..
     select_a_stock_location: Velg lagerlokasjon..
     select_from_prototype: Velg fra prototype
-    select_stock:
+    select_stock: 
     send_copy_of_all_mails_to: Send kopi av all epost til
     send_mails_as: Send epost som
     server: Server
@@ -1080,7 +1081,7 @@ nb:
     ship_address: Leveringsadresse
     ship_total: Leveringskostnader
     shipment: Levering
-    shipment_adjustments:
+    shipment_adjustments: 
     shipment_details: Leveringsdetaljer
     shipment_mailer:
       shipped_email:
@@ -1099,22 +1100,22 @@ nb:
       pending: venter
       ready: klar
       shipped: sendt
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Forsendelser
     shipped: Sendt
     shipping: Frakt
     shipping_address: Leveringsadresse
     shipping_categories: Fraktkategorier
     shipping_category: Shipping Category
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
     shipping_instructions: Sendingsinstruks
     shipping_method: Leveransemåte
     shipping_methods: Leveransemåter
     shipping_price_sack: Fast forsendelsespris
-    shipping_total:
+    shipping_total: 
     shop_by_taxonomy: Handle etter %{taxonomy}
     shopping_cart: Handlekurv
     show: Vis
@@ -1136,37 +1137,37 @@ nb:
     state: Fylke
     state_based: Tilstandsbasert
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Fylker
     states_required: Fylke påkrevd
     status: Status
@@ -1174,11 +1175,11 @@ nb:
     stock_location: Varelokasjon
     stock_location_info: Varelokasjoninformasjon
     stock_locations: Varelokasjoner
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Lagerstyring
     stock_management_requires_a_stock_location: Lagerstyring krever en lagerlokasjon
     stock_movements: Beholdningsendring
-    stock_movements_for_stock_location:
+    stock_movements_for_stock_location: 
     stock_successfully_transferred: Beholdning vellykket flyttet
     stock_transfer: Beholdningsendring
     stock_transfers: Beholdningsendringer
@@ -1188,18 +1189,18 @@ nb:
     street_address_2: Adresselinje 2
     subtotal: Sum
     subtract: Trekk fra
-    success:
+    success: 
     successfully_created: "%{resource} ble opprettet!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} ble fjernet!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: 
     successfully_updated: "%{resource} ble oppdatert!"
-    summary:
+    summary: 
     tax: Avgift
     tax_categories: Avgiftsklasser
     tax_category: Avgiftsklasse
-    tax_code:
-    tax_included:
+    tax_code: 
+    tax_included: 
     tax_rate_amount_explanation: Avgiftsnivå (0.10 = 10%)
     tax_rates: Avgiftsnivå
     taxon: Gruppe
@@ -1207,13 +1208,14 @@ nb:
     taxon_placeholder: Grupper
     taxon_rule:
       choose_taxons: Velg grupper
-      label:
-      match_all:
-      match_any:
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Grupperinger
     taxonomy: Gruppering
     taxonomy_edit: Endre grupperinger
-    taxonomy_tree_error: Den forespurte endringen ble ikke akseptert, og treet har blitt tilbakestilt til sin opprinnelige tilstand. Vennligst prøv igjen.
+    taxonomy_tree_error: Den forespurte endringen ble ikke akseptert, og treet har blitt tilbakestilt til sin opprinnelige tilstand. Vennligst
+      prøv igjen.
     taxonomy_tree_instruction: "* Høyreklikk på underelement i treet for å aksessere menyen for og legge til, slette å sortere underelementer."
     taxons: Klasser
     test: Test
@@ -1226,24 +1228,24 @@ nb:
     thank_you_for_your_order: Takk for bestillingen. Vennligst skriv ut og ta vare på denne bekreftelsen.
     there_are_no_items_for_this_order: Det er ingen enheter for denne ordren
     there_were_problems_with_the_following_fields: Det er problemer med følgende felter
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: tidspunkt
     to_add_variants_you_must_first_define: For å legge til varianter, må du først definere
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Sporing
     tracking_number: Sporingsnummer
     tracking_url: Sporingslenke
     tracking_url_placeholder: http://..
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Flytt fra lokasjon
     transfer_stock: Flytt varebeholdning
     transfer_to_location: Flytt til lokasjon
@@ -1251,7 +1253,7 @@ nb:
     type: Type
     type_to_search: Skriv for å søke..
     unable_to_connect_to_gateway: Kunne ikke koble til systemport.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
     unlock: Lås opp
     unrecognized_card_type: Ukjent korttype
@@ -1259,7 +1261,7 @@ nb:
     update: Oppdater
     updating: Oppdaterer
     usage_limit: Bruksgrense
-    use_app_default:
+    use_app_default: 
     use_billing_address: Bruk fakturaadressen
     use_new_cc: Use a new card
     use_s3: Bruk Amazon S3 for bilder
@@ -1269,12 +1271,12 @@ nb:
     users: Brukere
     validation:
       cannot_be_less_than_shipped_units: kan ikke være lavere en antall sendte enheter.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 
       is_too_large: er for stor -- varebeholdningen kan ikke dekke forespurt antall!
       must_be_int: må være et heltall
       must_be_non_negative: må være en ikke-negativ verdi
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Verdi
     variant: Variant
     variant_placeholder: Varianter
@@ -1285,7 +1287,7 @@ nb:
     what_is_a_cvv: Hva er en CVV-kode?
     what_is_this: Hva er dette?
     width: Bredde
-    year: "År"
+    year: År
     you_have_no_orders_yet: Du har ikke plassert noen ordrer hos oss ennå!
     your_cart_is_empty: Din handlekurv er tom
     your_order_is_empty_add_product: Ordren din er tom - Kjøp noe!

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ nl:
         state: Provincie
         zipcode: Postcode
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +25,10 @@ nl:
         name: Naam
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: 
         cc_type: Type
         month: Maand
-        name:
+        name: 
         number: Nummer
         verification_value: Veiligheidscode
         year: Jaar
@@ -42,7 +43,7 @@ nl:
       spree/order:
         checkout_complete: Bestelling afgerond
         completed_at: Voltooid op
-        considered_risky:
+        considered_risky: 
         coupon_code: Kortingscode
         created_at: Besteldatum
         email: Klant e-mail
@@ -95,7 +96,7 @@ nl:
         starts_at: Begint op
         usage_limit: Gebruikslimiet
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Naam
         presentation: Presentatie
@@ -109,20 +110,20 @@ nl:
         abbr: Afkorting
         name: Naam
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Omschrijving
         name: Naam
@@ -157,47 +158,47 @@ nl:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: Kaart is verlopen
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Adres
@@ -208,42 +209,42 @@ nl:
       spree/credit_card:
         one: Kredietkaart
         other: Kredietkaarten
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Voorraadeenheid
         other: Voorraadeenheden
       spree/line_item:
         one: Regel
         other: Regels
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Bestelling
         other: Bestellingen
       spree/payment:
         one: Betaling
         other: Betalingen
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Product
         other: Producten
       spree/promotion:
         one: Promotie
         other: Promoties
-      spree/promotion_category:
+      spree/promotion_category: 
       spree/property:
         one: Eigenschap
         other: Eigenschappen
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Retour
         other: Retouren
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Rol
         other: Rollen
@@ -253,14 +254,14 @@ nl:
       spree/shipping_category:
         one: Verzendcategorie
         other: Verzendcategorieën
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: Provincie
         other: Provincies
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Belastingscategorie
         other: Belastingscategorieën
@@ -273,7 +274,7 @@ nl:
       spree/taxonomy:
         one: Taxonomie
         other: Taxonomieën
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: Gebruiker
         other: Gebruikers
@@ -285,10 +286,10 @@ nl:
         other: Zones
   spree:
     abbreviation: Afkorting
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Account
     account_updated: Account bijgewerkt!
     action: Actie
@@ -301,7 +302,7 @@ nl:
       list: Lijst
       listing: Opsomming
       new: Nieuw
-      refund:
+      refund: 
       save: Opslaan
       update: Bijwerken
     activate: Activeer
@@ -309,7 +310,7 @@ nl:
     add: Toevoegen
     add_action_of_type: Voeg actie toe van type
     add_country: Land toevoegen
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Voeg nieuwe header toe
     add_new_style: Voeg nieuwe stijl toe
     add_one: Voeg één toe
@@ -325,7 +326,7 @@ nl:
     additional_item: Toegevoegde artikel kosten
     address1: Adres
     address2: Adres (vervolg)
-    adjustable:
+    adjustable: 
     adjustment: Aanpassing
     adjustment_amount: Hoeveelheid
     adjustment_successfully_closed: Aanpassing is met succes afgesloten!
@@ -339,32 +340,32 @@ nl:
         orders: Bestellingen
         overview: Overzicht
         products: Producten
+        promotion_categories: 
         promotions: Promoties
-        promotion_categories:
         properties: Eigenschappen
-        prototypes:
+        prototypes: 
         reports: Rapportages
-        taxonomies:
-        taxons:
+        taxonomies: 
+        taxons: 
         users: Gebruikers
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administratie
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Akkoord met privacy beleid
     agree_to_terms_of_service: Akkoord met algemene voorwaarden
     all: Alle
     all_adjustments_closed: Alle aanpassingen succesvol gesloten!
     all_adjustments_opened: Alle aanpassingen succesvol geopend
     all_departments: Alle afdelingen
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Sta toe SSL te gebruiken in ontwikkel en test modus
     allow_ssl_in_production: Sta toe SSL te gebruiken in productie modus
     allow_ssl_in_staging: Sta toe SSL te gebruikten in staging modus
@@ -380,59 +381,60 @@ nl:
     analytics_desc_list_4: Het is volledig gratis
     analytics_trackers: Analytics trackers
     and: en
-    approve:
+    approve: 
     approved_at: Goedgekeurd op
     approver: Door
     are_you_sure: Weet je het zeker
     are_you_sure_delete: Wilt je dit record echt verwijderen?
     associated_adjustment_closed: De bijbehorende aanpassing is gesloten, en wordt niet herberekend. Wil je de aanpassing openen?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Autorisatie mislukt
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Beschikbaar op
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Terug
     back_end: Backend
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Verder winkelen
     back_to_users_list: Terug naar gebruikers lijst
     backorderable: Nabestelbaar
-    backorderable_default:
+    backorderable_default: 
     backordered: Nabestelling
     backorders_allowed: Nabestellingen toegestaan
     balance_due: Te betalen
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Factuuradres
     billing: Factuur
     billing_address: Factuuradres
     both: Beide
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Calculator
     calculator_settings_warning: Als je de calculator verandert, dien je eerst op te slaan voordat je de calculator instellingen kan wijzigen
     cancel: Annuleer
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: Je kunt geen betaling aanmaken voor een bestelling als er geen betaalmethodes gedefinieerd zijn.
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: Je kunt geen betaling aanmaken voor een bestelling als er geen betaalmethodes gedefinieerd
+      zijn.
     cannot_create_returns: Kan geen retour aanmaken aangezien de bestelling nog niet is verstuurd
     cannot_perform_operation: Kan deze opdracht niet uitvoeren
     cannot_set_shipping_method_without_address: Kan geen verzendmethode kiezen totdat klant details bekend zijn.
     capture: betaling vastleggen
-    capture_events:
+    capture_events: 
     card_code: Kaartcode
     card_number: Kaartnummer
-    card_type:
+    card_type: 
     card_type_is: Kaarttype is
     cart: Winkelwagen
-    cart_subtotal:
+    cart_subtotal: 
     categories: Categorieën
     category: Categorie
-    charged:
+    charged: 
     check_for_spree_alerts: Controleer op Spree Alerts
     checkout: Afrekenen
     choose_a_customer: Kies een klant
@@ -441,10 +443,10 @@ nl:
     choose_dashboard_locale: Kies dashboard regio-instelling
     choose_location: Kies locatie
     city: Stad
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Dupliceren
     close: Sluiten
     close_all_adjustments: Sluit alle aanpassingen
@@ -461,7 +463,7 @@ nl:
     cost_currency: Kosten valuta
     cost_price: Kostprijs
     could_not_connect_to_jirafe: Kon geen verbinding maken met Jirafe. Dit wordt later automatisch nogmaals geprobeerd.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: Er is een fout opgetreden bij het bewaren van deze voorraad verplaatsing. Probeer het nogmaals.
     count_on_hand: Aantal in voorraad
     countries: Landen
@@ -469,10 +471,10 @@ nl:
     country_based: Gebaseerd op land
     country_name: Naam
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Kortingscode
     coupon_code: Kortingscode
     coupon_code_already_applied: Deze kortingscode is al toegepast op deze bestelling
@@ -482,17 +484,17 @@ nl:
     coupon_code_max_usage: Kortingscode is te vaak gebruikt
     coupon_code_not_eligible: Kortingscode is niet geldig voor deze bestelling
     coupon_code_not_found: Deze kortingscode bestaat niet. Probeer het nogmaals.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Aanmaken
     create_a_new_account: Maak een nieuwe account aan
-    create_new_order:
-    create_reimbursement:
+    create_new_order: 
+    create_reimbursement: 
     created_at: Aangemaakt op
     credit: Krediet
     credit_card: Kredietkaart
     credit_cards: Kredietkaart
     credit_owed: Credits ontvangen
-    credits:
+    credits: 
     currency: Valuta
     currency_decimal_mark: Scheidingsteken voor decimalen
     currency_settings: Valuta instellingen
@@ -503,64 +505,64 @@ nl:
     customer: Klant
     customer_details: Klant details
     customer_details_updated: Klant details bijgewerkt
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Klant zoeken
     cut: Knippen
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: App ID
         app_token: App Token
-        currently_unavailable:
+        currently_unavailable: 
         explanation: De onderstaande velden kunnen al ingevuld zijn als je via het dashboard hebt gekozen om te registreren met Jirafe.
         header: Jirafe Analytics instellingen
-        site_id:
-        token:
+        site_id: 
+        token: 
       jirafe_settings_updated: Jirafe instellingen bijgewerkt.
     date: Datum
     date_completed: Datum voluit
     date_picker:
-      first_day:
+      first_day: 
       format: "%d/%m/%Y"
       js_format: dd/mm/yy
     date_range: Datumbereik
     default: Standaard
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Standaardbelasting
     default_tax_zone: Standaardbelastingszone
     delete: Verwijder
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Bezorging
     depth: Diepte
     description: Omschrijving
     destination: Bestemming
     destroy: Verwijder
-    details:
+    details: 
     discount_amount: Kortingsbedrag
     dismiss_banner: Nee. Bedankt! Ik heb geen interesse. Laat dit bericht niet meer zien.
     display: Weergeven
     display_currency: Weergave valuta
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Wijzig
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Bewerk gebruikers
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: E-mail
     empty: Leeg
     empty_cart: Winkelwagen legen
@@ -592,19 +594,21 @@ nl:
         user:
           signup: Gebruiker registratie
     exceptions:
-      count_on_hand_setter: 'Kan count_on_hand niet handmatig instellen, omdat het automatisch wordt ingesteld door de recalculate_count_on_hand callback. Gebruik  `update_column (: count_on_hand, waarde)` in plaats hier van.'
-    exchange_for:
-    excl:
+      count_on_hand_setter: >-
+        Kan count_on_hand niet handmatig instellen, omdat het automatisch wordt ingesteld door de recalculate_count_on_hand callback. Gebruik
+        `update_column (: count_on_hand, waarde)` in plaats hier van.
+    exchange_for: 
+    excl: 
     existing_shipments: Bestaande verzendingen
-    expedited_exchanges_warning:
+    expedited_exchanges_warning: 
     expiration: Verval
     extension: Extensie
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Bestandsnaam
     fill_in_customer_info: Vul klant informatie in aub.
     filter_results: Filter resultaten
     finalize: Afronden
-    finalized:
+    finalized: 
     find_a_taxon: Zoek een taxon
     first_item: Kosten eerste item
     first_name: Voornaam
@@ -614,7 +618,7 @@ nl:
     flexible_rate: Flexibel bedrag
     forgot_password: Wachtwoord vergeten
     free_shipping: Gratis verzending
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Frontend
     gateway: Gateway
     gateway_config_unavailable: Gateway niet beschikbaar voor configuratie
@@ -635,33 +639,33 @@ nl:
       localization_settings: Regio-instellingen
       this_file_language: Nederlands (NL)
     icon: Icoon
-    identifier:
+    identifier: 
     image: Afbeelding
     images: Afbeeldingen
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Inbegrepen in prijs
     included_price_validation: kan niet worden gekozen tenzij je een standaardbelastingszone hebt ingesteld.
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Vul je e-mailadres in. De instructies om je wachtwoord te resetten worden naar je verstuurd:'
     insufficient_stock: Onvoldoende voorraad beschikbaar, enkel %{on_hand} beschikbaar
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: E-mailadres opvangen
     intercept_email_instructions: Ontvanger van de e-mail overschrijven met dit e-mail adres.
     internal_name: Interne naam
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Ongeldige betaalprovider.
     invalid_promotion_action: Ongeldige promotieactie.
     invalid_promotion_rule: Ongeldige promotieregel.
     inventory: Voorraad
     inventory_adjustment: Voorraadaanpassing
     inventory_error_flash_for_insufficient_quantity: Een item in uw winkelwagen is niet meer beschikbaar zijn.
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: is niet beschikbaar voor afleveradres
     iso_name: ISO Naam
     item: Product
@@ -671,26 +675,26 @@ nl:
       operators:
         gt: groter dan
         gte: groter dan of gelijk aan
-        lt:
-        lte:
+        lt: 
+        lte: 
     items_cannot_be_shipped: Items kunnen niet worden verstuurd
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Pad
     last_name: Achternaam
     last_name_begins_with: Achternaam begint met
     learn_more: Lees meer
-    lifetime_stats:
+    lifetime_stats: 
     line_item_adjustments: Regel-aanpassingen
     list: Lijst
     loading: Bezig met laden
     locale_changed: Regio-instelling gewijzigd
     location: Locatie
     lock: Vergrendel
-    log_entries:
+    log_entries: 
     logged_in_as: aangemeld als
     logged_in_succesfully: Je bent aangemeld
     logged_out: Je bent nu afgemeld.
@@ -699,23 +703,23 @@ nl:
     login_failed: Aanmelden mislukt.
     login_name: Gebruikersnaam
     logout: Afmelden
-    logs:
+    logs: 
     look_for_similar_items: Zoek naar dezelfde items
     make_refund: Terugboeking aanmaken
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Prijs
     match_choices:
       all: Alles
       none: Geen
     max_items: Maximaal aantal items
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Meta beschrijving
     meta_keywords: Meta sleutelwoorden
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Minimum afname
     month: Maand
@@ -724,13 +728,13 @@ nl:
     my_account: Mijn profiel
     my_orders: Mijn bestellingen
     name: Naam
-    name_on_card:
+    name_on_card: 
     name_or_sku: Naam of SKU
     new: Nieuw
     new_adjustment: Nieuwe toevoeging
     new_country: Land toevoegen
     new_customer: Nieuwe klant
-    new_customer_return:
+    new_customer_return: 
     new_image: Nieuwe afbeelding
     new_option_type: Nieuw optietype
     new_order: Nieuwe bestelling
@@ -739,13 +743,13 @@ nl:
     new_payment_method: Nieuwe betaalmethode
     new_product: Nieuw product
     new_promotion: Nieuwe promotie
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Nieuwe eigenschap
     new_prototype: Nieuw prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Nieuwe retour-autorisatie
-    new_rma_reason:
+    new_rma_reason: 
     new_shipment_at_location: Nieuwe verzending vanaf locatie
     new_shipping_category: Nieuwe verzend categorie
     new_shipping_method: Nieuwe verzendwijze
@@ -763,24 +767,24 @@ nl:
     new_zone: Nieuwe zone
     next: Volgende
     no_actions_added: Geen acties toegevoegd
-    no_payment_found:
-    no_pending_payments:
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: Geen producten gevonden
-    no_resource_found:
+    no_resource_found: 
     no_results: Geen resultaten
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: Geen regels toegevoegd
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: Geen tracking details opgegeven.
     none: Geen
-    none_selected:
+    none_selected: 
     normal_amount: Normaal aantal
     not: Niet
     not_available: Niet beschikbaar
     not_enough_stock: Er is niet voldoende voorraad op de locatie van afkomst om deze overdracht te voltooien.
     not_found: "%{resource} is niet gevonden"
-    note:
+    note: 
     notice_messages:
       product_cloned: Product is gedupliceerd
       product_deleted: Product is verwijderd
@@ -788,7 +792,7 @@ nl:
       product_not_deleted: Product kon niet worden verwijderd
       variant_deleted: Variant is verwijderd
       variant_not_deleted: Variant kon niet worden verwijderd
-    num_orders:
+    num_orders: 
     on_hand: Op voorraad
     open: Open
     open_all_adjustments: Open alle aanpassingen
@@ -803,9 +807,9 @@ nl:
     or_over_price: Of meer dan %{price}
     order: Bestelling
     order_adjustments: Bestellingstoevoegingen
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Bestellingsdetails
     order_email_resent: Verstuur bevestigings e-mail opnieuw
     order_information: Bestellingsinformatie
@@ -815,20 +819,20 @@ nl:
         instructions: Je order is GEANNULEERD. Bewaar deze annulering voor je administratie.
         order_summary_canceled: Besteloverzicht [GEANNULEERD]
         subject: Bestelling is geannuleerd
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Beste klant,
         instructions: Controleer je bestelling en bewaar deze mail.
         order_summary: Besteloverzicht
         subject: Bestelling is bevestigd
-        subtotal:
+        subtotal: 
         thanks: Bedankt voor je bestelling.
-        total:
+        total: 
     order_not_found: We konden je bestelling niet vinden. Probeer het nogmaals.
     order_number: Bestelling %{number}
     order_processed_successfully: Je bestelling is succesvol verwerkt
-    order_resumed:
+    order_resumed: 
     order_state:
       address: adres
       awaiting_return: wachten op retour
@@ -836,7 +840,7 @@ nl:
       cart: winkelwagen
       complete: voltooid
       confirm: bevestigen
-      considered_risky:
+      considered_risky: 
       delivery: verzendmethode
       payment: betalen
       resumed: hervatten
@@ -846,7 +850,7 @@ nl:
     order_total: Bestelling totaal
     order_updated: Bestelling gewijzigd
     orders: Bestellingen
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Niet op voorraad
     overview: Overzicht
     package_from: pakketje van
@@ -859,8 +863,8 @@ nl:
     path: Pad
     pay: Betalen
     payment: Betaling
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Betaalmethode
     payment_method: Betaalmethode
     payment_method_not_supported: Betaalmethode wordt niet ondersteund
@@ -881,7 +885,7 @@ nl:
       void: Ongeldig
     payment_updated: Betaling bijgewerkt
     payments: Betalingen
-    pending:
+    pending: 
     percent: Procent
     percent_per_item: Procent per item
     permalink: Permalink
@@ -890,13 +894,13 @@ nl:
     please_define_payment_methods: Definieer eerst een betaalmethode.
     populate_get_error: Er ging iets mis. Probeer het nogmaals.
     powered_by: Mede mogelijk gemaakt door
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Presentatie
     previous: vorige
-    previous_state_missing:
+    previous_state_missing: 
     price: Prijs
     price_range: Prijsklasse
     price_sack: Prijsvork
@@ -908,10 +912,10 @@ nl:
     product_properties: Producteigenschappen
     product_rule:
       choose_products: Kies producten
-      label:
+      label: 
       match_all: alle
       match_any: op zijn minst één
-      match_none:
+      match_none: 
       product_source:
         group: Van productgroep
         manual: Handmatige keuze
@@ -923,14 +927,14 @@ nl:
         description: Past de prijs van een order aan gebaseerd op een promotie.
         name: Maak aanpassing
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Vult de kar met de aangegeven hoeveelheid van variant
         name: Maak regel
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Acties
     promotion_form:
       match_policies:
@@ -948,27 +952,27 @@ nl:
         description: Klant moet een specifieke pagina bezocht hebben
         name: Landings Pagina
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Bestelling bevat de volgende producten
         name: Product(en)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Alleen beschikbaar voor de volgende gebruikers
         name: Gebruiker
       user_logged_in:
         description: Alleen beschikbaar voor aangemelde gebruikers
         name: Gebruik aangemeld
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Acties
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Eigenschappen
     property: Eigenschap
     prototype: Prototype
@@ -979,46 +983,46 @@ nl:
     quantity: Hoeveelheid
     quantity_returned: Aantal geretourneerd
     quantity_shipped: Aantal verzonden
-    quick_search:
+    quick_search: 
     rate: Tarief
     reason: Reden
     receive: ontvangen
     receive_stock: Ontvang voorraad
     received: Ontvangen
-    reception_status:
+    reception_status: 
     reference: Verwijzing
     refund: Terugbetaling
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Registreer als een nieuwe gebruiker
     registration: Registratie
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Onthouden
     remove: Verwijderen
     rename: Hernoemen
-    report:
+    report: 
     reports: Rapporten
     resend: Opnieuw verzenden
     reset_password: Reset mijn wachtwoord
@@ -1027,29 +1031,29 @@ nl:
     resumed: Hervat
     return: Terugzenden
     return_authorization: Retour
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Retour bijgewerkt
     return_authorizations: Retouren
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Retour aantal
     returned: Teruggezonden
-    returns:
+    returns: 
     review: Beoordeel
     risk: Risico
     risk_analysis: Risicoanalyse
-    risky:
+    risky: 
     rma_credit: RMA krediet
     rma_number: RMA nummer
     rma_value: RMA waarde
     roles: Rollen
     rules: Regels
-    safe:
+    safe: 
     sales_total: Omzet
     sales_total_description: Totaalbedrag van alle verkopen
     sales_totals: Verkoopstotaal
@@ -1064,8 +1068,8 @@ nl:
     secure_connection_type: Type beveiligde verbinding
     security_settings: Beveiligingsinstellingen
     select: Selecteer
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Selecteer vanuit prototype
     select_stock: Kies voorraad
     send_copy_of_all_mails_to: Verstuur kopie van alle e-mails naar
@@ -1078,7 +1082,7 @@ nl:
     ship_total: Verzend totaal
     shipment: Verzending
     shipment_adjustments: Verzending aanpassingen
-    shipment_details:
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Beste klant
@@ -1091,13 +1095,13 @@ nl:
     shipment_state: Verzendstatus
     shipment_states:
       backorder: nabestelling
-      canceled:
+      canceled: 
       partial: gedeeltelijk
       pending: in afwachting
       ready: voltooid
       shipped: verzonden
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Verzendingen
     shipped: verzonden
     shipping: Verzenden
@@ -1111,67 +1115,67 @@ nl:
     shipping_method: Verzendwijze
     shipping_methods: Verzendwijzen
     shipping_price_sack: Prijsvork
-    shipping_total:
+    shipping_total: 
     shop_by_taxonomy: Winkelen per %{taxonomy}
     shopping_cart: Winkelwagen
     show: Toon
     show_active: Toon actieve
     show_deleted: Toon verwijderde items
     show_only_complete_orders: Toon enkel afgewerkte bestellingen
-    show_only_considered_risky:
+    show_only_considered_risky: 
     show_rate_in_label: Toon tarief naast naam
     sku: Sku
-    skus:
+    skus: 
     slug: Verkorte URL
     source: Bron
     special_instructions: Speciale instructies
     split: Splits
     spree_gateway_error_flash_for_checkout: Er was een probleem met je betaal gegevens. Controleer je gegevens en probeer het opnieuw.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Start
     state: Status
     state_based: Status gebaseerd
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Statussen
     states_required: Vereiste statussen
     status: Status
-    stock:
+    stock: 
     stock_location: Voorraadlocatie
     stock_location_info: Voorraadlocatie info
     stock_locations: Voorraadlocaties
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Voorraadbeheer
     stock_management_requires_a_stock_location: Voorraadbeheer vereist een voorraadlocatie
     stock_movements: Voorraadverplaatsing
@@ -1185,17 +1189,17 @@ nl:
     street_address_2: Adres 2
     subtotal: Subtotaal
     subtract: Verreken
-    success:
+    success: 
     successfully_created: "%{resource} is succesvol aangemaakt!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} is succesvol verwijderd!"
     successfully_signed_up_for_analytics: Succesvol aangemeld voor Spree Analytics
     successfully_updated: "%{resource} is succesvol bijgewerkt!"
-    summary:
+    summary: 
     tax: Belasting
     tax_categories: Belastingcategorieën
     tax_category: Belastingcategorie
-    tax_code:
+    tax_code: 
     tax_included: Inclusief belasting
     tax_rate_amount_explanation: 'Belastingtarieven zijn een decimaal getal. (bijvoorbeeld: als het tarief 21% is vul je 0.21 in)'
     tax_rates: Belastingtarieven
@@ -1203,10 +1207,10 @@ nl:
     taxon_edit: Bewerk taxon
     taxon_placeholder: Taxonomie toevoegen
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taxonomieën
     taxonomy: Taxonomie
     taxonomy_edit: Bewerk taxonomie
@@ -1223,24 +1227,24 @@ nl:
     thank_you_for_your_order: Hartelijk dank voor je bestelling. Je kan deze pagina afdrukken als bewijs van bestelling.
     there_are_no_items_for_this_order: Er zijn geen items voor deze bestelling
     there_were_problems_with_the_following_fields: Er zijn problemen met de volgende velden
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Tijd
     to_add_variants_you_must_first_define: Om varianten toe te voegen dien je er eerst te definiëren
     total: Totaal
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
     track_inventory: Voorraadbeheer
     tracking: Tracking
     tracking_number: Tracking nummer
     tracking_url: Tracking URL
     tracking_url_placeholder: bv. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Overdracht van
     transfer_stock: Voorraadoverdracht
     transfer_to_location: Overdracht naar
@@ -1248,7 +1252,7 @@ nl:
     type: Type
     type_to_search: Typ om te zoeken
     unable_to_connect_to_gateway: Kon geen verbinding maken met de betaalserver.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Minder dan %{price}
     unlock: Ontgrendel
     unrecognized_card_type: Niet herkend kaart type
@@ -1256,7 +1260,7 @@ nl:
     update: Aanpassen
     updating: Aan het bijwerken
     usage_limit: Gebruikslimiet
-    use_app_default:
+    use_app_default: 
     use_billing_address: Gebruik factuuradres
     use_new_cc: Gebruik een nieuwe kaart
     use_s3: Gebruik Amazon S3 Voor Afbeeldingen
@@ -1266,12 +1270,12 @@ nl:
     users: Gebruikers
     validation:
       cannot_be_less_than_shipped_units: kan niet minder zijn dan het aantal verzonden producten.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: overschrijdt beschikbare voorraad. Zorg dat je een juiste hoeveelheid hebt ingevuld per bestelregel.
       is_too_large: is te veel - voorraad kan de aanvraag niet aan!
       must_be_int: moet een getal zijn
       must_be_non_negative: moet een positief getal zijn
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Waarde
     variant: Variant
     variant_placeholder: Kies een variant

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,3 +1,4 @@
+---
 pl:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ pl:
         state: Województwo
         zipcode: Kod pocztowy
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +25,10 @@ pl:
         name: Nazwa
         numcode: Kod ISO
       spree/credit_card:
-        base:
+        base: 
         cc_type: Typ
         month: Miesiąc
-        name:
+        name: 
         number: Numer
         verification_value: Wartość weryfikacyjna
         year: Rok
@@ -73,7 +74,7 @@ pl:
       spree/payment:
         amount: Wartość
       spree/payment_method:
-        name:
+        name: 
       spree/product:
         available_on: Dostępne od
         cost_currency: Waluta kosztu
@@ -91,11 +92,11 @@ pl:
         event_name: Nazwa zdarzenia
         expires_at: Data wygaśnięcia
         name: Nazwa
-        path: "Ścieżka"
+        path: Ścieżka
         starts_at: Data rozpoczęcia
         usage_limit: Limit wykorzystania
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Nazwa
         presentation: Prezentacja
@@ -109,20 +110,20 @@ pl:
         abbr: Skrót
         name: Nazwa
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Opis
         name: Nazwa
@@ -157,47 +158,47 @@ pl:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: Ważność karty wygasła
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Adres
@@ -208,42 +209,42 @@ pl:
       spree/credit_card:
         one: Karta kredytowa
         other: Karty kredytowe
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Jednostka magazynowa
         other: Jednostki magazynowe
       spree/line_item:
         one: Jednostka linii
         other: Jednostki linii
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Zamówienie
         other: Zamówienia
       spree/payment:
         one: Płatność
         other: Płatności
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Produkt
         other: Produkty
       spree/promotion:
         one: Promocja
         other: Promocje
-      spree/promotion_category:
+      spree/promotion_category: 
       spree/property:
         one: Własność
         other: Własności
       spree/prototype:
         one: Prototyp
         other: Prototypy
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Autoryzacja zwrotna
         other: Autoryzacje zwrotne
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Rola
         other: Role
@@ -253,16 +254,16 @@ pl:
       spree/shipping_category:
         one: Kategoria wysyłki
         other: Kategorie wysyłki
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: Stan
         other: Stany
-      spree/state_change:
+      spree/state_change: 
       spree/stock_location:
         one: Lokalizacja magazynu
         other: Lokalizacje magazynu
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Kategoria podatku
         other: Kategorie podatku
@@ -275,7 +276,7 @@ pl:
       spree/taxonomy:
         one: Taksonomia
         other: Taksonomie
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: Użytkownik
         other: Użytkownicy
@@ -287,10 +288,10 @@ pl:
         other: Strefy
   spree:
     abbreviation: Skrót
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Konto
     account_updated: Konto uaktualnione
     action: Działanie
@@ -303,7 +304,7 @@ pl:
       list: Lista
       listing: Wypisuje
       new: Nowy
-      refund:
+      refund: 
       save: Zachowaj
       update: Uaktualnij
     activate: Uaktywnij
@@ -311,7 +312,7 @@ pl:
     add: Dodaj
     add_action_of_type: Dodaj działanie typu
     add_country: Dodaj kraj
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Dodaj nowy nagłówek
     add_new_style: Dodaj nowy styl
     add_one: Dodaj jeden
@@ -327,7 +328,7 @@ pl:
     additional_item: Dodatkowy koszt jednostki
     address1: Adres
     address2: Adres (cd.)
-    adjustable:
+    adjustable: 
     adjustment: Poprawka
     adjustment_amount: Ilość
     adjustment_successfully_closed: Zamknięto poprawkę!
@@ -337,36 +338,36 @@ pl:
     admin:
       tab:
         configuration: Konfiguracja
-        option_types:
+        option_types: 
         orders: Zamówienia
         overview: Przegląd
         products: Produkty
+        promotion_categories: 
         promotions: Promocje
-        promotion_categories:
-        properties:
-        prototypes:
+        properties: 
+        prototypes: 
         reports: Raporty
-        taxonomies:
-        taxons:
+        taxonomies: 
+        taxons: 
         users: Użytkownicy
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administracja
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Zgoda na politykę prywatności
     agree_to_terms_of_service: Zgoda na warunki serwisu
     all: Wszystko
     all_adjustments_closed: Zamknięto wszystkie poprawki!
     all_adjustments_opened: Otwarto wszystkie poprawki!
     all_departments: Wszystkie działy
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Wykorzystuj SSL w trybie rozwojowym i testowym
     allow_ssl_in_production: Wykorzystuj SSL w trybie produkcyjnym
     allow_ssl_in_staging: Wykorzystuj SSL w trybie postoju
@@ -380,73 +381,73 @@ pl:
     analytics_desc_list_2: Wymaga jedynie aktywacji darmowego konta Spree
     analytics_desc_list_3: Nie trzeba instalować żadnego kodu
     analytics_desc_list_4: Całkiem za darmo!
-    analytics_trackers: "Śledzenie analizy"
+    analytics_trackers: Śledzenie analizy
     and: i
-    approve:
-    approved_at:
-    approver:
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Na pewno?
     are_you_sure_delete: Na pewno chcesz usunąć ten wpis?
     associated_adjustment_closed: Powiązana poprawka jest zamknięta i nie zostanie przeliczona. Czy chcesz ją otworzyć?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Błąd autoryzacji
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Dostępne od
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Powrót
     back_end: Zaplecze
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Powrót do sklepu
     back_to_users_list: Powrót do listy użytkowników
     backorderable: Możliwość cofnięcia zamówienia
-    backorderable_default:
-    backordered:
+    backorderable_default: 
+    backordered: 
     backorders_allowed: Cofnięcie zamówienia dozwolone
     balance_due: Do zapłaty
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Adres do zapłatya
     billing: Zapłata
     billing_address: Adres do zapłaty
     both: Oba
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Kalkulator
     calculator_settings_warning: Jeśli zmieniasz typ kalkulatora, musisz najpierw zachować dane przed edycją ustawień.
     cancel: Rezygnuj
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: Nie możesz utworzyć płatności dla zamówienia, jeżeli nie zdefiniowano żadnych metod płatności.
     cannot_create_returns: Nie można utworzyć zwrotu ponieważ w tym zamówieniu nie wysłano żadnego towaru.
     cannot_perform_operation: Nie można wykonać żądanej operacji
     cannot_set_shipping_method_without_address: Nie można ustawić metody wysyłki bez uzupełnienie danych klienta.
     capture: Przechwyć
-    capture_events:
+    capture_events: 
     card_code: Kod karty
     card_number: Numer karty
-    card_type:
+    card_type: 
     card_type_is: Typ karty to
     cart: Koszyk
-    cart_subtotal:
+    cart_subtotal: 
     categories: Kategorie
     category: Kategoria
-    charged:
+    charged: 
     check_for_spree_alerts: Sprawdź alarmy Spree
     checkout: Złożenie zamówienia
     choose_a_customer: Wybierz klienta
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Wybierz walutę
     choose_dashboard_locale: Wybierz ustawienia regionalne konsoli
-    choose_location:
+    choose_location: 
     city: Miasto
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Powiel
     close: Zamknij
     close_all_adjustments: Zamknij wszystkie poprawki
@@ -463,7 +464,7 @@ pl:
     cost_currency: Waluta kosztu
     cost_price: Cena kosztu
     could_not_connect_to_jirafe: Nie można połączyć się z Jirafe w celu synchronizacji danych. Próba zostanie automatycznie ponowiona.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: Wystąpił błąd przy próbie zachowania tego przesunięcia magazynowego. Spróbuj ponownie później.
     count_on_hand: Policz dostępne
     countries: Kraje
@@ -484,17 +485,17 @@ pl:
     coupon_code_max_usage: Przekroczono limit wykorzystania kodu kuponu
     coupon_code_not_eligible: Podany kod kuponu nie jest możliwy do wykorzystania z tym zamówieniem
     coupon_code_not_found: Podany kod kuponu nie istnieje. Spróbuj ponownie.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Utwórz
     create_a_new_account: Utwórz nowe konto
-    create_new_order:
-    create_reimbursement:
+    create_new_order: 
+    create_reimbursement: 
     created_at: Utworzono
     credit: Kredyt
     credit_card: Karta kredytowa
     credit_cards: Karty kredytowe
     credit_owed: Należny kredyt
-    credits:
+    credits: 
     currency: Waluta
     currency_decimal_mark: Znak dziesiętny waluty
     currency_settings: Ustawienia waluty
@@ -505,20 +506,20 @@ pl:
     customer: Klient
     customer_details: Dane klienta
     customer_details_updated: Uaktualniono dane klienta
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Przeszukaj bazę klientów
     cut: Wytnij
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: Identyfikator aplikacji
-        app_token: "Żeton aplikacji"
+        app_token: Żeton aplikacji
         currently_unavailable: Jirafe jest niedostępna. Spree połączy się z Jirafe automatycznie, jak tylko będzie to możliwe.
         explanation: Pola poniżej mogą już być wypełnione jeżeli wybrano rejestrację z Jirafe w konsoli administratora.
         header: Ustawienia analityki Jirafe
         site_id: Identyfikator miejsca
-        token: "Żeton"
+        token: Żeton
       jirafe_settings_updated: Uaktualniono ustawienia Jirafe.
     date: Data
     date_completed: Data uaktualniona
@@ -528,48 +529,48 @@ pl:
       js_format: yy/mm/dd
     date_range: Zakres dat
     default: Domyślny
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Domyślny podatek
     default_tax_zone: Domyślna strefa podatkowe
     delete: Usuń
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Dostawa
     depth: Głębokość
     description: Opis
     destination: Przeznaczenie
     destroy: Zniszcz
-    details:
+    details: 
     discount_amount: Wielkość rabatu
     dismiss_banner: Dziękuję, ale nie! Nie interesuje mnie to i nie wyświetlaj więcej tej wiadomości
     display: Wyświetl
     display_currency: Wyświetl walutę
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Edycja
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Edycja użytkownika
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: E-mail
     empty: Pusty
     empty_cart: Pusty koszyk
     enable_mail_delivery: Włącz dostawę pocztą
     end: Koniec
     ending_in: Koniec w
-    environment: "Środowisko"
+    environment: Środowisko
     error: błąd
     errors:
       messages:
@@ -594,19 +595,21 @@ pl:
         user:
           signup: Rejestracja użytkownika
     exceptions:
-      count_on_hand_setter: Nie można ręcznie ustawić count_on_hand, ponieważ jest ustawione automatycznie przez wywołanie recalculate_count_on_hand. Zamiast tego użyj `update_column(:count_on_hand, value)`.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: >-
+        Nie można ręcznie ustawić count_on_hand, ponieważ jest ustawione automatycznie przez wywołanie recalculate_count_on_hand. Zamiast tego
+        użyj `update_column(:count_on_hand, value)`.
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Wygaśnięcie
     extension: Rozszerzenie
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Nazwa pliku
     fill_in_customer_info: Uzupełnij informację o kliencie
     filter_results: Wyniki filtra
     finalize: Zakończ
-    finalized:
+    finalized: 
     find_a_taxon: Znajdź takson
     first_item: Koszt pierwszej sztuki
     first_name: Imię
@@ -616,7 +619,7 @@ pl:
     flexible_rate: Stawka elastyczna
     forgot_password: Zapomniałeś hasła?
     free_shipping: Darmowa wysyłka
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Przód
     gateway: Brama
     gateway_config_unavailable: Brak bramy dla środowiska
@@ -637,33 +640,33 @@ pl:
       localization_settings: Ustawienia regionalne
       this_file_language: Polski (PL)
     icon: Ikona
-    identifier:
+    identifier: 
     image: Obraz
     images: Obrazy
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Cena zawiera
     included_price_validation: nie można wybrać dopóki nie ustawiono domyślnej strefy podatkoej
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: Podaj swój e-mail w poniższym formularzu
     insufficient_stock: Zbyt mały stan magazynowy, zostało jedynie %{on_hand}
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Przechwyć adres e-mail
     intercept_email_instructions: Nadpisz e-mail odbiorcy tym adresem.
     internal_name: Nazwa wewnętrzna
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Niepoprawny dostawca płatności.
     invalid_promotion_action: Niepoprawna działanie promocyjne.
     invalid_promotion_rule: Niepoprawna reguła promocyjna.
     inventory: Inwentarz
     inventory_adjustment: Poprawka inwentarza
     inventory_error_flash_for_insufficient_quantity: Pozycja w Twoim koszyku nie jest już dostępna.
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: nie jest dostępny dla adresu wysyłki
     iso_name: Nazwa Iso
     item: Pozycja
@@ -676,23 +679,23 @@ pl:
         lt: mniej niż
         lte: mniejszy lub równy
     items_cannot_be_shipped: Nie można było obliczyć stawek wysyłki dla wybranych pozycji.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Scieżka
     last_name: Nazwisko
     last_name_begins_with: Nazwisko zaczyna się na
     learn_more: Dowiedz się więcej
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Lista
-    loading: "Ładuję"
+    loading: Ładuję
     locale_changed: Zmieniono ustawienia regionalne
     location: Lokalizacja
     lock: Zablokuj
-    log_entries:
+    log_entries: 
     logged_in_as: Zalogowano jako
     logged_in_succesfully: Zalogowano
     logged_out: Wylogowano.
@@ -701,23 +704,23 @@ pl:
     login_failed: Uwierzytelnienie nie powiodło się.
     login_name: Zaloguj
     logout: Wyloguj
-    logs:
+    logs: 
     look_for_similar_items: Szukaj podobnych pozycji
     make_refund: Wykonaj zwrot kosztów
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Cena główna
     match_choices:
       all: Wszystkie
       none: Nic
     max_items: Maksymalna ilość pozycji
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Metaopis
     meta_keywords: Metasłowa kluczowe
-    meta_title:
+    meta_title: 
     metadata: Metadane
     minimal_amount: Minimalna ilość
     month: Miesiąc
@@ -726,13 +729,13 @@ pl:
     my_account: Moje konto
     my_orders: Moje zamówienia
     name: Nazwa
-    name_on_card:
+    name_on_card: 
     name_or_sku: Nazwa lub SKU (wprowadź przynajmniej 4 pierwsze litery nazwy produktu)
     new: Nowy
     new_adjustment: Nowa poprawka
-    new_country:
+    new_country: 
     new_customer: Nowy klient
-    new_customer_return:
+    new_customer_return: 
     new_image: Nowy obraz
     new_option_type: Nowy typ opcji
     new_order: Nowe zamówienie
@@ -741,14 +744,14 @@ pl:
     new_payment_method: Nowa metoda płatności
     new_product: Nowy produkt
     new_promotion: Nowa promocja
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Nowa własność
     new_prototype: Nowy prototyp
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Nowa autoryzacja powrotna
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Nowa kategoria wysyłki
     new_shipping_method: Nowa metoda wysyłki
     new_state: Nowy stan
@@ -765,24 +768,24 @@ pl:
     new_zone: Nowa strefa
     next: Następny
     no_actions_added: Nie dodano działania
-    no_payment_found:
+    no_payment_found: 
     no_pending_payments: Brak zawieszonych płatności
     no_products_found: Nie znaleziono produktów
     no_resource_found: Nie znaleziono %{resource}
     no_results: Brak wyników
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: Nie dodano reguł
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: Nie wprowadzono żadneych danych śledzących.
     none: Brak
-    none_selected:
+    none_selected: 
     normal_amount: Zwykład ilość
     not: nie
     not_available: Niedostępne
     not_enough_stock: Zbyt mała ilość towaru w lokalizacji źródłowej, by dokończyć to przeniesienie.
     not_found: Nie znaleziono %{resource}
-    note:
+    note: 
     notice_messages:
       product_cloned: Produkt został powielony
       product_deleted: Produkt został usunięty
@@ -790,7 +793,7 @@ pl:
       product_not_deleted: Nie można było usunąć produktu
       variant_deleted: Odmiana została usunięta
       variant_not_deleted: Nie można było usunąć odmiany
-    num_orders:
+    num_orders: 
     on_hand: na stanie
     open: Otwórz
     open_all_adjustments: Otwórz wszystkie poprawki
@@ -805,9 +808,9 @@ pl:
     or_over_price: "%{price} lub więcej"
     order: Zamówienie
     order_adjustments: Poprawki zamówienia
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Szczegóły zamówienia
     order_email_resent: Wysłano ponownie e-mail z zamówieniem
     order_information: Informacja o zamówieniu
@@ -817,24 +820,24 @@ pl:
         instructions: Twoje zamówienie zostało anulowane. Zachowaj na wszelki wypadek tę infromację.
         order_summary_canceled: Podsumowanie zamówienia [ANULOWANO]
         subject: Anulowanie zamówienia
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
+        dear_customer: 
+        instructions: 
+        order_summary: 
+        subject: 
+        subtotal: 
         thanks: Dziękujemy za zakupy.
-        total:
+        total: 
     order_not_found: Nie mogliśmy odnaleźć Twojego zamówienia. Prosimy spróbować ponownie.
-    order_number:
+    order_number: 
     order_populator:
       out_of_stock: Brak %{item} w magazynie.
       please_enter_reasonable_quantity: Podaj rozsądną ilość.
-      selected_quantity_not_available: ! 'wybrana dla %{item} nie jest dostępna.'
+      selected_quantity_not_available: wybrana dla %{item} nie jest dostępna.
     order_processed_successfully: Twoje zamówienie zostało przetworzone
-    order_resumed:
+    order_resumed: 
     order_state:
       address: adres
       awaiting_return: czeka na zwrot
@@ -852,7 +855,7 @@ pl:
     order_total: Całkowita wartość zamówienia
     order_updated: Uaktualniono zamówienie
     orders: Zamówienia
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Brak w magazynie
     overview: Przegląd
     package_from: paczka z
@@ -862,14 +865,14 @@ pl:
       truncate: "…"
     password: Hasło
     paste: Wklej
-    path: "Ścieżka"
+    path: Ścieżka
     pay: zapłać
     payment: Płatność
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Informacja o płatności
     payment_method: Metoda płatności
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Metody płatności
     payment_processing_failed: Nie udało się przetworzyć płatności, sprawdź podane przez Ciebie dane
     payment_processor_choose_banner_text: Jeśli potrzebujesz pomocy przy wyborze sposobu przetwarzania płatności, odwiedź
@@ -887,7 +890,7 @@ pl:
       void: nieważny
     payment_updated: Płatność uaktualniona
     payments: Płatności
-    pending:
+    pending: 
     percent: procent
     percent_per_item: Procent na pozycję
     permalink: Permalink
@@ -896,13 +899,13 @@ pl:
     please_define_payment_methods: Zdefiniuj najpierw jakieś metody płatności.
     populate_get_error: Coś poszło źle. Spróbuj ponownie dodać pozycję.
     powered_by: Działa dzięki
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Prezentacja
     previous: Poprzedni
-    previous_state_missing:
+    previous_state_missing: 
     price: Cena
     price_range: Zakres cen
     price_sack: Worek cenowy
@@ -914,10 +917,10 @@ pl:
     product_properties: Własności produktu
     product_rule:
       choose_products: Wybierz produkty
-      label:
+      label: 
       match_all: wszystkie
       match_any: co najmniej jeden
-      match_none:
+      match_none: 
       product_source:
         group: Z grupy produktów
         manual: Wybierz ręcznie
@@ -929,14 +932,14 @@ pl:
         description: Tworzy poprawkę kredytu promocyjnego w zamówieniu
         name: Utwórz poprawkę
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Zapełnia koszyk określoną ilością odmiany
         name: Utwórz pozycje linii
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Działania
     promotion_form:
       match_policies:
@@ -954,27 +957,27 @@ pl:
         description: Klient musiał odwiedzić konkretną stronę
         name: Strona przekierowująca
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Zamówienie zawiera określone produkty
         name: Produkt(y)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Dostępne tylko dla okreśłonych użytkowników
         name: Użytkownik
       user_logged_in:
         description: Dostępne tylko dla zalogowanych użytkowników
         name: Zalogowany użytkownik
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promocje
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Właściwości
     property: Własność
     prototype: Prototyp
@@ -991,40 +994,40 @@ pl:
     receive: Odbierz
     receive_stock: Odbierz magazyn
     received: Odebrane
-    reception_status:
+    reception_status: 
     reference: Odnośnik
     refund: Zwrot funduszy
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Zarejestruj
     registration: Rejestracja
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Zapamiętaj mnie
     remove: Usuń
     rename: Zmień nazwę
-    report:
+    report: 
     reports: Raporty
     resend: Prześlij ponownie
     reset_password: Ponownie ustaw moje hasło
@@ -1033,16 +1036,16 @@ pl:
     resumed: Wznowiono
     return: zwróć
     return_authorization: Autoryzacja zwrotu
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Uaktualniono autoryzację zwrotu
     return_authorizations: Autoryzacje zwrotu
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Zwracana ilość
     returned: Zwrócono
     returns: Zwroty
@@ -1060,7 +1063,7 @@ pl:
     sales_total_description: Sprzedaż razem dla wszystkich zamówień
     sales_totals: Suma sprzedaży
     save_and_continue: Zachowaj i kontynuuj
-    save_my_address:
+    save_my_address: 
     say_no: Nie
     say_yes: Tak
     scope: Zakres
@@ -1070,11 +1073,11 @@ pl:
     secure_connection_type: Typ bezpiecznego połączenia
     security_settings: Ustawienia bezpieczeństwa
     select: Wybierz
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Wybierz z prototypu
     select_stock: Wybierz magazyn
-    selected_quantity_not_available: ! 'wybrana dla %{item} nie jest dostępna.'
+    selected_quantity_not_available: wybrana dla %{item} nie jest dostępna.
     send_copy_of_all_mails_to: Wyślij kopię wszystkich wiadomości do
     send_mails_as: Wyślij wiadomości jako
     server: Serwer
@@ -1084,8 +1087,8 @@ pl:
     ship_address: Adres wysyłki
     ship_total: Wartość wysyłki
     shipment: Wysyłka
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Szanowny Kliencie,\n
@@ -1103,8 +1106,8 @@ pl:
       pending: oczekujące
       ready: gotowe
       shipped: wysłane
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Wysyłki
     shipped: Wysłane
     shipping: Koszt wysyłki
@@ -1118,7 +1121,7 @@ pl:
     shipping_method: Metoda wysyłki
     shipping_methods: Metody wysyłki
     shipping_price_sack: Worek cenowy
-    shipping_total:
+    shipping_total: 
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: Koszyk
     show: Pokaż
@@ -1128,49 +1131,49 @@ pl:
     show_only_considered_risky: Pokaż tylko zamówienia ryzykowne
     show_rate_in_label: Pokaż stawkę w etykiecie
     sku: SKU
-    skus:
-    slug:
-    source: "Źródło"
+    skus: 
+    slug: 
+    source: Źródło
     special_instructions: Specjalne instrukcje
     split: Podziel
     spree_gateway_error_flash_for_checkout: Był problem z Twoimi informacjami, dotyczącymi płatności. Sprawdź dane i spróbuj ponownie.
     ssl:
-      change_protocol: "Proszę zmienić protokół na HTTP (zamiast HTTPS) i powtórzyć żądanie"
+      change_protocol: Proszę zmienić protokół na HTTP (zamiast HTTPS) i powtórzyć żądanie
     start: Start
     state: Województwo
     state_based: Stan oparty na
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Stany
     states_required: Wymagane stany
     status: Status
@@ -1178,7 +1181,7 @@ pl:
     stock_location: Lokalizacja magazynu
     stock_location_info: Informacja o lokalizacji magazynu
     stock_locations: Lokalizacje magazynów
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Zarządzanie magazynami
     stock_management_requires_a_stock_location: Aby zarządzać magazynami utwórz lokalizację magazynu.
     stock_movements: Przesunięcia magazynowe
@@ -1192,32 +1195,32 @@ pl:
     street_address_2: Adres ulicy (cd.)
     subtotal: Suma częściowa
     subtract: Odejmij
-    success:
+    success: 
     successfully_created: Utworzono %{resource}!
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: Usunięto %{resource}!
     successfully_signed_up_for_analytics: Zarejestrowano w Analityce Spree
     successfully_updated: Uaktualniono %{resource}!
-    summary:
+    summary: 
     tax: Podatek
     tax_categories: Kategorie podatkowe
     tax_category: Kategoria podatkowa
-    tax_code:
-    tax_included:
+    tax_code: 
+    tax_included: 
     tax_rate_amount_explanation: By ułatwić wyliczenia stawki podatku podane są w notacji dziesiętnej (np. jeśli stawka wynosi 5% wprowadź 0.05)
     tax_rates: Stawki podatku
     taxon: Takson
     taxon_edit: Edycja taksona
     taxon_placeholder: Dodaj takson
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taksonomie
     taxonomy: Taksonomia
     taxonomy_edit: Edycja taksonomii
-    taxonomy_tree_error: "Żądana zmiana nie została zaakceptowana i drzewo wróciło do poprzedniego stanu, spróbuj ponownie."
+    taxonomy_tree_error: Żądana zmiana nie została zaakceptowana i drzewo wróciło do poprzedniego stanu, spróbuj ponownie.
     taxonomy_tree_instruction: "* Menu dla dodawania, usuwania lub sortowania dziecka dostępne jest pod prawym przyciskiem myszy."
     taxons: Taksony
     test: Test
@@ -1230,24 +1233,24 @@ pl:
     thank_you_for_your_order: Dziękujemy za Twoje zainteresowanie. Wydrukuj kopię tej strony na wszelki wypadek.
     there_are_no_items_for_this_order: W zamówieniu brak pozycji. Aby kontynuować, dodaj towar.
     there_were_problems_with_the_following_fields: Wystąpiły problemy z następującymi polami
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Miniatura
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Czas
     to_add_variants_you_must_first_define: Aby dodać odmiany musisz najpierw zdefiniować
     total: razem
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
-    tracking: "Śledzenie przesyłki"
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
+    tracking: Śledzenie przesyłki
     tracking_number: Numer przesyłki
     tracking_url: URL do śledzenia przesyłki
     tracking_url_placeholder: e.g. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Przeniesienie z
     transfer_stock: Przenieś magazyn
     transfer_to_location: Przenieś do
@@ -1255,7 +1258,7 @@ pl:
     type: Typ
     type_to_search: Wpisz wyszukiwaną frazę
     unable_to_connect_to_gateway: Nie można połączyć się z bramą.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Poniżej %{price}
     unlock: Odblokuj
     unrecognized_card_type: Nierozpoznany typ karty
@@ -1263,7 +1266,7 @@ pl:
     update: Uaktualnij
     updating: Uaktualnienie
     usage_limit: Limit wykorzystania
-    use_app_default:
+    use_app_default: 
     use_billing_address: Taki sam jak do zapłaty
     use_new_cc: Wprowadź nową kartę
     use_s3: Wykorzystaj Amazon S3 do obrazów
@@ -1273,12 +1276,12 @@ pl:
     users: Użytkownicy
     validation:
       cannot_be_less_than_shipped_units: nie może być mniejsza niż liczba wysłanych jednostek.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: przekracza dostępny stan magazynowy. Upewnij się, że podano właściwe ilości.
       is_too_large: to zbyt dużo -- dostępny stan w magazynie nie może pokryć zapotrzebowania!
       must_be_int: musi być liczbą całkowitą
       must_be_non_negative: musi być dodatnie
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Wartość
     variant: Odmiana
     variant_placeholder: Wybierz odmianę

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -101,7 +101,7 @@ pt-BR:
         coupon_code: Código do cupom
         created_at: Criado em
         email: Email do cliente
-        included_tax_total:
+        included_tax_total: 
         ip_address: Endereço IP
         item_total: Total de itens
         number: Número
@@ -248,11 +248,11 @@ pt-BR:
         acceptance_status_errors: Erros no Status de Aceitação
         amount: Valor
         charged: Cobrado
-        exchange_variant:
+        exchange_variant: 
         inventory_unit_state: Status da Unidade de Inventário
         item_received?: Item recebido?
-        override_reimbursement_type_id:
-        preferred_reimbursement_type_id:
+        override_reimbursement_type_id: 
+        preferred_reimbursement_type_id: 
         reception_status: Status de Recebimento
         resellable: Revenda
         return_reason: Rasão de Retorno
@@ -389,7 +389,7 @@ pt-BR:
         height: Altura
         price: Preço
         sku: SKU
-        tax_category:
+        tax_category: 
         weight: Peso
         width: Largura
       spree/zone:
@@ -499,8 +499,8 @@ pt-BR:
         one: Taxa Bruta
         other: Taxas Brutas
       spree/calculator/flexi_rate:
-        one:
-        other:
+        one: 
+        other: 
       spree/calculator/free_shipping:
         one: Frete Grátis
         other: Fretes Grátis
@@ -511,8 +511,8 @@ pt-BR:
         one: Porcentagem por Item
         other: Porcentagens por Itens
       spree/calculator/price_sack:
-        one:
-        other:
+        one: 
+        other: 
       spree/calculator/returns/default_refund_amount:
         one: Valor Padrão de Restituição
         other: Valores Padrão de Restituição
@@ -523,17 +523,17 @@ pt-BR:
         one: Taxa Bruta
         other: Taxas Brutas
       spree/calculator/shipping/flexi_rate:
-        one:
-        other:
+        one: 
+        other: 
       spree/calculator/shipping/per_item:
         one: Por Item
         other: Por Itens
       spree/calculator/shipping/price_sack:
-        one:
-        other:
+        one: 
+        other: 
       spree/calculator/tiered_flat_rate:
-        one:
-        other:
+        one: 
+        other: 
       spree/calculator/tiered_percent:
         one: Porcentagem Nivelada
         other: Porcentagens Niveladas
@@ -766,7 +766,7 @@ pt-BR:
     add_variant: Adicionar Variante
     add_variant_properties: Adicionar Propriedades de Variante
     added: Adicionado
-    adding_match:
+    adding_match: 
     additional_item: Item Adicional
     address1: Endereço
     address2: Endereço (cont.)
@@ -779,12 +779,12 @@ pt-BR:
       tax_rates:
         sales_tax: Taxa de venda
         sales_tax_refund: Taxa de restituição de venda
-        sales_tax_refund_with_rate:
-        sales_tax_with_rate:
-        vat:
-        vat_refund:
-        vat_refund_with_rate:
-        vat_with_rate:
+        sales_tax_refund_with_rate: 
+        sales_tax_with_rate: 
+        vat: 
+        vat_refund: 
+        vat_refund_with_rate: 
+        vat_with_rate: 
     adjustment_reasons: Rasões de Ajuste
     adjustment_successfully_closed: Ajuste foi salvo com sucesso!
     adjustment_successfully_opened: Ajuste foi aberto com sucesso!
@@ -853,9 +853,9 @@ pt-BR:
         issued_on: Invalidados em
         new: Novo Crédito da Loja
         no_store_credit_selected: Crédito da Loja não foi selecionado
-        payment_originator: "Pagamento - Pedido #%{order_number}"
+        payment_originator: 'Pagamento - Pedido #%{order_number}'
         reason_for_updating: Rasão de mudança
-        refund_originator: "Restituição - #%{order_number}"
+        refund_originator: 'Restituição - #%{order_number}'
         resource_name: crédito da loja
         select_amount_update_reason: Selecione uma razão para mudar o valor
         select_reason: Selecione uma razão
@@ -865,7 +865,7 @@ pt-BR:
         unable_to_delete: Não foi possível remover Crédito da Loja
         unable_to_invalidate: Não foi possível invalidar Crédito da Loja
         unable_to_update: Não foi possível editar Crédito da Loja
-        user_originator: "Usuário - %{email}"
+        user_originator: Usuário - %{email}
         view: Ver crédito da loja
       stores:
         form:
@@ -957,9 +957,8 @@ pt-BR:
     approver: Aprovador
     are_you_sure: Tem Certeza?
     are_you_sure_delete: Tem certeza que deseja remover este registro?
-    are_you_sure_ship_stock_transfer:
-    associated_adjustment_closed: O ajuste relacionado está fechado e não será recalculado.
-      Você que deixar o ajuste em aberto?
+    are_you_sure_ship_stock_transfer: 
+    associated_adjustment_closed: O ajuste relacionado está fechado e não será recalculado. Você que deixar o ajuste em aberto?
     at_symbol: "@"
     authorization_failure: Falha na Autorização
     authorized: Autorizado
@@ -1006,7 +1005,7 @@ pt-BR:
     back_to_users_list: Voltar a lista de usuários
     back_to_zones_list: Voltar à lista de Zonas
     backorderable: Aceita pedido pendente
-    backorderable_default:
+    backorderable_default: 
     backorderable_header: Pedidos em espera
     backordered: Em espera
     backorders_allowed: permite pedido em espera
@@ -1019,27 +1018,25 @@ pt-BR:
     both: Ambos
     calculated_reimbursements: Reembolsos Calculados
     calculator: Calculadora
-    calculator_settings_warning: Se você alterar o tipo de calculadora, deve-se primeiro
-      confirmar a alteração antes de editar as configurações.
+    calculator_settings_warning: Se você alterar o tipo de calculadora, deve-se primeiro confirmar a alteração antes de editar as configurações.
     cancel: Cancelar
     cancel_inventory: Cancelar Itens
     canceled: Cancelado
     canceled_at: Cancelado em
     canceler: Cancelado por
-    cancellation:
+    cancellation: 
     cannot_create_customer_returns: Não foi possível criar devolução do cliente
     cannot_create_payment_link: Criar link de pagamento
-    cannot_create_payment_without_payment_methods: Você não pode efetuar o pagamento
-      sem definir a forma de pagamento.
-    cannot_create_payment_without_payment_methods_html: Você não pode criar um pagamento para um pedido sem nenhum método de pagamento definido. %{link}
-    cannot_create_returns: Não é possível criar um retorno para esse pedido, pois
-      ele ainda não foi enviado.
+    cannot_create_payment_without_payment_methods: Você não pode efetuar o pagamento sem definir a forma de pagamento.
+    cannot_create_payment_without_payment_methods_html: Você não pode criar um pagamento para um pedido sem nenhum método de pagamento definido.
+      %{link}
+    cannot_create_returns: Não é possível criar um retorno para esse pedido, pois ele ainda não foi enviado.
     cannot_perform_operation: Não foi possível realizar esta operação
     cannot_rebuild_shipments_order_completed: Não é possível refazer envios em um pedido completo
     cannot_rebuild_shipments_shipments_not_pending: Não é possível refazer envios para um pedido com envios não pendentes
-    cannot_set_shipping_method_without_address: Insira os detalhes do cliente para
-      escolher o método de envio
-    cannot_update_email: Você não tem permissão para atualizer o email desse usuário. <br>Por favor contate um administrador se você precisa realizar esta ação
+    cannot_set_shipping_method_without_address: Insira os detalhes do cliente para escolher o método de envio
+    cannot_update_email: Você não tem permissão para atualizer o email desse usuário. <br>Por favor contate um administrador se você precisa realizar
+      esta ação
     capture: Capturar
     capture_events: Capturar eventos
     card_code: Código do Cartão
@@ -1058,8 +1055,7 @@ pt-BR:
     check_stock_on_transfer: Checar estoque na transferência
     checkout: Finalizar Compra
     choose_a_customer: Escolha um cliente
-    choose_a_taxon_to_sort_products_for: Selecione uma árvore de categorias para ordenar
-      os produtos
+    choose_a_taxon_to_sort_products_for: Selecione uma árvore de categorias para ordenar os produtos
     choose_currency: Escolha moeda
     choose_dashboard_locale: Escolha idioma do painel
     choose_location: Escolha um local
@@ -1072,11 +1068,14 @@ pt-BR:
     close: Fechar
     close_all_adjustments: Fechar todos os Ajustes
     close_stock_transfer:
-      confirm: "Tem certeza que quer fechar essa transferência de estoque?\n\nNíveis de estoque vão mudar para os itens recebidos e você não poderá editar a transferência de estoque"
+      confirm: |-
+        Tem certeza que quer fechar essa transferência de estoque?
+
+        Níveis de estoque vão mudar para os itens recebidos e você não poderá editar a transferência de estoque
     code: Código
     company: Empresa
     complete: Completo
-    complete_order:
+    complete_order: 
     configuration: Configuração
     configurations: Configurações
     confirm: Confirme
@@ -1087,11 +1086,9 @@ pt-BR:
     continue_shopping: Continuar Comprando
     cost_currency: Moeda
     cost_price: Preço de Custo
-    could_not_connect_to_jirafe: Não foi possivel se conectar ao Jirafe para sincronizar
-      dados. Será feita outra tentativa mais tarde.
+    could_not_connect_to_jirafe: Não foi possivel se conectar ao Jirafe para sincronizar dados. Será feita outra tentativa mais tarde.
     could_not_create_customer_return: Não foi possível criar o Retorno do Consumidor
-    could_not_create_stock_movement: Ocorreu um problema ao salvar a transferência.
-      Por favor tente novamente.
+    could_not_create_stock_movement: Ocorreu um problema ao salvar a transferência. Por favor tente novamente.
     count_on_hand: Disponíveis
     countries: Países
     country: País
@@ -1120,7 +1117,7 @@ pt-BR:
     create_reimbursement: Criar restituição
     created_at: Criado
     created_by: Criado por
-    created_successfully:
+    created_successfully: 
     credit: Crédito
     credit_allowed: Crédito Permitido
     credit_card: Cartão de Crédito
@@ -1146,10 +1143,8 @@ pt-BR:
       jirafe:
         app_id: App ID
         app_token: App token
-        currently_unavailable: Jirafe esta indisponível no momento. Spree irá se conectar
-          automaticamente com Jirafe quando o serviço estive disponível
-        explanation: Os campos abaixo já podem ser preenchidos if você escolher registrar
-          no painel de administração do Jirafe.
+        currently_unavailable: Jirafe esta indisponível no momento. Spree irá se conectar automaticamente com Jirafe quando o serviço estive disponível
+        explanation: Os campos abaixo já podem ser preenchidos if você escolher registrar no painel de administração do Jirafe.
         header: Configurações do Jirafe Analytics
         site_id: Site ID
         token: Tokan
@@ -1166,18 +1161,17 @@ pt-BR:
     default_tax: Imposto Padrão
     default_tax_zone: Imposto de Zona Padrão
     delete: Apagar
-    deleted_successfully:
-    deleted_variants_present:
+    deleted_successfully: 
+    deleted_variants_present: 
     delivery: Entrega
     depth: Profundidade
     description: Descrição
     destination: Destino
-    destination_location:
+    destination_location: 
     destroy: Remover
     details: Detalhes
     discount_amount: Desconto
-    dismiss_banner: Não, obrigado! Eu não estou interessado, não mostre essa mensagem
-      novamente!
+    dismiss_banner: Não, obrigado! Eu não estou interessado, não mostre essa mensagem novamente!
     display: Mostrar
     display_currency: Mostrar Moeda
     doesnt_track_inventory: Não gerenciar estoque
@@ -1236,14 +1230,15 @@ pt-BR:
     errors:
       messages:
         cannot_delete_finalized_stock_transfer: Transferências de estoque finalizadas não podem ser removidas
-        cannot_delete_transfer_item_with_finalized_stock_transfer: Itens de transferência que fazem parte de uma transferência de estoque finalizada não podem ser removidos
-        cannot_modify_transfer_item_closed_stock_transfer: Itens de transferência que fazem parte de uma transferência de estoque finalizada não podem ser modificados
-        cannot_update_expected_transfer_item_with_finalized_stock_transfer: A quantidade especificada não pode ser modificada em itens que fazem parte de uma transferência de estoque finalizada
+        cannot_delete_transfer_item_with_finalized_stock_transfer: Itens de transferência que fazem parte de uma transferência de estoque finalizada
+          não podem ser removidos
+        cannot_modify_transfer_item_closed_stock_transfer: Itens de transferência que fazem parte de uma transferência de estoque finalizada não
+          podem ser modificados
+        cannot_update_expected_transfer_item_with_finalized_stock_transfer: A quantidade especificada não pode ser modificada em itens que fazem
+          parte de uma transferência de estoque finalizada
         could_not_create_taxon: Não foi possível criar a árvore de categorias
-        no_payment_methods_available: Não existem métodos de pagamentos configurados
-          para esse ambiente
-        no_shipping_methods_available: Não existem métodos de entrega para o local
-          selecionado, por favor troque seu endereço e tente novamente.
+        no_payment_methods_available: Não existem métodos de pagamentos configurados para esse ambiente
+        no_shipping_methods_available: Não existem métodos de entrega para o local selecionado, por favor troque seu endereço e tente novamente.
         transfer_item_insufficient_stock: A variante do item não tem estoque suficiente na origem da transferência
     errors_prohibited_this_record_from_being_saved:
       one: 1 Erro impediu o registro de ser salvo!
@@ -1263,15 +1258,15 @@ pt-BR:
         user:
           signup: Usuário Cadastrado
     exceptions:
-      count_on_hand_setter: Não pode setar coun_on_hand manualmente, esse valor é
-        automaticamente gerado do método recalculate_count_on_hand. Por favor use
-        `update_column(:count_on_hand, value)`.
-    exchange_for:
-    excl:
+      count_on_hand_setter: >-
+        Não pode setar coun_on_hand manualmente, esse valor é automaticamente gerado do método recalculate_count_on_hand. Por favor use `update_column(:count_on_hand,
+        value)`.
+    exchange_for: 
+    excl: 
     existing_shipments: Envios existentes
     expected: Esperado
     expected_items: Itens esperados
-    expedited_exchanges_warning:
+    expedited_exchanges_warning: 
     expiration: Validade
     extension: Extensão
     failed_payment_attempts: Tentativas fracassadas de pagamento
@@ -1283,7 +1278,10 @@ pt-BR:
     finalize: Finalizar
     finalize_all_adjustments: Finalizar Todos os Ajustes
     finalize_stock_transfer:
-      confirm: "Você tem certeza que quer finalizar esta transferência de estoques?\n\nVocê não podera adicionar ou editar nenhum item depois disso"
+      confirm: |-
+        Você tem certeza que quer finalizar esta transferência de estoques?
+
+        Você não podera adicionar ou editar nenhum item depois disso
     finalized: Finalizado
     finalized_at: Finalizado em
     finalized_by: Finalizado por
@@ -1320,25 +1318,30 @@ pt-BR:
     hide_out_of_stock: Esconder fora de estoque
     hints:
       spree/price:
-        country: "Determina em que país o preço é valido.<br>Padrão: Qualquer País"
-        master_variant: "Mudar o preço da variante principal não vai alterar os preços das variantes abaixo mas vai ser utilizado para popular o preço de novas variantes"
+        country: 'Determina em que país o preço é valido.<br>Padrão: Qualquer País'
+        master_variant: >-
+          Mudar o preço da variante principal não vai alterar os preços das variantes abaixo mas vai ser utilizado para popular o preço de novas
+          variantes
         options: Estas opções são utilizadas para criar variantes na tabela de variantes. Elas podem ser alteradas na tab Variantes
       spree/product:
-        promotionable: "Isto determina se promoções podem ou não ser aplicadas a este produto.<br> Padrão: Selecionado"
-        shipping_category: "Isto determina que tipo de envio este produto utiliza.<br> Padrão: Default"
-        tax_category: "Isto determina que tipos de taxas são aplicadas a este produto.<br> Padrão: Nenhuma"
+        promotionable: 'Isto determina se promoções podem ou não ser aplicadas a este produto.<br> Padrão: Selecionado'
+        shipping_category: 'Isto determina que tipo de envio este produto utiliza.<br> Padrão: Default'
+        tax_category: 'Isto determina que tipos de taxas são aplicadas a este produto.<br> Padrão: Nenhuma'
       spree/promotion:
-        expires_at: "Isto determina quando a promoção pode ser aplicada nos pedidos.<br> Se nenhum valor for especificado, a promoção fica disponível imediatamente"
-        starts_at: "Isto determina quando uma promoção expira.<br> Se nenhum valor for especificado, a promoção nunca irá expirar."
+        expires_at: >-
+          Isto determina quando a promoção pode ser aplicada nos pedidos.<br> Se nenhum valor for especificado, a promoção fica disponível imediatamente
+        starts_at: Isto determina quando uma promoção expira.<br> Se nenhum valor for especificado, a promoção nunca irá expirar.
       spree/store:
-        cart_tax_country_iso: "Isto determina que país é usado para taxas nos carrinhos (pedidos ainda sem endereço).<br> Padrão: Nenhum"
+        cart_tax_country_iso: 'Isto determina que país é usado para taxas nos carrinhos (pedidos ainda sem endereço).<br> Padrão: Nenhum'
       spree/tax_rate:
-        validity_period: "Isto determina o período de validade em que a taxa é valida e vai ser aplicada para itens elegíveis.<br> Se a data de inicio não for especificada, a taxa entrará em vigor imediatamente.<br> Se a data de finalização não for especificada, a taxa nunca sairá de vigor."
+        validity_period: >-
+          Isto determina o período de validade em que a taxa é valida e vai ser aplicada para itens elegíveis.<br> Se a data de inicio não for
+          especificada, a taxa entrará em vigor imediatamente.<br> Se a data de finalização não for especificada, a taxa nunca sairá de vigor.
       spree/variant:
         deleted: Variante deletada
-        deleted_explanation: "Esta variante foi deletada em %{date}."
-        deleted_explanation_with_replacement: "Esta variante foi deletada em %{date}. Desde então ela foi substituída por outra com o mesmo SKU"
-        tax_category: "Isto determina que tipo de taxação é aplicada a esta variante.<br> Padrão: Usa o mesmo tipo do produto associado"
+        deleted_explanation: Esta variante foi deletada em %{date}.
+        deleted_explanation_with_replacement: Esta variante foi deletada em %{date}. Desde então ela foi substituída por outra com o mesmo SKU
+        tax_category: 'Isto determina que tipo de taxação é aplicada a esta variante.<br> Padrão: Usa o mesmo tipo do produto associado'
     home: Início
     i18n:
       available_locales: Idiomas disponíveis
@@ -1357,19 +1360,18 @@ pt-BR:
     identifier: Identificador
     image: Imagem
     images: Imagens
-    implement_eligible_for_return: "Deve implementar #eligible_for_return? para seu EligibilityValidator."
-    implement_requires_manual_intervention: "Deve implementar #requires_manual_intervention? para seu EligibilityValidator."
+    implement_eligible_for_return: 'Deve implementar #eligible_for_return? para seu EligibilityValidator.'
+    implement_requires_manual_intervention: 'Deve implementar #requires_manual_intervention? para seu EligibilityValidator.'
     inactive: Inativo
-    incl:
+    incl: 
     included_in_price: Incluso no preço
     included_price_validation: Não pode ser selecionado a menos que você tenha escolhido uma zona de imposto padrão
     incomplete: Incompleto
     info_number_of_skus_not_shown:
+      info_product_has_multiple_skus: 'Este produto tem %{count} variantes:'
       one: e mais um
-      other: "e %{count} outros"
-      info_product_has_multiple_skus: "Este produto tem %{count} variantes:"
-    instructions_to_reset_password: 'Preencha o formulário abaixo e enviaremos instruções
-      de como resetar sua senha por email:'
+      other: e %{count} outros
+    instructions_to_reset_password: 'Preencha o formulário abaixo e enviaremos instruções de como resetar sua senha por email:'
     insufficient_stock: Estoque insuficiente, apenas %{on_hand} em estoque
     insufficient_stock_for_order: Estoque insuficiente para o pedido
     insufficient_stock_lines_present: Algum item do pedido não tem estoque suficiente
@@ -1377,7 +1379,7 @@ pt-BR:
     intercept_email_instructions: Interceptar Instruções de Email
     internal_name: Nome interno
     invalid_credit_card: Cartão de Crédito Inválido
-    invalid_exchange_variant:
+    invalid_exchange_variant: 
     invalid_payment_method_type: Método de pagamento inválido
     invalid_payment_provider: Provedor de pagamento inválido
     invalid_promotion_action: Ação de promoção inválida
@@ -1390,7 +1392,7 @@ pt-BR:
     inventory_not_available: Inventário não disponível para o item %{item}
     inventory_state: Estado do Inventário
     inventory_states:
-      backordered:
+      backordered: 
       canceled: cancelado
       on_hand: em mãos
       returned: retornado
@@ -1399,7 +1401,7 @@ pt-BR:
     iso_name: Nome ISO
     item: Item
     item_description: Descrição do Item
-    item_not_in_stock_transfer:
+    item_not_in_stock_transfer: 
     item_total: Total de Itens
     item_total_rule:
       operators:
@@ -1407,8 +1409,7 @@ pt-BR:
         gte: Maior ou igual que
         lt: Menor que
         lte: Maior ou igual que
-    items_cannot_be_shipped: Estamos impossibilitados de enviar os itens selecionados
-      para seu endereço de entrega. Por favor, escolha outro endereço.
+    items_cannot_be_shipped: Estamos impossibilitados de enviar os itens selecionados para seu endereço de entrega. Por favor, escolha outro endereço.
     items_in_rmas: Itens em Autorização de Retorno de Mercadoria
     items_reimbursed: Itens reembolsados
     items_to_be_reimbursed: Itens a ser reembolsados
@@ -1416,10 +1417,10 @@ pt-BR:
     landing_page_rule:
       path: Caminho
     last_name: Sobrenome
-    last_name_begins_with: 'Sobrenome Começa Com'
+    last_name_begins_with: Sobrenome Começa Com
     learn_more: Aprenda Mais
     lifetime_stats: Histórico
-    line_item_adjustments:
+    line_item_adjustments: 
     list: Lista
     listing_countries: Países
     listing_orders: Pedidos
@@ -1443,7 +1444,7 @@ pt-BR:
     logs: Logs
     look_for_similar_items: Procurar Artigos Similares
     make_refund: Extornar
-    make_sure_the_above_reimbursement_amount_is_correct:
+    make_sure_the_above_reimbursement_amount_is_correct: 
     manage_promotion_categories: Gerenciar categoria de promoções
     manage_stock: Gerenciar Estoque
     manage_variants: Gerenciar variantes
@@ -1472,7 +1473,7 @@ pt-BR:
     negative_movement_absent_item: Não pode criar um movimento negativo para um item de estoque não existente
     new: Novo
     new_adjustment: Novo Ajuste
-    new_adjustment_reason:
+    new_adjustment_reason: 
     new_country: Novo país
     new_customer: Novo Cliente
     new_customer_return: Nova devolução de cliente
@@ -1485,7 +1486,7 @@ pt-BR:
     new_product: Novo Produto
     new_promotion: Nova Promoção
     new_promotion_category: Nova Categoria de promoção
-    new_promotion_code_batch:
+    new_promotion_code_batch: 
     new_property: Nova Propriedade
     new_prototype: Novo Protótipo
     new_refund: Novo reembolso
@@ -1500,7 +1501,7 @@ pt-BR:
     new_stock_movement: Nova movimentação de estoque
     new_stock_transfer: Nova transferência de estoque
     new_store: Nova Loja
-    new_store_credit:
+    new_store_credit: 
     new_tax_category: Nova Categoria de Imposto
     new_tax_rate: Nova Taxa de Imposto
     new_taxon: Nova Árvore de Categorias
@@ -1513,16 +1514,16 @@ pt-BR:
     no_actions_added: Nenhuma ação adicionada
     no_images_found: Nenhuma imagem encontrada
     no_inventory_selected: Nenhum inventário selecionado
-    no_option_values_on_product_html: "Este produto não tem valores de opção associados. Adicione alguns através de Tipos de Opção aqui %{link}."
+    no_option_values_on_product_html: Este produto não tem valores de opção associados. Adicione alguns através de Tipos de Opção aqui %{link}.
     no_orders_found: Nenhum pedido encontrado
     no_payment_found: Nenhum pagamento encontrado
     no_payment_methods_found: Nenhum método de pagamento encontrado
     no_pending_payments: Sem pagamentos pendentes
     no_products_found: Não existem produtos
     no_promotions_found: Nenhuma promoção encontrada
-    no_resource: "Nenhum %{resource} encontrado(a)."
+    no_resource: Nenhum %{resource} encontrado(a).
     no_resource_found: Não existe %{resource}
-    no_resource_found_html: "Nenhum %{resource} encontrado, %{add_one_link}!"
+    no_resource_found_html: Nenhum %{resource} encontrado, %{add_one_link}!
     no_resource_found_link: Criar Um
     no_results: Não existem resultados
     no_returns_found: Nenhum retorno encontrado
@@ -1543,7 +1544,7 @@ pt-BR:
     not_enough_stock: Não há inventório suficiente no estoque para complete essa transferência
     not_found: "%{resource} não encontrado"
     note: Anotação
-    note_already_received_a_refund: "Importante: Este pedido já recebeu uma restituição. Tenha certeza que o valor do reembolso está correto."
+    note_already_received_a_refund: 'Importante: Este pedido já recebeu uma restituição. Tenha certeza que o valor do reembolso está correto.'
     notice_messages:
       product_cloned: Produto Clonado
       product_deleted: Produto Deletado
@@ -1553,7 +1554,7 @@ pt-BR:
       variant_not_deleted: Variante não Pode ser Deletada
     num_orders: Número de pedidos
     number: Número
-    number_of_codes: ! '%{count} códigos'
+    number_of_codes: "%{count} códigos"
     on_hand: Em Estoque
     open: Abrir
     open_all_adjustments: Abrir todos os ajustes
@@ -1568,19 +1569,18 @@ pt-BR:
     or_over_price: "%{price} ou mais"
     order: Pedido
     order_adjustments: Ajustar Pedido
-    order_already_completed:
+    order_already_completed: 
     order_already_updated: Pedido já foi atualizado
     order_approved: Pedido aprovado
     order_canceled: Pedido cancelado
-    order_completed:
+    order_completed: 
     order_details: Detalhes do Pedido
     order_email_resent: Email de confirmação reenviado
     order_information: Informações do pedido
     order_mailer:
       cancel_email:
         dear_customer: Caro Cliente,\n
-        instructions: Seu pedido foi cancelado. Por favor, mantenha esse cancelamento
-          em seus registros.
+        instructions: Seu pedido foi cancelado. Por favor, mantenha esse cancelamento em seus registros.
         order_summary_canceled: Índice de Pedido [Cancelado]
         subject: Cancelamento de Pedido
         subtotal: Subtotal
@@ -1642,14 +1642,11 @@ pt-BR:
     payment_identifier: Identificador de Pagamento
     payment_information: Dados do Pagamento
     payment_method: Método de Pagamento
-    payment_method_not_supported: Esse método de pagamento não é suportado. Por favor
-      escolha outro.
+    payment_method_not_supported: Esse método de pagamento não é suportado. Por favor escolha outro.
     payment_method_settings_warning: Se você está mudando o tipo de pagamento, você deve primeiro salvá-lo antes de poder editar as suas opções
     payment_methods: Métodos de Pagamento
-    payment_processing_failed: Pagamento não foi processado, por favor verifique os
-      detalhes informados.
-    payment_processor_choose_banner_text: Se você precisa de ajuda para escolher um
-      tipo de pagamento, por favor visite
+    payment_processing_failed: Pagamento não foi processado, por favor verifique os detalhes informados.
+    payment_processor_choose_banner_text: Se você precisa de ajuda para escolher um tipo de pagamento, por favor visite
     payment_processor_choose_link: nossa página de pagamentos
     payment_state: Status do Pagamento
     payment_states:
@@ -1674,14 +1671,14 @@ pt-BR:
     phone: Telefone
     place_order: Fazer Pedido
     please_define_payment_methods: Por favor, defina algum método de pagamento.
-    please_enter_reasonable_quantity:
+    please_enter_reasonable_quantity: 
     populate_get_error: Algo está trrado. Tente adicionar o item novamente.
     powered_by: Feito por
     pre_tax_amount: Valor Sem Taxas
     pre_tax_refund_amount: Valor Sem Restituição de Taxas
     pre_tax_total: Total Sem Taxas
-    preference_source_none: '(personalizado)'
-    preference_source_using: 'Usando preferencias estáticas "%{name}"'
+    preference_source_none: "(personalizado)"
+    preference_source_using: Usando preferencias estáticas "%{name}"
     preferred_reimbursement_type: Tipo de Reembolso Preferido
     presentation: Apresentação
     previous: Anterior
@@ -1693,12 +1690,11 @@ pt-BR:
     product: Produto
     product_details: Detalhes do Produto
     product_has_no_description: Produto não tem descrição
-    product_not_available_in_this_currency: Este produto não está disponível na moeda
-      selecionada.
+    product_not_available_in_this_currency: Este produto não está disponível na moeda selecionada.
     product_properties: Propriedades do Produto
     product_rule:
       choose_products: Escolher Produtos
-      label:
+      label: 
       match_all: Todos
       match_any: Pelo Menos Um
       match_none: Nenhum
@@ -1724,15 +1720,15 @@ pt-BR:
     promotion_actions: Ações das Promoções
     promotion_code_batch_mailer:
       promotion_code_batch_errored:
-        message: "Lote de códigos promocionais com erro (%{error}) para promoção: "
+        message: 'Lote de códigos promocionais com erro (%{error}) para promoção: '
         subject: Lote de códigos promocionais com erro
       promotion_code_batch_finished:
-        message: "Todos os %{number_of_codes} códigos promocionais foram criados para a promoção: "
+        message: 'Todos os %{number_of_codes} códigos promocionais foram criados para a promoção: '
         subject: Lote de códigos promocionais finalizado
     promotion_code_batches:
-      errored: "Com erro: %{error}"
-      finished: "Todos os %{number_of_codes} códigos promocionais foram criados."
-      processing: "Processando: %{number_of_codes_processed} / %{number_of_codes}"
+      errored: 'Com erro: %{error}'
+      finished: Todos os %{number_of_codes} códigos promocionais foram criados.
+      processing: 'Processando: %{number_of_codes_processed} / %{number_of_codes}'
     promotion_form:
       match_policies:
         all: Combinar todas regras
@@ -1767,7 +1763,8 @@ pt-BR:
         description: Disponível apenas para usuários logados
         name: Usuário Logado
     promotion_successfully_created: Promoção foi criada com sucesso!
-    promotion_total_changed_before_complete: Um ou mais promoções no seu pedido foram invalidas e foram removidas. Por favor verifique os novos valores do pedido e tente novamente.
+    promotion_total_changed_before_complete: Um ou mais promoções no seu pedido foram invalidas e foram removidas. Por favor verifique os novos
+      valores do pedido e tente novamente.
     promotion_uses: Usos da Promoção
     promotionable: Em promoção
     promotions: Promoções
@@ -1777,8 +1774,7 @@ pt-BR:
     prototype: Protótipo
     prototypes: Protótipos
     provider: Provedor
-    provider_settings_warning: Se está mudando o tipo de provedor, deve salvar antes
-      de editar as configurações
+    provider_settings_warning: Se está mudando o tipo de provedor, deve salvar antes de editar as configurações
     qty: Quantidade
     quantity: Quantidade
     quantity_returned: Quantidade Retornada
@@ -1797,7 +1793,7 @@ pt-BR:
     reception_status: Status do Recebimento
     reference: Referência
     refund: Restituição
-    refund_amount_must_be_greater_than_zero:
+    refund_amount_must_be_greater_than_zero: 
     refund_reasons: Razões para restituição
     refunded_amount: Valor Reembolsado
     refunds: Restituições
@@ -1808,7 +1804,7 @@ pt-BR:
     reimbursement: Restituição
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send: ! 'Você tem %{days} dias para retornar itens aguardando troca.'
+        days_to_send: Você tem %{days} dias para retornar itens aguardando troca.
         dear_customer: Caro cliente,
         exchange_summary: Resumo da Troca
         for: Para
@@ -1840,16 +1836,15 @@ pt-BR:
     return_authorization_reasons: Razões para autorização de devolução
     return_authorization_updated: Autorização de devolução atualizada
     return_authorizations: Autorizações de devolução
-    return_item_inventory_unit_ineligible: Unidade de Inventório do Item Devolvido
-      Inelegível
-    return_item_inventory_unit_reimbursed: Unidade de Inventório do Item Devolvido
-      Reembolsado
+    return_item_inventory_unit_ineligible: Unidade de Inventório do Item Devolvido Inelegível
+    return_item_inventory_unit_reimbursed: Unidade de Inventório do Item Devolvido Reembolsado
     return_item_order_not_completed: Pedido do item de retorno deve estar completo
     return_item_rma_ineligible: RMA de Item Devolvido Inelegível
     return_item_time_period_ineligible: Período de Item Devolvido Inelegível
     return_items: Itens Devolvidos
     return_items_cannot_be_associated_with_multiple_orders: Item de devolução não pode ser associado com multiplos pedidos
-    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: Itens de devolução não podem ser criados para itens de inventário esperando por troca.
+    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: Itens de devolução não podem ser criados para itens
+      de inventário esperando por troca.
     return_number: Número de Devolução
     return_quantity: Quantidade a ser devolvida
     return_reasons: Rasões de Retorno
@@ -1884,7 +1879,7 @@ pt-BR:
     select_a_stock_location: Selecione uma localização de estoque
     select_from_prototype: Selecionar a partir de protótipo
     select_stock: Selecione estoque
-    selected_quantity_not_available: ! 'selecionada de %{item} não está disponível'
+    selected_quantity_not_available: selecionada de %{item} não está disponível
     send_copy_of_all_mails_to: Enviar cópias de todos emails para
     send_mailer: Enviar Email
     send_mails_as: Enviar email como
@@ -1895,7 +1890,10 @@ pt-BR:
     ship_address: Endereço da entrega
     ship_address_required: Endereço de Envio Obrigatório
     ship_stock_transfer:
-      confirm: "Você tem certeza que quer marcar esta transferência de estoque como 'Enviada'?\n\nVocê não poderá fazer mudanças a transferência de estoque depois disso"
+      confirm: |-
+        Você tem certeza que quer marcar esta transferência de estoque como 'Enviada'?
+
+        Você não poderá fazer mudanças a transferência de estoque depois disso
     ship_total: Total no envio
     shipment: Distribuição
     shipment_adjustments: Ajustes de envio
@@ -1966,7 +1964,7 @@ pt-BR:
       authorized: Autorizado
       awaiting: Em aguardo
       awaiting_return: Aguardando retorno
-      backordered:
+      backordered: 
       canceled: Cancelado
       cart: Carrinho
       checkout: Checkout
@@ -1999,11 +1997,9 @@ pt-BR:
     stock_location: Local de Estoque
     stock_location_info: Local de estoque
     stock_locations: Locais de estoque
-    stock_locations_need_a_default_country: Locais de estoque necessitam de um país
-      padrão
+    stock_locations_need_a_default_country: Locais de estoque necessitam de um país padrão
     stock_management: Gerenciamento de estoque
-    stock_management_requires_a_stock_location: Por favor, crie um local de estoque
-      para poder gerenciar o estoque.
+    stock_management_requires_a_stock_location: Por favor, crie um local de estoque para poder gerenciar o estoque.
     stock_movements: Movimentos de estoque
     stock_movements_for_stock_location: Movimentos de estoque por %{stock_location_name}
     stock_not_below_zero: Estoque não mode ser menor que zero
@@ -2018,7 +2014,7 @@ pt-BR:
     store_credit:
       actions:
         invalidate: Invalidar
-      credit_allocation_memo: 'Este é um crédito do crédito da loja ID "%{id}"'
+      credit_allocation_memo: Este é um crédito do crédito da loja ID "%{id}"
       currency_mismatch: Moeda de crédito da loja não é a mesma do pedido
       display_action:
         adjustment: Ajuste
@@ -2040,10 +2036,10 @@ pt-BR:
       non_expiring: Não expirando
       select_one_store_credit: Selecione crédito da loja utilizado no pedido
       store_credit: Crédito da Loja
-      unable_to_credit: "Não foi possível creditar o código: %{auth_code}"
+      unable_to_credit: 'Não foi possível creditar o código: %{auth_code}'
       unable_to_find: Não foi possível encontrar crédito da loja
-      unable_to_find_for_action: "Não foi possível encontrar o crédito da loja para o código %{auth_code} e ação %{action}"
-      unable_to_void: "Não foi possível estornar o código de crédito: %{auth_code}"
+      unable_to_find_for_action: Não foi possível encontrar o crédito da loja para o código %{auth_code} e ação %{action}
+      unable_to_void: 'Não foi possível estornar o código de crédito: %{auth_code}'
       user_has_no_store_credits: Usuário não possui mais crédito da loja
     store_credit_category:
       default: Padrão
@@ -2062,7 +2058,7 @@ pt-BR:
     tax_categories: Categorias de imposto
     tax_category: Categoria de imposto
     tax_code: Código do imposto
-    tax_included: "Taxa (incl.)"
+    tax_included: Taxa (incl.)
     tax_rate_amount_explanation: Valores das taxas são em décimos. (ex. se o valor é 5% insira 0.05)
     tax_rates: Aliquotas de imposto
     taxon: Categoria
@@ -2070,17 +2066,15 @@ pt-BR:
     taxon_placeholder: Adicionar uma árvore de categorias
     taxon_rule:
       choose_taxons: Escolha as Categorias
-      label: "Pedido deve conter %{select} destas categorias"
+      label: Pedido deve conter %{select} destas categorias
       match_all: todos
       match_any: ao menos um
       match_none: nenhum
     taxonomies: Categorias
     taxonomy: Categoria
     taxonomy_edit: Editar Categoria
-    taxonomy_tree_error: A modificação não foi aceita e a árvore retornou ao seu estado
-      anterior, por favor tente novamente.
-    taxonomy_tree_instruction: "* Clique com o botão direito sobre um nó da árvore
-      para ver o menu."
+    taxonomy_tree_error: A modificação não foi aceita e a árvore retornou ao seu estado anterior, por favor tente novamente.
+    taxonomy_tree_instruction: "* Clique com o botão direito sobre um nó da árvore para ver o menu."
     taxons: Árvores de Categorias
     test: Teste
     test_mailer:
@@ -2092,12 +2086,9 @@ pt-BR:
         message: Se você recebeu esse email, suas configurações estão corretas!
         subject: Email de teste!
     test_mode: Modo de teste
-    thank_you_for_your_order: Obrigado por sua compra. Por favor, imprima uma cópia
-      desta página de confirmação para seu controle.
-    there_are_no_items_for_this_order: Não existem itens para esse pedido. Por favor
-      adicione um item ao pedido para continuar.
-    there_were_problems_with_the_following_fields: 'Existem problemas com os seguintes
-      campos:'
+    thank_you_for_your_order: Obrigado por sua compra. Por favor, imprima uma cópia desta página de confirmação para seu controle.
+    there_are_no_items_for_this_order: Não existem itens para esse pedido. Por favor adicione um item ao pedido para continuar.
+    there_were_problems_with_the_following_fields: 'Existem problemas com os seguintes campos:'
     this_order_has_already_received_a_refund: Esse pedindo já recebeu um reembolso
     thumbnail: Miniatura
     tiered_flat_rate: Taxa bruta com Níveis
@@ -2105,8 +2096,7 @@ pt-BR:
     tiers: Níveis
     time: Horário
     to: para
-    to_add_variants_you_must_first_define: Para adicionar variantes você deve primeiro
-      definir
+    to_add_variants_you_must_first_define: Para adicionar variantes você deve primeiro definir
     total: Total
     total_per_item: Total por item
     total_pre_tax_refund: Total do Reembolso sem taxa
@@ -2150,24 +2140,21 @@ pt-BR:
     user: Usuário
     user_role_rule:
       choose_roles: Escolher Funções
-      label: "Usuário deve ter %{select} dessas funções"
+      label: Usuário deve ter %{select} dessas funções
       match_all: todas
       match_any: ao menos uma
     user_rule:
       choose_users: Escolher usuários
     users: Usuários
     validation:
-      cannot_be_less_than_shipped_units: Não pode ser menor que o número de unidades
-        enviadas.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock: excede estoque disponível. Por favor confira se os
-        items tem uma quantia válida.
-      is_too_large: é Muito Grande -- Quantidade em estoque não consegue cobrir este
-        pedido!
+      cannot_be_less_than_shipped_units: Não pode ser menor que o número de unidades enviadas.
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: excede estoque disponível. Por favor confira se os items tem uma quantia válida.
+      is_too_large: é Muito Grande -- Quantidade em estoque não consegue cobrir este pedido!
       must_be_int: deve ser um inteiro
       must_be_non_negative: deve ser um valor positivo ou zero
-      unpaid_amount_not_zero:
-    validity_period:
+      unpaid_amount_not_zero: 
+    validity_period: 
     value: Valor
     variant: Variante
     variant_placeholder: Escolha um produto
@@ -2188,8 +2175,7 @@ pt-BR:
     you_cannot_undo_action: Você não pode desfazer esta ação
     you_have_no_orders_yet: Você não possui pedidos ainda.
     your_cart_is_empty: O carrinho está vazio
-    your_order_is_empty_add_product: Seu pedido está vazio, por favor procure e adicione
-      um produto
+    your_order_is_empty_add_product: Seu pedido está vazio, por favor procure e adicione um produto
     zip: Codigo postal
     zipcode: Código zip
     zone: Zona

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,3 +1,4 @@
+---
 pt:
   activerecord:
     attributes:
@@ -12,11 +13,11 @@ pt:
         state: Estado
         zipcode: Código Postal
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,386 +25,386 @@ pt:
         name: Nome
         numcode: Código ISO
       spree/credit_card:
-        base:
+        base: 
         cc_type: Tipo
         month: Mês
-        name:
+        name: 
         number: Número
-        verification_value:
-        year:
+        verification_value: 
+        year: 
       spree/inventory_unit:
-        state:
+        state: 
       spree/line_item:
         price: Preço
         quantity: Quantidade
       spree/option_type:
         name: Nome
-        presentation:
+        presentation: 
       spree/order:
-        checkout_complete:
-        completed_at:
-        considered_risky:
-        coupon_code:
-        created_at:
-        email:
-        ip_address:
-        item_total:
+        checkout_complete: 
+        completed_at: 
+        considered_risky: 
+        coupon_code: 
+        created_at: 
+        email: 
+        ip_address: 
+        item_total: 
         number: Número
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
-        total:
+        payment_state: 
+        shipment_state: 
+        special_instructions: 
+        state: 
+        total: 
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/payment:
         amount: Quantia
       spree/payment_method:
         name: Nome
       spree/product:
-        available_on:
-        cost_currency:
+        available_on: 
+        cost_currency: 
         cost_price: Cost Price
         description: Descrição
         master_price: Master Price
         name: Nome
-        on_hand:
-        shipping_category:
-        tax_category:
+        on_hand: 
+        shipping_category: 
+        tax_category: 
       spree/promotion:
         advertise: Advertise
         code: Código
         description: Descrição
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        event_name: 
+        expires_at: 
+        name: 
+        path: 
+        starts_at: 
+        usage_limit: 
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
-        name:
-        presentation:
+        name: 
+        presentation: 
       spree/prototype:
-        name:
+        name: 
       spree/return_authorization:
-        amount:
+        amount: 
       spree/role:
-        name:
+        name: 
       spree/state:
-        abbr:
-        name:
+        abbr: 
+        name: 
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
-        description:
-        name:
+        description: 
+        name: 
       spree/tax_rate:
-        amount:
-        included_in_price:
-        show_rate_in_label:
+        amount: 
+        included_in_price: 
+        show_rate_in_label: 
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: 
+        permalink: 
+        position: 
       spree/taxonomy:
-        name:
+        name: 
       spree/user:
-        email:
-        password:
-        password_confirmation:
+        email: 
+        password: 
+        password_confirmation: 
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_currency: 
+        cost_price: 
+        depth: 
+        height: 
+        price: 
+        sku: 
+        weight: 
+        width: 
       spree/zone:
-        description:
-        name:
+        description: 
+        name: 
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
-      spree/address:
-      spree/country:
-      spree/credit_card:
-      spree/customer_return:
-      spree/inventory_unit:
-      spree/line_item:
-      spree/option_type:
-      spree/option_value:
-      spree/order:
-      spree/payment:
-      spree/payment_method:
-      spree/product:
-      spree/promotion:
-      spree/promotion_category:
-      spree/property:
-      spree/prototype:
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
-      spree/return_authorization:
-      spree/return_authorization_reason:
-      spree/role:
-      spree/shipment:
-      spree/shipping_category:
-      spree/shipping_method:
-      spree/state:
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
-      spree/tax_category:
-      spree/tax_rate:
-      spree/taxon:
-      spree/taxonomy:
-      spree/tracker:
-      spree/user:
-      spree/variant:
-      spree/zone:
+      spree/address: 
+      spree/country: 
+      spree/credit_card: 
+      spree/customer_return: 
+      spree/inventory_unit: 
+      spree/line_item: 
+      spree/option_type: 
+      spree/option_value: 
+      spree/order: 
+      spree/payment: 
+      spree/payment_method: 
+      spree/product: 
+      spree/promotion: 
+      spree/promotion_category: 
+      spree/property: 
+      spree/prototype: 
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
+      spree/return_authorization: 
+      spree/return_authorization_reason: 
+      spree/role: 
+      spree/shipment: 
+      spree/shipping_category: 
+      spree/shipping_method: 
+      spree/state: 
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
+      spree/tax_category: 
+      spree/tax_rate: 
+      spree/taxon: 
+      spree/taxonomy: 
+      spree/tracker: 
+      spree/user: 
+      spree/variant: 
+      spree/zone: 
   spree:
     abbreviation: Abreviação
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Conta
     account_updated: Conta atualizada!
     action: Ação
     actions:
       cancel: Cancelar
-      continue:
+      continue: 
       create: Criar
       destroy: Destruir
-      edit:
+      edit: 
       list: Lista
       listing: Listagem
       new: Nova
-      refund:
-      save:
+      refund: 
+      save: 
       update: Atualizar
     activate: Activate
     active: Ativo
     add: Adicionar
     add_action_of_type: Add action of type
     add_country: Adicionar País
-    add_coupon_code:
-    add_new_header:
-    add_new_style:
-    add_one:
+    add_coupon_code: 
+    add_new_header: 
+    add_new_style: 
+    add_one: 
     add_option_value: Adicionar Valor da Opção
     add_product: Adicionar Produtp
     add_product_properties: Adicionar Propriedades do Produto
     add_rule_of_type: Adicionar regra de tipo
     add_state: Adicionar Distrito
-    add_stock:
-    add_stock_management:
+    add_stock: 
+    add_stock_management: 
     add_to_cart: Adicionar ao Carrinho de Compras
-    add_variant:
+    add_variant: 
     additional_item: Artigo adicional
-    address1:
-    address2:
-    adjustable:
+    address1: 
+    address2: 
+    adjustable: 
     adjustment: Acerto
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: 
+    adjustment_successfully_closed: 
+    adjustment_successfully_opened: 
     adjustment_total: Total do Acerto
     adjustments: Acertos
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administração
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
-    all:
-    all_adjustments_closed:
-    all_adjustments_opened:
-    all_departments:
-    all_items_have_been_returned:
+    advertise: 
+    agree_to_privacy_policy: 
+    agree_to_terms_of_service: 
+    all: 
+    all_adjustments_closed: 
+    all_adjustments_opened: 
+    all_departments: 
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
-    already_signed_up_for_analytics:
+    already_signed_up_for_analytics: 
     alt_text: Texto alternativo
     alternative_phone: Telefone alternativo
     amount: Montante
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: 
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
     analytics_trackers: Analytics Trackers
-    and:
-    approve:
-    approved_at:
-    approver:
+    and: 
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Tem a certeza?
     are_you_sure_delete: Tem a certeza que deseja remover este registo?
-    associated_adjustment_closed:
-    at_symbol: '@'
+    associated_adjustment_closed: 
+    at_symbol: "@"
     authorization_failure: Falha na autorização
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Disponível em
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Voltar
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Voltar para a loja
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_users_list: 
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Saldo devedor
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Endereço para Faturação
     billing: Faturação
     billing_address: Endereço para Faturação
     both: Ambos
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Calculadora
     calculator_settings_warning: Se alterar o tipo de calculadora, deve primeiro confirmar a alteração antes de editar as configurações.
     cancel: cancelar
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Não é possível criar um retorno para esse pedido, pois ele ainda não foi enviado.
     cannot_perform_operation: Não foi possível realizar esta operação
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: 
     capture: Capturar
-    capture_events:
+    capture_events: 
     card_code: Código do cartão
     card_number: Número do cartão
-    card_type:
+    card_type: 
     card_type_is: A bandeira do cartão é
     cart: Carrinho de Compras
-    cart_subtotal:
+    cart_subtotal: 
     categories: Categorias
     category: Categoria
-    charged:
-    check_for_spree_alerts:
+    charged: 
+    check_for_spree_alerts: 
     checkout: Finalizar compra
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: 
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 
+    choose_dashboard_locale: 
+    choose_location: 
     city: Cidade
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Clone
-    close:
-    close_all_adjustments:
+    close: 
+    close_all_adjustments: 
     code: Código
-    company:
+    company: 
     complete: completo
     configuration: Configuração
     configurations: Configurações
@@ -412,122 +413,123 @@ pt:
     confirm_password: Confirmação da password
     continue: Continuar
     continue_shopping: Continuar a comprar
-    cost_currency:
+    cost_currency: 
     cost_price: Preço de custo
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
+    countries: 
     country: País
     country_based: Baseado em País
-    country_name:
+    country_name: 
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Cupão
     coupon_code: Código do cupão de desconto
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_already_applied: 
+    coupon_code_applied: 
+    coupon_code_better_exists: 
+    coupon_code_expired: 
+    coupon_code_max_usage: 
+    coupon_code_not_eligible: 
+    coupon_code_not_found: 
+    coupon_code_unknown_error: 
     create: Criar
     create_a_new_account: Criar uma nova conta
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: 
+    create_reimbursement: 
+    created_at: 
     credit: Crédito
     credit_card: Cartão de Crédito
     credit_cards: Credit Cards
     credit_owed: Crédito Devedor
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credits: 
+    currency: 
+    currency_decimal_mark: 
+    currency_settings: 
+    currency_symbol_position: 
+    currency_thousands_separator: 
     current: Atual
-    current_promotion_usage:
+    current_promotion_usage: 
     customer: Cliente
     customer_details: Detalhes do cliente
-    customer_details_updated:
-    customer_return:
-    customer_returns:
+    customer_details_updated: 
+    customer_return: 
+    customer_returns: 
     customer_search: Busca de clientes
-    cut:
-    cvv_response:
+    cut: 
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: 
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 
+      format: 
+      js_format: 
     date_range: Entre as Datas
     default: Padrão
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default_refund_amount: 
+    default_tax: 
+    default_tax_zone: 
     delete: Apagar
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Entrega
     depth: Espessura
     description: Descrição
-    destination:
+    destination: 
     destroy: Destruir
-    details:
+    details: 
     discount_amount: Desconto
-    dismiss_banner:
+    dismiss_banner: 
     display: Mostrar
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: 
+    doesnt_track_inventory: 
     edit: Editar de Imposto
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Editando Utilizador
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Email
     empty: Vazio
     empty_cart: Esvaziar o Carro
     enable_mail_delivery: Habilitar envio de email
-    end:
-    ending_in:
+    end: 
+    ending_in: 
     environment: Ambiente
     error: erro
     errors:
       messages:
         could_not_create_taxon: Não foi possível criar taxon
         no_payment_methods_available: No payment methods are configured for this environment
-        no_shipping_methods_available: Não há métodos de envio disponíveis para a localização que selecionou, por favor altere o seu endereço e tente novamente
+        no_shipping_methods_available: Não há métodos de envio disponíveis para a localização que selecionou, por favor altere o seu endereço
+          e tente novamente
     errors_prohibited_this_record_from_being_saved:
       one: 1 erro não permitiu que estes dados fossem gravados
       other: "%{count} erros não permitiram que estes dados fossem gravados"
@@ -535,31 +537,31 @@ pt:
     events:
       spree:
         cart:
-          add:
+          add: 
         checkout:
-          coupon_code_added:
+          coupon_code_added: 
         content:
-          visited:
+          visited: 
         order:
-          contents_changed:
-        page_view:
+          contents_changed: 
+        page_view: 
         user:
-          signup:
+          signup: 
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Expiração
     extension: Extensão
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Nome do arquivo
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: 
+    filter_results: 
     finalize: Finalizar
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: Custo do primeiro item
     first_name: Nome
     first_name_begins_with: Primeiro nome começa com
@@ -568,7 +570,7 @@ pt:
     flexible_rate: Taxa Flexivel
     forgot_password: Esqueci-me da minha password
     free_shipping: Entrega grátis
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway não está disponível
@@ -581,43 +583,43 @@ pt:
     guest_user_account: Comprar como visitante
     has_no_shipped_units: não tem unidades entregues
     height: Altura
-    hide_cents:
+    hide_cents: 
     home: Início
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: Português (PT)
     icon: Icone
-    identifier:
+    identifier: 
     image: Imagem
     images: Imagens
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: 
+    included_price_validation: 
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Preencha o formulário abaixo e enviaremos instruções de como redefinir a sua password por email:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Interceptar endereço de email
     intercept_email_instructions: Sobreescrever destinatários por este endereço de email.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 
+    invalid_promotion_action: 
+    invalid_promotion_rule: 
     inventory: Inventário
     inventory_adjustment: Ajuste de Inventário
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: 
+    inventory_state: 
     is_not_available_to_shipment_address: Não está disponível para endereço de entrega
-    iso_name:
+    iso_name: 
     item: Artigo
     item_description: Descrição do Artigo
     item_total: Total do Artigo
@@ -625,26 +627,26 @@ pt:
       operators:
         gt: maior que
         gte: maior ou igual que
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
+    jirafe: 
     landing_page_rule:
       path: Path
     last_name: Sobrenome
     last_name_begins_with: Sobrenome começa com
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Lista
     loading: Carregando
     locale_changed: Localização Alterada
-    location:
-    lock:
-    log_entries:
+    location: 
+    lock: 
+    log_entries: 
     logged_in_as: Registado como
     logged_in_succesfully: Autenticação feita com sucesso, obrigado!
     logged_out: Você saiu.
@@ -653,38 +655,38 @@ pt:
     login_failed: Falha na autenticação.
     login_name: Nome de Utilizador
     logout: Sair
-    logs:
+    logs: 
     look_for_similar_items: Procurar artigos similares
     make_refund: Devolução
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Preço Principal
     match_choices:
-      all:
-      none:
+      all: 
+      none: 
     max_items: Artigos máximos
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Descrição
     meta_keywords: Palavras-Chave
-    meta_title:
+    meta_title: 
     metadata: Metadados
     minimal_amount: Quantidade mínima
     month: Mês
     more: More
-    move_stock_between_locations:
+    move_stock_between_locations: 
     my_account: Minha Conta
     my_orders: As Minhas Encomendas
     name: Nome
-    name_on_card:
+    name_on_card: 
     name_or_sku: Nome ou SKU
     new: Novo
     new_adjustment: Novo Ajuste
-    new_country:
+    new_country: 
     new_customer: Novo Cliente
-    new_customer_return:
+    new_customer_return: 
     new_image: Nova Imagem
     new_option_type: Novo Tipo de Opção
     new_order: Novo Pedido
@@ -693,20 +695,20 @@ pt:
     new_payment_method: Nova Forma de Pagamento
     new_product: Novo Produto
     new_promotion: Nova Promoção
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Nova Propriedade
     new_prototype: Novo Protótipo
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Nova Autorização de Devolução
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Nova Categoria de Entrega
     new_shipping_method: Novo Método de Entrega
     new_state: Novo Estado
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: 
+    new_stock_movement: 
+    new_stock_transfer: 
     new_tax_category: Nova Categoria de Imposto
     new_tax_rate: Nova Taxa de Imposto
     new_taxon: Novo Táxon
@@ -716,25 +718,25 @@ pt:
     new_variant: Nova Variante
     new_zone: Nova Zona
     next: Próximo
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: 
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: Não existem produtos
-    no_resource_found:
+    no_resource_found: 
     no_results: Não existem resultados
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: Nenhuma regra adicionada
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
     none: Nenhum
-    none_selected:
+    none_selected: 
     normal_amount: Quantidade Normal
     not: não
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: 
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
       product_cloned: Produto clonado
       product_deleted: Produto apagado
@@ -742,47 +744,47 @@ pt:
       product_not_deleted: Produto não pode ser apagado
       variant_deleted: Variante deletada
       variant_not_deleted: Variante não pode ser apagada
-    num_orders:
+    num_orders: 
     on_hand: Em Stock
-    open:
-    open_all_adjustments:
+    open: 
+    open_all_adjustments: 
     option_type: Tipo de Opção
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Tipos de Opção
     option_value: Valor da Opção
     option_values: Valores das Opções
-    optional:
+    optional: 
     options: Opções
     or: ou
     or_over_price: "%{price} ou mais"
     order: Pedido
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Detalhes do Pedido
     order_email_resent: Email de Confirmação Reenviado
-    order_information:
+    order_information: 
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
+        dear_customer: 
+        instructions: 
+        order_summary_canceled: 
         subject: Cancelamento da Encomenda
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: 
+        instructions: 
+        order_summary: 
+        subject: 
+        subtotal: 
+        thanks: 
+        total: 
+    order_not_found: 
+    order_number: 
     order_processed_successfully: O seu pedido foi processado com sucesso.
-    order_resumed:
+    order_resumed: 
     order_state:
       address: endereço
       awaiting_return: aguardando retorno
@@ -790,7 +792,7 @@ pt:
       cart: carrinho de compras
       complete: completo
       confirm: confirmação
-      considered_risky:
+      considered_risky: 
       delivery: entrega
       payment: pagamento
       resumed: resumido
@@ -800,24 +802,24 @@ pt:
     order_total: Total do Pedido
     order_updated: Pedido Atualizado
     orders: Encomendas
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Esgotado
     overview: Resumo
-    package_from:
+    package_from: 
     pagination:
-      next_page:
-      previous_page:
+      next_page: 
+      previous_page: 
       truncate: "…"
-    password:
-    paste:
+    password: 
+    paste: 
     path: Caminho
     pay: Pague
     payment: Pagamento
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Dados do Pagamento
     payment_method: Método de Pagamento
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Métodos de Pagamento
     payment_processing_failed: Pagamento não foi processado, por favor verifique os detalhes informados.
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -835,22 +837,22 @@ pt:
       void: nulo
     payment_updated: Pagamento Atualizado
     payments: Pagamentos
-    pending:
-    percent:
-    percent_per_item:
+    pending: 
+    percent: 
+    percent_per_item: 
     permalink: Link Permanente
     phone: Telefone
     place_order: Fazer Pedido
-    please_define_payment_methods:
-    populate_get_error:
-    powered_by:
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    please_define_payment_methods: 
+    populate_get_error: 
+    powered_by: 
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Apresentação
     previous: anterior
-    previous_state_missing:
+    previous_state_missing: 
     price: Preço
     price_range: Intervalo de Preço
     price_sack: Saco de Preço
@@ -858,34 +860,34 @@ pt:
     product: Produto
     product_details: Detalhes do Produto
     product_has_no_description: Produto não tem descrição
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: Propriedades do Produto
     product_rule:
       choose_products: Escolher produtos
-      label:
+      label: 
       match_all: todos
       match_any: pelo menos um
-      match_none:
+      match_none: 
       product_source:
         group: de grupo de produto
         manual: escolha manual
     products: Produtos
     promotion: Promoção
-    promotion_action:
+    promotion_action: 
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: 
+        name: 
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: 
+        name: 
+    promotion_actions: 
     promotion_form:
       match_policies:
         all: Combinar todas regras
@@ -897,32 +899,32 @@ pt:
         name: Primeiro pedido
       item_total:
         description: Total do pedio fecha com estes critérios
-        name:
+        name: 
       landing_page:
-        description:
-        name:
+        description: 
+        name: 
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Pedido inclui produto(s) específico(s)
         name: Produto(s)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Disponível apenas para utilizadores específicos
         name: Utilizadores
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promoções
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Propriedades
     property: Propriedade
     prototype: Protótipo
@@ -930,49 +932,49 @@ pt:
     provider: Provedor
     provider_settings_warning: Se está a alterar o tipo de provedor, deve guardar antes de editar as configurações
     qty: Qtde.
-    quantity:
+    quantity: 
     quantity_returned: Quantidade devolvida
     quantity_shipped: Quantidade enviada
-    quick_search:
+    quick_search: 
     rate: Taxa
     reason: Razões
     receive: receber
-    receive_stock:
+    receive_stock: 
     received: Recebido
-    reception_status:
-    reference:
+    reception_status: 
+    reference: 
     refund: Restituição
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Registrar-se
     registration: Registo
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Lembre-se de mim
     remove: Remover
     rename: Rename
-    report:
+    report: 
     reports: Relatórios
     resend: Reenviar
     reset_password: Repôr a minha password
@@ -981,34 +983,34 @@ pt:
     resumed: Resumido
     return: Devolução
     return_authorization: Autorização de devolução
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Autorização de devolução atualizada
     return_authorizations: Autorizações de devolução
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Quantidade a ser devolvido
     returned: Devolvido
-    returns:
+    returns: 
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: Crédito RMA
     rma_number: Número RMA
     rma_value: Valor RMA
     roles: Funções
     rules: Regras
-    safe:
+    safe: 
     sales_total: Total de Vendas
     sales_total_description: Total de vendas por todos os pedidos
-    sales_totals:
+    sales_totals: 
     save_and_continue: Guardar e Continuar
-    save_my_address:
+    save_my_address: 
     say_no: false
     say_yes: true
     scope: Scopo
@@ -1018,10 +1020,10 @@ pt:
     secure_connection_type: Tipo de conexão segura
     security_settings: Security Settings
     select: Selecionar
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Selecionar a partir de Protótipo
-    select_stock:
+    select_stock: 
     send_copy_of_all_mails_to: Enviar cópias de todos emails para
     send_mails_as: Enviar email como
     server: Servidor
@@ -1029,138 +1031,138 @@ pt:
     settings: Configurações
     ship: entrega
     ship_address: Endereço da Entrega
-    ship_total:
+    ship_total: 
     shipment: Distribuição
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
+        dear_customer: 
+        instructions: 
+        shipment_summary: 
         subject: Notificação de Envio
-        thanks:
-        track_information:
-        track_link:
+        thanks: 
+        track_information: 
+        track_link: 
     shipment_state: Estado da entrega
     shipment_states:
       backorder: fora do sistema
-      canceled:
+      canceled: 
       partial: parcial
       pending: pendente
       ready: pronta
       shipped: entregue
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Entregas
     shipped: enviado
     shipping: Entrega
     shipping_address: Endereço de Entrega
     shipping_categories: Categorias de Entrega
     shipping_category: Categoria de Entrega
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
     shipping_instructions: Instruções de entrega
     shipping_method: Método de Entrega
     shipping_methods: Métodos de Entrega
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: 
+    shipping_total: 
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrinho de Compra
     show: Mostrar
     show_active: Mostrar ativos
     show_deleted: Mortra Eliminados
     show_only_complete_orders: Mostrar apenas pedidos completos
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: 
+    show_rate_in_label: 
     sku: SKU
-    skus:
-    slug:
-    source:
+    skus: 
+    slug: 
+    source: 
     special_instructions: Instruções Especiais
-    split:
+    split: 
     spree_gateway_error_flash_for_checkout: Houve um problema com a informação de pagamentp. Por favor verifique a informação e tente novamente.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Início
     state: Distrito
     state_based: Baseado no Distrito
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Distritos
-    states_required:
+    states_required: 
     status: Estado
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: 
+    stock_location: 
+    stock_location_info: 
+    stock_locations: 
+    stock_locations_need_a_default_country: 
+    stock_management: 
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
+    stock_transfer: 
+    stock_transfers: 
     stop: Final
     store: Loja
     street_address: Endereço
     street_address_2: Endereço (compl.)
     subtotal: Sub-total
     subtract: Subtrair
-    success:
+    success: 
     successfully_created: "%{resource} foi criado com sucesso!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} foi removido com sucesso!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: 
     successfully_updated: "%{resource} foi atualizado com sucesso!"
-    summary:
+    summary: 
     tax: Imposto
     tax_categories: Categorias de Imposto
     tax_category: Categoria de Imposto
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
     tax_rates: Taxas de imposto
     taxon: Taxón
     taxon_edit: Editar taxón
-    taxon_placeholder:
+    taxon_placeholder: 
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taxonomias
     taxonomy: Taxonomy
     taxonomy_edit: Editar taxonomia
@@ -1170,47 +1172,47 @@ pt:
     test: Teste
     test_mailer:
       test_email:
-        greeting:
-        message:
-        subject:
+        greeting: 
+        message: 
+        subject: 
     test_mode: Modo de Teste
     thank_you_for_your_order: Obrigado pela sua compra. Por favor, imprima uma cópia desta página de confirmação.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: Houve um problema com os seguintes campos
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Miniatura
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: 
     to_add_variants_you_must_first_define: Para adicionar variantes você deve primeiro definir
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Rastreio
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
-    tree: "Árvore"
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
+    tree: Árvore
     type: Tipo
     type_to_search: Tipo de pesquisa
     unable_to_connect_to_gateway: Impossível conectar-se ao Gateway
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Menos de %{price}
-    unlock:
+    unlock: 
     unrecognized_card_type: Tipo de cartão desconhecido
-    unshippable_items:
+    unshippable_items: 
     update: Atualizar
     updating: Atualizando
     usage_limit: Limite de utilização
-    use_app_default:
+    use_app_default: 
     use_billing_address: Utilizar endereço de faturação
     use_new_cc: Utilizar um novo cartão
     use_s3: Use Amazon S3 For Images
@@ -1220,15 +1222,15 @@ pt:
     users: utilizadores
     validation:
       cannot_be_less_than_shipped_units: não pode ser menor que o número de unidades enviadas.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
-      is_too_large: "é muito grande -- quantidade em stock não consegue cobrir este pedido!"
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 
+      is_too_large: é muito grande -- quantidade em stock não consegue cobrir este pedido!
       must_be_int: deve ser um inteiro
       must_be_non_negative: deve ser um valor positivo ou zero
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Valor
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: 
     variants: Variantes
     version: Versão
     void: Vazio
@@ -1239,8 +1241,8 @@ pt:
     year: Ano
     you_have_no_orders_yet: Ainda não tem pedidos.
     your_cart_is_empty: O carrinho de compras está vazio
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: 
     zip: Código Postal
-    zipcode:
+    zipcode: 
     zone: Zona
     zones: Zonas

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,3 +1,4 @@
+---
 ro:
   activerecord:
     attributes:
@@ -5,18 +6,18 @@ ro:
         address1: Adresă
         address2: Adresă (continuare)
         city: Localitate
-        country: "Țara"
+        country: Țara
         firstname: Prenume
         lastname: Nume
         phone: Telefon
         state: Județ / Regiune
         zipcode: Cod poștal
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -27,7 +28,7 @@ ro:
         base: Bază
         cc_type: Tip
         month: Luna
-        name:
+        name: 
         number: Număr
         verification_value: Cod de verificare
         year: An
@@ -42,7 +43,7 @@ ro:
       spree/order:
         checkout_complete: Comandă finalizată
         completed_at: Finalizată la
-        considered_risky:
+        considered_risky: 
         coupon_code: Cod Cupon
         created_at: Data comenzii
         email: E-Mail Client
@@ -81,7 +82,7 @@ ro:
         description: Descriere
         master_price: Preț de bază
         name: Nume
-        on_hand: "În stoc"
+        on_hand: În stoc
         shipping_category: Categorie de livrare
         tax_category: Categorie taxă
       spree/promotion:
@@ -92,10 +93,10 @@ ro:
         expires_at: Expiră la
         name: Nume
         path: Cale
-        starts_at: "Începe la"
+        starts_at: Începe la
         usage_limit: Limită de folosire
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Nume
         presentation: Descriere
@@ -109,20 +110,20 @@ ro:
         abbr: Prescurtare
         name: Nume
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Descriere
         name: Nume
@@ -144,7 +145,7 @@ ro:
         cost_currency: Valută preț de cost
         cost_price: Preț de cost
         depth: Adâncime
-        height: "Înălțime"
+        height: Înălțime
         price: Preț
         sku: Cod produs
         weight: Greutate
@@ -157,91 +158,91 @@ ro:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: Cartela a expirat
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
         one: Adresă
         other: Adrese
       spree/country:
-        one: "Țara"
-        other: "Țări"
+        one: Țara
+        other: Țări
       spree/credit_card:
         one: Card de credit
         other: Carduri de credit
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit:
         one: Unitatea de inventar
         other: Unități de inventar
       spree/line_item:
         one: Element
         other: Elemente
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
         one: Comandă
         other: Comenzi
       spree/payment:
         one: Plată
         other: Plăți
-      spree/payment_method:
+      spree/payment_method: 
       spree/product:
         one: Produs
         other: Produse
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
         one: Proprietate
         other: Proprietăți
       spree/prototype:
         one: Prototip
         other: Prototipuri
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
         one: Autorizație de retur
         other: Autorizații de retur
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role:
         one: Roluri
         other: Roluri
@@ -251,14 +252,14 @@ ro:
       spree/shipping_category:
         one: Categorie de expediție
         other: Categorii de expediții
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state:
         one: Județ / Regiune
         other: Județe / Regiuni
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
         one: Categorie de taxare
         other: Categorii de taxare
@@ -271,7 +272,7 @@ ro:
       spree/taxonomy:
         one: Clasificare
         other: Clasificări
-      spree/tracker:
+      spree/tracker: 
       spree/user:
         one: Utilizator
         other: Utilizatori
@@ -283,10 +284,10 @@ ro:
         other: Zone
   spree:
     abbreviation: Prescurtare
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Cont
     account_updated: Cont actualizat!
     action: Acțiune
@@ -294,12 +295,12 @@ ro:
       cancel: Anulează
       continue: Continuă
       create: Creează
-      destroy: "Șterge"
+      destroy: Șterge
       edit: Editează
       list: Listează
       listing: Listare
       new: Nou
-      refund:
+      refund: 
       save: Salvează
       update: Actualizează
     activate: Activează
@@ -307,7 +308,7 @@ ro:
     add: Adaugă
     add_action_of_type: Adaugă tip acțiune
     add_country: Adaugă țară
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Adaugă header nou
     add_new_style: Adaugă stil nou
     add_one: Adaugă unul
@@ -323,7 +324,7 @@ ro:
     additional_item: Cost adițional pe articol
     address1: Adresă
     address2: Adresă (continuare)
-    adjustable:
+    adjustable: 
     adjustment: Re-evaluare
     adjustment_amount: Valoare
     adjustment_successfully_closed: Ajustarea a fost închisă cu succes!
@@ -337,32 +338,32 @@ ro:
         orders: Comenzi
         overview: Prezentare generală
         products: Produse
+        promotion_categories: 
         promotions: Promoții
-        promotion_categories:
         properties: Proprietăți
         prototypes: Prototipuri
         reports: Rapoarte
-        taxonomies:
-        taxons:
+        taxonomies: 
+        taxons: 
         users: Utilizatori
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administrare
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Acceptă Politica de Confidențialitate
     agree_to_terms_of_service: Acceptă Condițiile de Utilizare
     all: Toate
     all_adjustments_closed: Toate ajustările au fost  închise cu succes!
     all_adjustments_opened: Toate ajustările au fost deschise cu succes!
     all_departments: Toate departamentele
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Permite utilizare SSL în modurile de dezvoltare și testare
     allow_ssl_in_production: Permite utilizare SSL în modul producție
     allow_ssl_in_staging: Permite utilizare în modul staging
@@ -377,75 +378,75 @@ ro:
     analytics_desc_list_3: Niciun cod de instalat
     analytics_desc_list_4: Este complet gratuit!
     analytics_trackers: Analytics Trackers
-    and: "și"
-    approve:
-    approved_at:
-    approver:
+    and: și
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Ești sigur(ă)
     are_you_sure_delete: Ești sigur(ă) că vrei să ștergi această înregistrare?
     associated_adjustment_closed: Ajustarea asociată este închisă și nu va fi recalculată. Doriți să o deschideți?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Autorizare nereușită
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Disponibil de la
-    average_order_value:
-    avs_response:
-    back: "Înapoi"
+    average_order_value: 
+    avs_response: 
+    back: Înapoi
     back_end: Interfața de administrare
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
-    back_to_store: "Înapoi la magazin"
-    back_to_users_list: "Înapoi la lista de utilizatori"
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
+    back_to_store: Înapoi la magazin
+    back_to_users_list: Înapoi la lista de utilizatori
     backorderable: Permite comenzi în așteptare
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Sold datorat
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Adresă de facturare
     billing: Facturare
     billing_address: Adresă facturare
     both: Ambele
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Calculator
     calculator_settings_warning: Dacă schimbi tipul de calculator, trebuie mai întâi să salvezi, ca să poți edita setările calculatorului
     cancel: anulează
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: Nu puteți crea o plată pentru o comandă fără a defini o metodă de plată.
     cannot_create_returns: Nu poți genera un retur deoarece această comandă nu a fost livrată încă.
     cannot_perform_operation: Operațiunea cerută nu poate fi îndeplinită
     cannot_set_shipping_method_without_address: Metoda de livrare nu poate fi setată înaintea furnizării datelor clientului.
-    capture: "Înregistrare"
-    capture_events:
+    capture: Înregistrare
+    capture_events: 
     card_code: Codul cardului
     card_number: Numărul cardului
-    card_type:
+    card_type: 
     card_type_is: Tipul cardului este
     cart: Coșul meu
-    cart_subtotal:
+    cart_subtotal: 
     categories: Categorii
     category: Categorie
-    charged:
+    charged: 
     check_for_spree_alerts: Verifică alerte Spree
     checkout: Efectuați plata
     choose_a_customer: Alege un client
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Alege valuta
     choose_dashboard_locale: Alege localizare panou de administrare
-    choose_location:
+    choose_location: 
     city: Oraș / Localitate
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Clonă
-    close: "Închide"
-    close_all_adjustments: "Închide toate ajustările"
+    close: Închide
+    close_all_adjustments: Închide toate ajustările
     code: Cod
     company: Firma
     complete: complet
@@ -459,18 +460,18 @@ ro:
     cost_currency: Valută preț de cost
     cost_price: Preț de cost
     could_not_connect_to_jirafe: Conexiunea la Jirafe pentru a sincroniza datele nu a putut fi realizată. Se va reîncerca conexiunea mai târziu.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: A apărut o problemă la salvarea mișcării de stoc. Vă rog reîncercați.
     count_on_hand: Valoare stoc
-    countries: "Țări"
-    country: "Țara"
+    countries: Țări
+    country: Țara
     country_based: Bazat pe țară
     country_name: Nume
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Cupon
     coupon_code: Cod cupon
     coupon_code_already_applied: Codul voucher a fost deja aplicat acestei comenzi
@@ -480,17 +481,17 @@ ro:
     coupon_code_max_usage: Limita de utilizare a acestui voucher a fost depășită
     coupon_code_not_eligible: Acest cod voucher nu este eligibil pentru această comandă
     coupon_code_not_found: Codoul voucherului introdus nu există. Încercați din nou.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Creează
     create_a_new_account: Creează un nou cont
-    create_new_order:
-    create_reimbursement:
+    create_new_order: 
+    create_reimbursement: 
     created_at: Creat la
     credit: Credit
     credit_card: Card de credit
     credit_cards: Carduri de credit
     credit_owed: Credit datorat
-    credits:
+    credits: 
     currency: Valuta
     currency_decimal_mark: Separator zecimale
     currency_settings: Setări valută
@@ -501,16 +502,16 @@ ro:
     customer: Client
     customer_details: Detalii client
     customer_details_updated: Detaliile clientului au fost actualizate
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Căutare client
     cut: Taie
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: ID Aplicație
         app_token: Cod Aplicație
-        currently_unavailable:
+        currently_unavailable: 
         explanation: Câmpurile de mai jos pot fi deja populate în cazul în care doriți să vă înregistrați cu Jirafe din panoul de administrare.
         header: Setări Jirafe Analytics
         site_id: ID Site
@@ -519,46 +520,46 @@ ro:
     date: Data
     date_completed: Data efectuării
     date_picker:
-      first_day:
+      first_day: 
       format: "%d.%m.%Y"
       js_format: "%d.%m.%Y"
     date_range: Perioada
     default: Standard
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Taxă prestabilită
     default_tax_zone: Zonă de taxare prestabilită
-    delete: "Șterge"
-    deleted_variants_present:
+    delete: Șterge
+    deleted_variants_present: 
     delivery: Livrare
     depth: Adâncime
     description: Descriere
     destination: Destinație
-    destroy: "Șterge"
-    details:
+    destroy: Șterge
+    details: 
     discount_amount: Valoare reducere
     dismiss_banner: Nu, mulțumesc! Nu sunt interesat, nu mai afișa acest mesaj din nou.
     display: Arată
     display_currency: Afișează cod valută
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Modifică
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Modificarea utilizatorului
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Email
     empty: Gol
     empty_cart: Golește coșul
@@ -571,7 +572,8 @@ ro:
       messages:
         could_not_create_taxon: Nu se poate crea clasa
         no_payment_methods_available: Nicio metodă de plată nu a fost configurată pentru acest mediu
-        no_shipping_methods_available: Nu există nicio modalitate de expediție pentru locația aleasă, te rugăm să schimbi adresa și să mai încerci odată.
+        no_shipping_methods_available: Nu există nicio modalitate de expediție pentru locația aleasă, te rugăm să schimbi adresa și să mai încerci
+          odată.
     errors_prohibited_this_record_from_being_saved:
       one: 1 eroare nu permite ca această înregistrare să fie salvată
       other: "%{count} erori nu permit ca această înregistrare să fie salvată"
@@ -588,22 +590,22 @@ ro:
           contents_changed: Conținutul comenzii a fost modificat
         page_view: Pagină vizualizată
         user:
-          signup: "Înregistrare utilizator"
+          signup: Înregistrare utilizator
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Expirare
     extension: Extensie
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Nume fișier
     fill_in_customer_info: Vă rugăm introduceți informațiile de client
     filter_results: Rezultate filtrare
     finalize: Finalizează
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: Cost primul articol
     first_name: Prenume
     first_name_begins_with: Prenumele începe cu
@@ -612,7 +614,7 @@ ro:
     flexible_rate: Rată flexibilă
     forgot_password: Ai uitat parola?
     free_shipping: Livrare gratuită
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Interfață utilizatori
     gateway: Metodă de plată
     gateway_config_unavailable: Metodă de plată indisponibilă în acest context
@@ -624,7 +626,7 @@ ro:
     guest_checkout: Comandă oaspete
     guest_user_account: Comandă ca oaspete
     has_no_shipped_units: Nu are unități de expediție
-    height: "Înălțime"
+    height: Înălțime
     hide_cents: Ascunde subunități monetare (bani)
     home: Acasă
     i18n:
@@ -633,33 +635,33 @@ ro:
       localization_settings: Setări localizare
       this_file_language: Romanian (RO)
     icon: Icoană
-    identifier:
+    identifier: 
     image: Imagine
     images: Imagini
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Inclus în preț
     included_price_validation: nu poate fi selectat doar dacă ați ales o zonă de taxare prestabilită
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Completează formularul și instrucțiunile de mai jos, ca să resetezi parola, care îți va fi trimisă de email:'
     insufficient_stock: Stoc insuficient, doar %{on_hand} rămase
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Interceptează adresa de email
     intercept_email_instructions: Schimbă recipientul emailului cu această adresă.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Furnizor de plăți nevalid.
     invalid_promotion_action: Acțiune de promoție nevalidă
     invalid_promotion_rule: Regulă de promoție nevalidă.
     inventory: Inventar
     inventory_adjustment: Re-evaluare inventar
     inventory_error_flash_for_insufficient_quantity: Un articol din coșul dumneavoastră de cumpărături a devenit indisponibil.
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: nu este disponibil pentru adresa de expediție
     iso_name: Nume ISO
     item: Articol
@@ -669,26 +671,26 @@ ro:
       operators:
         gt: mai mare de
         gte: mai mare de sau egal cu
-        lt:
-        lte:
+        lt: 
+        lte: 
     items_cannot_be_shipped: Itemii nu pot fi cumpărați
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Cale
     last_name: Nume
     last_name_begins_with: Numele începe cu
-    learn_more: "Învață mai multe"
-    lifetime_stats:
-    line_item_adjustments:
+    learn_more: Învață mai multe
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Listă
-    loading: "Încarcă"
+    loading: Încarcă
     locale_changed: Localizare schimbat
     location: Locație
     lock: Blochează
-    log_entries:
+    log_entries: 
     logged_in_as: Autentificat ca
     logged_in_succesfully: Autentificat cu succes
     logged_out: V-ați deconectat.
@@ -697,23 +699,23 @@ ro:
     login_failed: Autentificare nereușită.
     login_name: Autentificare
     logout: Deconectare
-    logs:
+    logs: 
     look_for_similar_items: Caută articole similare
     make_refund: Fă o restituire
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Preț de bază
     match_choices:
       all: Toate
       none: Nici una
     max_items: Max articole
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Descriere meta
     meta_keywords: Cuvinte cheie meta
-    meta_title:
+    meta_title: 
     metadata: Metadate
     minimal_amount: Suma minimă
     month: Luna
@@ -722,13 +724,13 @@ ro:
     my_account: Contul meu
     my_orders: Comenzile mele
     name: Nume
-    name_on_card:
+    name_on_card: 
     name_or_sku: Nume sau cod produs
     new: Nou
     new_adjustment: Re-evaluare nouă
-    new_country:
+    new_country: 
     new_customer: Client nou
-    new_customer_return:
+    new_customer_return: 
     new_image: Imagine nouă
     new_option_type: Tip nou de opțiune
     new_order: Comandă nouă
@@ -737,14 +739,14 @@ ro:
     new_payment_method: Metodă nouă de plată
     new_product: Produs nou
     new_promotion: Promoție nouă
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Proprietate nouă
     new_prototype: Prototip nou
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Autorizație nouă de retur
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Categorie nouă de livrare
     new_shipping_method: Metodă nouă de livrare
     new_state: Județ nou / regiune nouă
@@ -761,24 +763,24 @@ ro:
     new_zone: Zonă nouă
     next: Următorul
     no_actions_added: Nicio acțiune adăugată
-    no_payment_found:
-    no_pending_payments:
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: Nu am găsit produse
-    no_resource_found:
+    no_resource_found: 
     no_results: Nu există rezultate
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: Nicio regulă adăugată
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: Nu au fost furnizate detalii de tracking
     none: Niciuna
-    none_selected:
+    none_selected: 
     normal_amount: Suma normală
     not: nu
     not_available: Indisponibil
     not_enough_stock: Nu există stoc suficient la locația sursă pentru a finaliza transferul.
     not_found: "%{resource} nu a fost găsit"
-    note:
+    note: 
     notice_messages:
       product_cloned: Produsul a fost clonat
       product_deleted: Produsul a fost șters
@@ -786,12 +788,12 @@ ro:
       product_not_deleted: Produsul nu a putut fi șters
       variant_deleted: Varianta a fost ștearsă
       variant_not_deleted: Varianta nu a putut fi ștearsă
-    num_orders:
+    num_orders: 
     on_hand: Pe stoc
     open: Deschis
     open_all_adjustments: Deschide toate ajustările
     option_type: Tip opțiune
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Tipuri opțiune
     option_value: Valoarea opțiune
     option_values: Valori opțiuni
@@ -801,9 +803,9 @@ ro:
     or_over_price: "%{price} sau peste"
     order: Comanda
     order_adjustments: Ajustări comandă
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Detaliile comenzii
     order_email_resent: Mail comandă retrimis
     order_information: Informații comandă
@@ -813,27 +815,27 @@ ro:
         instructions: Comanda Dvs. a fost anulată. Vă rugăm păstrați această notă de anulare.
         order_summary_canceled: Sumarul comenzii [ANULATE]
         subject: Anularea comenzii
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Stimate client,\n
         instructions: Vă rugăm să verificați și să păstrați informațiile despre comanda Dvs.
         order_summary: Sumarul comenzii
         subject: Confirmarea comenzii
-        subtotal:
+        subtotal: 
         thanks: Vă mulțumim pentru comanda efectuată.
-        total:
+        total: 
     order_not_found: Nu am putut găsi comanda dumneavoastră. Vă rugăm încercați din nou.
     order_processed_successfully: Comanda a fost procesată cu succes
-    order_resumed:
+    order_resumed: 
     order_state:
       address: adresă
-      awaiting_return: "în așteptarea returului"
+      awaiting_return: în așteptarea returului
       canceled: anulat
       cart: coș cumpărături
       complete: procesat
       confirm: confirmă
-      considered_risky:
+      considered_risky: 
       delivery: livrare
       payment: plată
       resumed: reluat
@@ -843,7 +845,7 @@ ro:
     order_total: Total comandă
     order_updated: Comandă salvată
     orders: Comenzi
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Nu mai este pe stoc
     overview: Sumar
     package_from: pachet din
@@ -856,11 +858,11 @@ ro:
     path: Rută
     pay: plătește
     payment: Plată
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Informații plată
     payment_method: Metodă de plată
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Metode de plată
     payment_processing_failed: Plata nu a putut fi procesată, te rugăm verifică dacă datele introduse sunt corecte
     payment_processor_choose_banner_text: Dacă aveți nevoie de ajutor pentru a alege un procesor de plați, vă rugăm vizitați
@@ -873,12 +875,12 @@ ro:
       credit_owed: credit datorat
       failed: nereușit
       paid: plătit
-      pending: "în așteptare"
+      pending: în așteptare
       processing: se procesează
       void: void
     payment_updated: Plată salvată
     payments: Plăți
-    pending:
+    pending: 
     percent: Procent
     percent_per_item: Procent per articol
     permalink: Permalink
@@ -887,13 +889,13 @@ ro:
     please_define_payment_methods: Vă rugăm, definiție metode de plată prima dată.
     populate_get_error: Ceva a mers prost. Vă rugăm încercați să adăugați articolul din nou.
     powered_by: Realizat de
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Descriere
     previous: Precedent
-    previous_state_missing:
+    previous_state_missing: 
     price: Preț
     price_range: Gamă de preț
     price_sack: Sac de preț
@@ -905,10 +907,10 @@ ro:
     product_properties: Proprietăți produs
     product_rule:
       choose_products: Alege produse
-      label:
+      label: 
       match_all: toate
       match_any: cel puțin unul
-      match_none:
+      match_none: 
       product_source:
         group: Din grup de produse
         manual: Alege de mână
@@ -920,14 +922,14 @@ ro:
         description: Crează o ajustare de credit promoțională la comandă
         name: Crează ajustare
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Populează coșul cu cantitatea specificată a variantei
         name: Adaugă articole la comandă
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Acțiuni
     promotion_form:
       match_policies:
@@ -945,27 +947,27 @@ ro:
         description: Clientul trebuie să fi vizitat pagina specificată
         name: Pagina de aterizare
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Comanda include produsul / produsele specificate
         name: Produs(e)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Disponibil doar pentru utilizatorii specificați
         name: Utilizator
       user_logged_in:
         description: Valabil doar utilzatorilor autentificați
         name: Utilizator autentificat
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promoții
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Proprietăți
     property: Proprietate
     prototype: Prototip
@@ -976,46 +978,46 @@ ro:
     quantity: Cantitate
     quantity_returned: Cantitate retururi
     quantity_shipped: Cantitate livrări
-    quick_search:
+    quick_search: 
     rate: Rată
     reason: Motiv
     receive: primește
     receive_stock: Primește stoc
     received: Primit
-    reception_status:
+    reception_status: 
     reference: Referință
     refund: Restituire
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
-    register: "Înregistrează-te ca utilizator nou"
-    registration: "Înregistrare"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
+    register: Înregistrează-te ca utilizator nou
+    registration: Înregistrare
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
-    remember_me: "Ține-mi minte datele"
-    remove: "Șterge"
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
+    remember_me: Ține-mi minte datele
+    remove: Șterge
     rename: Redenumește
-    report:
+    report: 
     reports: Rapoarte
     resend: Trimite din nou
     reset_password: Resetează parola
@@ -1024,34 +1026,34 @@ ro:
     resumed: Reluat
     return: retur
     return_authorization: Aviz de retur
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Aviz de retur salvată
     return_authorizations: Aviz de retur
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Cantitate retur
     returned: Returnat
-    returns:
+    returns: 
     review: Revizuie
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: Credit pentru avizul de retur a mărfii
     rma_number: Număr pentru avizul de retur a mărfii
     rma_value: Valoare pentru avizul de retur a mărfii
     roles: Roluri
     rules: Reguli
-    safe:
+    safe: 
     sales_total: Total vânzări
     sales_total_description: Total vânzări pentru toate comenzile
     sales_totals: Total vânzări
     save_and_continue: Salvează și continuă
-    save_my_address:
+    save_my_address: 
     say_no: Nu
     say_yes: Da
     scope: Gamă
@@ -1061,8 +1063,8 @@ ro:
     secure_connection_type: Tip de conexiune securizată
     security_settings: Setări de siguranță
     select: Selectează
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Selectează din prototip
     select_stock: Selectează stoc
     send_copy_of_all_mails_to: Trimite o copie a tuturor emailurilor către
@@ -1074,8 +1076,8 @@ ro:
     ship_address: Adresa de livrare
     ship_total: Total livrare
     shipment: Livrare
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Dragă client,\n
@@ -1088,13 +1090,13 @@ ro:
     shipment_state: Stare livrare
     shipment_states:
       backorder: comandă în afara stocului
-      canceled:
+      canceled: 
       partial: parțial
-      pending: "în așteptare"
+      pending: în așteptare
       ready: pregătit
       shipped: livrat
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Livrări
     shipped: Livrare
     shipping: Livrare
@@ -1108,69 +1110,70 @@ ro:
     shipping_method: Metodă livrare
     shipping_methods: Metode livrare
     shipping_price_sack: Sac de preț
-    shipping_total:
+    shipping_total: 
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: Coș cumpărături
     show: Afișează
     show_active: Afișează produsele active
     show_deleted: Afișează și produsele care au fost șterse
     show_only_complete_orders: Afișează doar comenzile neprocesate
-    show_only_considered_risky:
+    show_only_considered_risky: 
     show_rate_in_label: Afișează rata în etichetă
     sku: Cod produs
-    skus:
-    slug:
+    skus: 
+    slug: 
     source: Sursa
     special_instructions: Instrucțiuni speciale
     split: Divide
-    spree_gateway_error_flash_for_checkout: A apărut o problemă legat de informațiile de plată. Te rugăm verifică dacă informațiile sunt corecte și mai încearcă odaată.
+    spree_gateway_error_flash_for_checkout: A apărut o problemă legat de informațiile de plată. Te rugăm verifică dacă informațiile sunt corecte
+      și mai încearcă odaată.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: De la
     state: Județ / regiune
     state_based: Bazat pe un județ / regiune
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Județe
     states_required: Județe obligatorii
     status: Status
-    stock:
+    stock: 
     stock_location: Locație stoc
     stock_location_info: Informații locație stoc
     stock_locations: Locații stoc
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Gestionare stoc
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: 
     stock_movements: Mișcări stoc
     stock_movements_for_stock_location: Mișcări stoc pentru %{stock_location_name}
     stock_successfully_transferred: Stoc transferat cu succes între locații
@@ -1182,33 +1185,36 @@ ro:
     street_address_2: Strada (cont.)
     subtotal: Subtotal
     subtract: Scade
-    success:
+    success: 
     successfully_created: "%{resource} a fost creată cu succes!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} a fost ștearsă cu succes!"
     successfully_signed_up_for_analytics: Ați fost înregistrat cu success la Spree Analytics
     successfully_updated: "%{resource} a fost salvată cu succes!"
-    summary:
+    summary: 
     tax: Taxe
     tax_categories: Categorii taxe
     tax_category: Categorie Taxe
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation: Ratele de taxe sunt o valoare decimală folosită pentru ajutorarea calculelor, (ex. dacă rata taxei este 5% atunci introduceți 0.05)
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: Ratele de taxe sunt o valoare decimală folosită pentru ajutorarea calculelor, (ex. dacă rata taxei este 5% atunci
+      introduceți 0.05)
     tax_rates: Tarif taxe
     taxon: Clasă
     taxon_edit: Editare clasă
     taxon_placeholder: Adaugă un taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Clasificări
     taxonomy: Taxonomie
     taxonomy_edit: Modifică clasificări
     taxonomy_tree_error: Schimbarea cerută nu a fost acceptată, iar structura s-a reîntors la starea de dinainte, te rugăm încearcă din nou.
-    taxonomy_tree_instruction: "* Click de dreapta pe una din subcategoriile din structură, pentru a accesa meniul care îți permite să adaugi, să ștergi sau să sortezi sub-categoriile."
+    taxonomy_tree_instruction: >-
+      * Click de dreapta pe una din subcategoriile din structură, pentru a accesa meniul care îți permite să adaugi, să ștergi sau să sortezi
+      sub-categoriile.
     taxons: Clase
     test: Test
     test_mailer:
@@ -1218,26 +1224,26 @@ ro:
         subject: Email de test
     test_mode: Mod Testare
     thank_you_for_your_order: Mulțumim pentru comandă. Te rugăm să tipărești o copie a acestei pagini de confirmare pentru registrele tale.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: Au apărut probleme la următoarele câmpuri
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: miniatură
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Timp
     to_add_variants_you_must_first_define: Pentru a adăuga variante, trebuie mai întâi să le definești
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Tracking
     tracking_number: Număr de tracking
     tracking_url: URL de tracking
     tracking_url_placeholder: ex. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: 
     transfer_from_location: Transferă din
     transfer_stock: Transfer stoc
     transfer_to_location: Transferă către
@@ -1245,7 +1251,7 @@ ro:
     type: Tastează
     type_to_search: Tastează pentru căutare
     unable_to_connect_to_gateway: Nu se poate conecta la procesator de plăți.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Sub %{price}
     unlock: Deblochează
     unrecognized_card_type: Acest tip de card nu este recunoscut
@@ -1253,7 +1259,7 @@ ro:
     update: Salvează
     updating: Se salvează
     usage_limit: Limită de utilizare
-    use_app_default:
+    use_app_default: 
     use_billing_address: Folosește adresa de facturare
     use_new_cc: Folosește alt card
     use_s3: Folosește Amazon S3 pentru imagini
@@ -1263,15 +1269,15 @@ ro:
     users: Utilizatori
     validation:
       cannot_be_less_than_shipped_units: nu poate fi mai mic de numărul de unități livrate.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: depășește stocul disponibil. Vă rugăm verificați ca liniile comenzii să aibă cantități valide.
       is_too_large: este prea mare -- stocul actual nu acoperă cantitatea comandată!
       must_be_int: trebuie să fie indivizibil
       must_be_non_negative: trebuie să fie o valoare pozitivă sau nulă
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Valoare
     variant: Variantă
-    variant_placeholder:
+    variant_placeholder: 
     variants: Variante
     version: Versiune
     void: Void

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,1356 +1,1360 @@
+---
 ru:
   activerecord:
     attributes:
       spree/address:
-        address1: "Адрес"
-        address2: "адрес (продолж.)"
-        city: "Населённый пункт"
-        country: "Страна"
-        firstname: "Имя"
-        lastname: "Фамилия"
-        phone: "Телефон"
-        state: "Область/Регион"
-        zipcode: "Почтовый индекс"
+        address1: Адрес
+        address2: адрес (продолж.)
+        city: Населённый пункт
+        country: Страна
+        firstname: Имя
+        lastname: Фамилия
+        phone: Телефон
+        state: Область/Регион
+        zipcode: Почтовый индекс
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
         iso_name: ISO-имя
-        name: "Название"
+        name: Название
         numcode: ISO-код
       spree/credit_card:
-        base:
-        cc_type: "Тип кредитной карты"
-        month: "Месяц"
-        name:
-        number: "Номер"
-        verification_value: "Значение проверки"
-        year: "Год"
+        base: 
+        cc_type: Тип кредитной карты
+        month: Месяц
+        name: 
+        number: Номер
+        verification_value: Значение проверки
+        year: Год
       spree/inventory_unit:
-        state: "Состояние"
+        state: Состояние
       spree/line_item:
-        price: "Цена"
-        quantity: "Кол-во"
+        price: Цена
+        quantity: Кол-во
       spree/option_type:
-        name: "Название"
-        presentation: "Представление"
+        name: Название
+        presentation: Представление
       spree/order:
-        checkout_complete: "Оформление заказа завершено"
-        completed_at: "Завершено"
-        considered_risky: "Статус риска"
-        coupon_code: "Код купона"
-        created_at: "Дата заказа"
+        checkout_complete: Оформление заказа завершено
+        completed_at: Завершено
+        considered_risky: Статус риска
+        coupon_code: Код купона
+        created_at: Дата заказа
         email: E-mail покупателя
         ip_address: IP-адрес
-        item_total: "Итого по товарам"
-        number: "Номер"
-        payment_state: "Состояние оплаты"
-        shipment_state: "Состояние доставки"
-        special_instructions: "Специальные инструкции"
-        state: "Состояние"
-        total: "Итого по заказу"
+        item_total: Итого по товарам
+        number: Номер
+        payment_state: Состояние оплаты
+        shipment_state: Состояние доставки
+        special_instructions: Специальные инструкции
+        state: Состояние
+        total: Итого по заказу
       spree/order/bill_address:
-        address1: "Улица"
-        city: "Город"
-        firstname: "Имя"
-        lastname: "Фамилия"
-        phone: "Телефон"
-        state: "Область/Регион"
-        zipcode: "Почтовый индекс"
+        address1: Улица
+        city: Город
+        firstname: Имя
+        lastname: Фамилия
+        phone: Телефон
+        state: Область/Регион
+        zipcode: Почтовый индекс
       spree/order/ship_address:
-        address1: "Улица"
-        city: "Город"
-        firstname: "Имя"
-        lastname: "Фамилия"
-        phone: "Телефон"
-        state: "Область/Регион"
-        zipcode: "Почтовый индекс"
+        address1: Улица
+        city: Город
+        firstname: Имя
+        lastname: Фамилия
+        phone: Телефон
+        state: Область/Регион
+        zipcode: Почтовый индекс
       spree/payment:
-        amount: "Количество"
+        amount: Количество
       spree/payment_method:
-        name: "Название"
+        name: Название
       spree/product:
-        available_on: "Доступен с"
-        cost_currency: "Валюта"
-        cost_price: "Себестоимость"
-        description: "Описание"
-        master_price: "Цена"
-        name: "Название"
-        on_hand: "На складе"
-        shipping_category: "Категория доставки"
-        tax_category: "Категория налогов"
+        available_on: Доступен с
+        cost_currency: Валюта
+        cost_price: Себестоимость
+        description: Описание
+        master_price: Цена
+        name: Название
+        on_hand: На складе
+        shipping_category: Категория доставки
+        tax_category: Категория налогов
       spree/promotion:
-        advertise: "Рекламировать"
-        code: "Код"
-        description: "Описание"
-        event_name: "Название события"
-        expires_at: "Истекает в"
-        name: "Название"
-        path: "Путь"
-        starts_at: "Начинается"
-        usage_limit: "Лимит использования"
+        advertise: Рекламировать
+        code: Код
+        description: Описание
+        event_name: Название события
+        expires_at: Истекает в
+        name: Название
+        path: Путь
+        starts_at: Начинается
+        usage_limit: Лимит использования
       spree/promotion_category:
-        name: "Название"
-        code: "Код"
+        code: Код
+        name: Название
       spree/property:
-        name: "Название"
-        presentation: "Представление"
+        name: Название
+        presentation: Представление
       spree/prototype:
-        name: "Название"
+        name: Название
       spree/return_authorization:
-        amount: "Сумма"
+        amount: Сумма
       spree/role:
-        name: "Название"
+        name: Название
       spree/state:
-        abbr: "Аббревиатура"
-        name: "Название"
+        abbr: Аббревиатура
+        name: Название
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address: "Отсылать почту как"
+        mail_from_address: Отсылать почту как
         meta_description: Meta-описание
         meta_keywords: Meta ключевые слова
-        name: "Название сайта"
+        name: Название сайта
         seo_title: SEO-заголовок
         url: URL-адрес сайта
       spree/tax_category:
-        description: "Описание"
-        name: "Название"
+        description: Описание
+        name: Название
       spree/tax_rate:
-        amount: "Ставка"
-        included_in_price: "Включено в цену"
-        show_rate_in_label: "Показывать ставку в метке"
+        amount: Ставка
+        included_in_price: Включено в цену
+        show_rate_in_label: Показывать ставку в метке
       spree/taxon:
-        name: "Название"
-        permalink: "Постоянная ссылка"
-        position: "Позиция"
+        name: Название
+        permalink: Постоянная ссылка
+        position: Позиция
       spree/taxonomy:
-        name: "Название"
+        name: Название
       spree/user:
         email: Email
-        password: "Пароль"
-        password_confirmation: "Подтверждение пароля"
+        password: Пароль
+        password_confirmation: Подтверждение пароля
       spree/variant:
-        cost_currency: "Валюта"
-        cost_price: "Себестоимость"
-        depth: "Толщина"
-        height: "Высота"
-        price: "Цена"
-        sku: "Артикул"
-        weight: "Вес"
-        width: "Ширина"
+        cost_currency: Валюта
+        cost_price: Себестоимость
+        depth: Толщина
+        height: Высота
+        price: Цена
+        sku: Артикул
+        weight: Вес
+        width: Ширина
       spree/zone:
-        description: "Описание"
-        name: "Название"
+        description: Описание
+        name: Название
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired: "Срок действия карты истек"
-              expiry_invalid:
+              card_expired: Срок действия карты истек
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
-        many: "Адресов"
-        one: "Адрес"
-        other: "Адреса"
+        many: Адресов
+        one: Адрес
+        other: Адреса
       spree/country:
-        many: "Стран"
-        one: "Страна"
-        other: "Страны"
+        many: Стран
+        one: Страна
+        other: Страны
       spree/credit_card:
-        many: "Кредитных карт"
-        one: "Кредитная карта"
-        other: "Кредитные карты"
+        many: Кредитных карт
+        one: Кредитная карта
+        other: Кредитные карты
       spree/customer_return:
-        many: "Возвратов покупателю"
-        one: "Возврат покупателю"
-        other: "Возвраты покупателю"
+        many: Возвратов покупателю
+        one: Возврат покупателю
+        other: Возвраты покупателю
       spree/inventory_unit:
-        many: "Единиц"
-        one: "Единица"
-        other: "Единицы"
+        many: Единиц
+        one: Единица
+        other: Единицы
       spree/line_item:
-        many: "Позиций"
-        one: "Позиция"
-        other: "Позиции"
+        many: Позиций
+        one: Позиция
+        other: Позиции
       spree/option_type:
-        many: "Товарных опций"
-        one: "Товарная опция"
-        other: "Товарные опции"
-      spree/option_value:
+        many: Товарных опций
+        one: Товарная опция
+        other: Товарные опции
+      spree/option_value: 
       spree/order:
-        many: "Заказов"
-        one: "Заказ"
-        other: "Заказы"
+        many: Заказов
+        one: Заказ
+        other: Заказы
       spree/payment:
-        many: "Платежей"
-        one: "Платёж"
-        other: "Платежи"
+        many: Платежей
+        one: Платёж
+        other: Платежи
       spree/payment_method:
-        many: "Способов оплаты"
-        one: "Способ оплаты"
-        other: "Способы оплаты"
+        many: Способов оплаты
+        one: Способ оплаты
+        other: Способы оплаты
       spree/product:
-        many: "Товаров"
-        one: "Товар"
-        other: "Товары"
+        many: Товаров
+        one: Товар
+        other: Товары
       spree/promotion:
-        many: "Акций"
-        one: "Акция"
-        other: "Акции"
+        many: Акций
+        one: Акция
+        other: Акции
       spree/promotion_category:
-        many: "Категорий акций"
-        one: "Категория акций"
-        other: "Категории акций"
+        many: Категорий акций
+        one: Категория акций
+        other: Категории акций
       spree/property:
-        many: "Свойств"
-        one: "Свойство"
-        other: "Свойства"
+        many: Свойств
+        one: Свойство
+        other: Свойства
       spree/prototype:
-        many: "Прототипов"
-        one: "Прототип"
-        other: "Прототипы"
+        many: Прототипов
+        one: Прототип
+        other: Прототипы
       spree/refund_reason:
-        many: "Причин возврата"
-        one: "Причина возврата"
-        other: "Причины возврата"
-      spree/reimbursement:
+        many: Причин возврата
+        one: Причина возврата
+        other: Причины возврата
+      spree/reimbursement: 
       spree/reimbursement_type:
-        many: "Типов возврата"
-        one: "Тип возврата"
-        other: "Типы возврата"
+        many: Типов возврата
+        one: Тип возврата
+        other: Типы возврата
       spree/return_authorization:
-        many: "Разрешений на возврат"
-        one: "Разрешение на возврат"
-        other: "Разрешения на возврат"
+        many: Разрешений на возврат
+        one: Разрешение на возврат
+        other: Разрешения на возврат
       spree/return_authorization_reason:
-        many: "Причин разрешения на возврат"
-        one: "Причина разрешения на возврат"
-        other: "Причины разрешения на возврат"
+        many: Причин разрешения на возврат
+        one: Причина разрешения на возврат
+        other: Причины разрешения на возврат
       spree/role:
-        many: "Ролей"
-        one: "Роль"
-        other: "Роли"
+        many: Ролей
+        one: Роль
+        other: Роли
       spree/shipment:
-        many: "Доставок"
-        one: "Доставка"
-        other: "Доставки"
+        many: Доставок
+        one: Доставка
+        other: Доставки
       spree/shipping_category:
-        many: "Категорий доставки"
-        one: "Категория доставки"
-        other: "Категории доставки"
+        many: Категорий доставки
+        one: Категория доставки
+        other: Категории доставки
       spree/shipping_method:
         many: Cпособов доставки
         one: Cпособ доставки
         other: Cпособы доставки
       spree/state:
-        many: "Областей/Регионов"
-        one: "Область/Регион"
-        other: "Области/Регионы"
-      spree/state_change:
+        many: Областей/Регионов
+        one: Область/Регион
+        other: Области/Регионы
+      spree/state_change: 
       spree/stock_location:
-        many: "Расположений складов"
-        one: "Расположение склада"
-        other: "Расположения складов"
-      spree/stock_movement:
+        many: Расположений складов
+        one: Расположение склада
+        other: Расположения складов
+      spree/stock_movement: 
       spree/stock_transfer:
-        many: "Перемещений по складам"
-        one: "Перемещение по складам"
-        other: "Перемещения по складам"
+        many: Перемещений по складам
+        one: Перемещение по складам
+        other: Перемещения по складам
       spree/tax_category:
-        many: "Категорий налогов"
-        one: "Категория налогов"
-        other: "Категории налогов"
+        many: Категорий налогов
+        one: Категория налогов
+        other: Категории налогов
       spree/tax_rate:
-        many: "Ставок налога"
-        one: "Ставка налога"
-        other: "Ставки налога"
+        many: Ставок налога
+        one: Ставка налога
+        other: Ставки налога
       spree/taxon:
-        many: "Таксонов"
-        one: "Таксон"
-        other: "Таксона"
+        many: Таксонов
+        one: Таксон
+        other: Таксона
       spree/taxonomy:
-        many: "Таксономий"
-        one: "Таксономия"
-        other: "Таксономии"
+        many: Таксономий
+        one: Таксономия
+        other: Таксономии
       spree/tracker:
-        many: "Трекеров"
-        one: "Трекер"
-        other: "Трекеры"
+        many: Трекеров
+        one: Трекер
+        other: Трекеры
       spree/user:
-        many: "Пользователей"
-        one: "Пользователь"
-        other: "Пользователя"
+        many: Пользователей
+        one: Пользователь
+        other: Пользователя
       spree/variant:
-        many: "Вариантов"
-        one: "Вариант"
-        other: "Варианта"
+        many: Вариантов
+        one: Вариант
+        other: Варианта
       spree/zone:
-        many: "Зон"
-        one: "Зона"
-        other: "Зоны"
+        many: Зон
+        one: Зона
+        other: Зоны
   spree:
-    abbreviation: "Аббревиатура"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
-    account: "Учетная запись"
-    account_updated: "Учетная запись обновлена!"
-    action: "Действие"
+    abbreviation: Аббревиатура
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
+    account: Учетная запись
+    account_updated: Учетная запись обновлена!
+    action: Действие
     actions:
-      cancel: "Отменить"
-      continue: "Продолжить"
-      create: "Создать"
-      destroy: "Удалить"
-      edit: "Редактировать"
-      list: "Показать"
-      listing: "Список"
-      new: "Новый"
-      refund:
-      save: "Сохранить"
-      update: "Изменить"
-    activate: "Активировать"
-    active: "Активен"
-    add: "Добавить"
-    add_action_of_type: "Добавить действие типа"
-    add_country: "Добавить страну"
-    add_coupon_code: "Добавить код купона"
-    add_new_header: "Добавить новый заголовок"
-    add_new_style: "Добавить новый стиль"
-    add_one: "Добавить"
-    add_option_value: "Добавить значение опции"
-    add_product: "Добавить товар"
-    add_product_properties: "Добавить свойства товара"
-    add_rule_of_type: "Добавить правило типа"
-    add_state: "Добавить регион/область"
-    add_stock: "Добавить склад"
-    add_stock_management: "Добавить управление запасами"
-    add_to_cart: "Добавить в корзину"
-    add_variant: "Добавить вариант"
-    additional_item: "Ставка для дополнительных наименований"
-    address1: "Адрес"
-    address2: "адрес (продолж.)"
-    adjustable: "Корректируемое"
-    adjustment: "Корректировка"
-    adjustment_amount: "Количество"
-    adjustment_successfully_closed: "Корректировка была успешно закрыта!"
-    adjustment_successfully_opened: "Корректировка была успешно открыта!"
-    adjustment_total: "Итого (коррект.)"
-    adjustments: "Корректировки"
+      cancel: Отменить
+      continue: Продолжить
+      create: Создать
+      destroy: Удалить
+      edit: Редактировать
+      list: Показать
+      listing: Список
+      new: Новый
+      refund: 
+      save: Сохранить
+      update: Изменить
+    activate: Активировать
+    active: Активен
+    add: Добавить
+    add_action_of_type: Добавить действие типа
+    add_country: Добавить страну
+    add_coupon_code: Добавить код купона
+    add_new_header: Добавить новый заголовок
+    add_new_style: Добавить новый стиль
+    add_one: Добавить
+    add_option_value: Добавить значение опции
+    add_product: Добавить товар
+    add_product_properties: Добавить свойства товара
+    add_rule_of_type: Добавить правило типа
+    add_state: Добавить регион/область
+    add_stock: Добавить склад
+    add_stock_management: Добавить управление запасами
+    add_to_cart: Добавить в корзину
+    add_variant: Добавить вариант
+    additional_item: Ставка для дополнительных наименований
+    address1: Адрес
+    address2: адрес (продолж.)
+    adjustable: Корректируемое
+    adjustment: Корректировка
+    adjustment_amount: Количество
+    adjustment_successfully_closed: Корректировка была успешно закрыта!
+    adjustment_successfully_opened: Корректировка была успешно открыта!
+    adjustment_total: Итого (коррект.)
+    adjustments: Корректировки
     admin:
       tab:
-        configuration: "Настройки"
-        option_types: "Товарные опции"
-        orders: "Заказы"
-        overview: "Обзор"
-        products: "Товары"
-        promotions: "Акции"
-        promotion_categories: "Категории акций"
-        properties: "Свойства"
-        prototypes: "Прототипы"
-        reports: "Отчёты"
-        taxonomies: "Таксономии"
-        taxons: "Таксоны"
-        users: "Пользователи"
+        configuration: Настройки
+        option_types: Товарные опции
+        orders: Заказы
+        overview: Обзор
+        products: Товары
+        promotion_categories: Категории акций
+        promotions: Акции
+        properties: Свойства
+        prototypes: Прототипы
+        reports: Отчёты
+        taxonomies: Таксономии
+        taxons: Таксоны
+        users: Пользователи
       user:
-        account: "Учетная запись"
-        addresses: "Адреса"
-        items: "Товары"
-        items_purchased: "Купленные товары"
-        order_history: "История заказов"
-        order_num:
-        orders: "Заказы"
-        user_information: "Информация"
-    administration: "Администрирование"
-    advertise:
-    agree_to_privacy_policy: "Согласиться с Политикой Конфиденциальности"
-    agree_to_terms_of_service: "Согласиться с Уловиями обслуживания"
-    all: "все"
-    all_adjustments_closed: "Все корректировки успешно закрыты!"
-    all_adjustments_opened: "Все корректировки успешно открыты!"
-    all_departments: "Все разделы"
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test: "Разрешить SSL для development и test режимов"
-    allow_ssl_in_production: "Разрешить SSL для production режима"
-    allow_ssl_in_staging: "Разрешить SSL для staging режима"
-    already_signed_up_for_analytics: "Вы уже зарегистировались в Spree Analytics"
-    alt_text: "Альтернативный текст"
-    alternative_phone: "Дополнительный телефон"
-    amount: "Сумма"
-    analytics_desc_header_1: "Аналитика Spree"
-    analytics_desc_header_2: "Аналитика в прямом эфире добавлена на Spree dashboard"
-    analytics_desc_list_1: "Получать информацию о продажах в реальном времени"
-    analytics_desc_list_2: "Бесплатный аккаунт Spree требуется для активации"
-    analytics_desc_list_3: "Отсутствует код для установки"
-    analytics_desc_list_4: "Полностью бесплатный!"
-    analytics_trackers: "Трекеры веб-аналитики"
-    and: "и"
-    approve: "Подтвердить"
-    approved_at: "Подтверждено"
-    approver: "Подтвердил(а)"
-    are_you_sure: "Вы уверены"
-    are_you_sure_delete: "Вы уверены, что хотите удалить эту запись?"
-    associated_adjustment_closed: "Связанная корректировка закрыта, и не будет пересчитана. Хотите ли вы открыть её?"
-    at_symbol: '@'
-    authorization_failure: "Ошибка авторизации"
-    authorized:
-    auto_capture: "Автозахват"
-    available_on: "Доступно с"
-    average_order_value: "Средняя сумма заказа"
-    avs_response:
-    back: "Назад"
-    back_end: "в администраторском интерфейсе"
-    back_to_payment:
-    back_to_resource_list: "Назад к списку"
-    back_to_rma_reason_list: "Назад к списку причин разрешения на возврат"
-    back_to_store: "Вернуться в магазин"
-    back_to_users_list: "Назад к списку пользователей"
-    backorderable: "Возможен предзаказ"
-    backorderable_default: "Предзаказ по умолчанию"
-    backordered: "Предзаказано"
-    backorders_allowed: "Предзаказы разрешены"
-    balance_due: "Дебетовое сальдо"
-    base_amount:
-    base_percent:
-    bill_address: "Платёжный адрес"
-    billing: "Биллинг"
-    billing_address: "Платёжный адрес"
-    both: "везде"
-    calculated_reimbursements:
-    calculator: "Калькулятор"
-    calculator_settings_warning: "При изменении типа калькулятора, вы должны сохранить это изменение, прежде, чем вы сможете изменить настройки калькулятора."
-    cancel: "Отмена"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: "Нельзя создать платеж для заказа, если не настроен ни один из способов оплаты."
-    cannot_create_returns: "Невозможно оформить возврат, т.к. этот заказ ещё не отправлен."
-    cannot_perform_operation: "Невозможно выполнить требуемую операцию"
-    cannot_set_shipping_method_without_address: "Невозможно выбрать способ доставки, пока данные пользователя не указаны."
-    capture: "Провести платёж"
-    capture_events: "Платежи"
-    card_code: "Код карты"
-    card_number: "Номер карты"
-    card_type:
-    card_type_is: "Тип карты"
-    cart: "Корзина"
-    cart_subtotal:
-    categories: "Категории"
-    category: "Категория"
-    charged:
-    check_for_spree_alerts: "Проверить оповещения Spree"
-    checkout: "Оформление заказа"
-    choose_a_customer: "Выберите клиента"
-    choose_a_taxon_to_sort_products_for: "Выберите таксон для сортировки товаров"
-    choose_currency: "Выбрать валюту"
-    choose_dashboard_locale: "Выбрать язык отображения панели управления"
-    choose_location:
-    city: "Город"
-    clear_cache: "Очистить кэш"
-    clear_cache_ok:
-    clear_cache_warning: "Внимание, данное действие приведёт к очистке кэша"
-    click_and_drag_on_the_products_to_sort_them: "Перетаскивайте товары мышкой для сортировки"
-    clone: "Копировать"
-    close: "Закрыть"
-    close_all_adjustments: "Закрыть все корректировки"
-    code: "Кодовое слово"
-    company: "Компания"
-    complete: "Завершено"
-    configuration: "Конфигурация"
-    configurations: "Конфигурация"
-    confirm: "Подтвердить"
-    confirm_delete: "Подтверждение удаления"
-    confirm_password: "Подтверждение пароля"
-    continue: "Продолжить"
-    continue_shopping: "Продолжить покупки"
-    cost_currency: "Валюта"
-    cost_price: "Себестоимость"
-    could_not_connect_to_jirafe: "Невозможно синхоринизороваться с Jirafe. Попытка будет повторена позже."
-    could_not_create_customer_return:
-    could_not_create_stock_movement: "Возникла проблема при сохранении перемещения запасов. Пожалуйста, попытайтесь снова."
-    count_on_hand: "Наличие"
-    countries: "Страны"
-    country: "Страна"
-    country_based: "Страна"
-    country_name: "Имя"
+        account: Учетная запись
+        addresses: Адреса
+        items: Товары
+        items_purchased: Купленные товары
+        order_history: История заказов
+        order_num: 
+        orders: Заказы
+        user_information: Информация
+    administration: Администрирование
+    advertise: 
+    agree_to_privacy_policy: Согласиться с Политикой Конфиденциальности
+    agree_to_terms_of_service: Согласиться с Уловиями обслуживания
+    all: все
+    all_adjustments_closed: Все корректировки успешно закрыты!
+    all_adjustments_opened: Все корректировки успешно открыты!
+    all_departments: Все разделы
+    all_items_have_been_returned: 
+    allow_ssl_in_development_and_test: Разрешить SSL для development и test режимов
+    allow_ssl_in_production: Разрешить SSL для production режима
+    allow_ssl_in_staging: Разрешить SSL для staging режима
+    already_signed_up_for_analytics: Вы уже зарегистировались в Spree Analytics
+    alt_text: Альтернативный текст
+    alternative_phone: Дополнительный телефон
+    amount: Сумма
+    analytics_desc_header_1: Аналитика Spree
+    analytics_desc_header_2: Аналитика в прямом эфире добавлена на Spree dashboard
+    analytics_desc_list_1: Получать информацию о продажах в реальном времени
+    analytics_desc_list_2: Бесплатный аккаунт Spree требуется для активации
+    analytics_desc_list_3: Отсутствует код для установки
+    analytics_desc_list_4: Полностью бесплатный!
+    analytics_trackers: Трекеры веб-аналитики
+    and: и
+    approve: Подтвердить
+    approved_at: Подтверждено
+    approver: Подтвердил(а)
+    are_you_sure: Вы уверены
+    are_you_sure_delete: Вы уверены, что хотите удалить эту запись?
+    associated_adjustment_closed: Связанная корректировка закрыта, и не будет пересчитана. Хотите ли вы открыть её?
+    at_symbol: "@"
+    authorization_failure: Ошибка авторизации
+    authorized: 
+    auto_capture: Автозахват
+    available_on: Доступно с
+    average_order_value: Средняя сумма заказа
+    avs_response: 
+    back: Назад
+    back_end: в администраторском интерфейсе
+    back_to_payment: 
+    back_to_resource_list: Назад к списку
+    back_to_rma_reason_list: Назад к списку причин разрешения на возврат
+    back_to_store: Вернуться в магазин
+    back_to_users_list: Назад к списку пользователей
+    backorderable: Возможен предзаказ
+    backorderable_default: Предзаказ по умолчанию
+    backordered: Предзаказано
+    backorders_allowed: Предзаказы разрешены
+    balance_due: Дебетовое сальдо
+    base_amount: 
+    base_percent: 
+    bill_address: Платёжный адрес
+    billing: Биллинг
+    billing_address: Платёжный адрес
+    both: везде
+    calculated_reimbursements: 
+    calculator: Калькулятор
+    calculator_settings_warning: При изменении типа калькулятора, вы должны сохранить это изменение, прежде, чем вы сможете изменить настройки
+      калькулятора.
+    cancel: Отмена
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: Нельзя создать платеж для заказа, если не настроен ни один из способов оплаты.
+    cannot_create_returns: Невозможно оформить возврат, т.к. этот заказ ещё не отправлен.
+    cannot_perform_operation: Невозможно выполнить требуемую операцию
+    cannot_set_shipping_method_without_address: Невозможно выбрать способ доставки, пока данные пользователя не указаны.
+    capture: Провести платёж
+    capture_events: Платежи
+    card_code: Код карты
+    card_number: Номер карты
+    card_type: 
+    card_type_is: Тип карты
+    cart: Корзина
+    cart_subtotal: 
+    categories: Категории
+    category: Категория
+    charged: 
+    check_for_spree_alerts: Проверить оповещения Spree
+    checkout: Оформление заказа
+    choose_a_customer: Выберите клиента
+    choose_a_taxon_to_sort_products_for: Выберите таксон для сортировки товаров
+    choose_currency: Выбрать валюту
+    choose_dashboard_locale: Выбрать язык отображения панели управления
+    choose_location: 
+    city: Город
+    clear_cache: Очистить кэш
+    clear_cache_ok: 
+    clear_cache_warning: Внимание, данное действие приведёт к очистке кэша
+    click_and_drag_on_the_products_to_sort_them: Перетаскивайте товары мышкой для сортировки
+    clone: Копировать
+    close: Закрыть
+    close_all_adjustments: Закрыть все корректировки
+    code: Кодовое слово
+    company: Компания
+    complete: Завершено
+    configuration: Конфигурация
+    configurations: Конфигурация
+    confirm: Подтвердить
+    confirm_delete: Подтверждение удаления
+    confirm_password: Подтверждение пароля
+    continue: Продолжить
+    continue_shopping: Продолжить покупки
+    cost_currency: Валюта
+    cost_price: Себестоимость
+    could_not_connect_to_jirafe: Невозможно синхоринизороваться с Jirafe. Попытка будет повторена позже.
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: Возникла проблема при сохранении перемещения запасов. Пожалуйста, попытайтесь снова.
+    count_on_hand: Наличие
+    countries: Страны
+    country: Страна
+    country_based: Страна
+    country_name: Имя
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon: "Купон"
-    coupon_code: "Код купона"
-    coupon_code_already_applied: "Скидочный купон уже был применен к этому заказу"
-    coupon_code_applied: "Купон успешно применен к Вашему заказу."
-    coupon_code_better_exists: "Предыдущий купон выгоднее"
-    coupon_code_expired: "Код купона истек"
-    coupon_code_max_usage: "Лимит использования кода купона превышен"
-    coupon_code_not_eligible: "Это скидочный купон не отвечает требованиям для этого заказа"
-    coupon_code_not_found: "Скидочный купон не существует. Пожалуйста, попробуйте еще раз."
-    coupon_code_unknown_error:
-    create: "Создать"
-    create_a_new_account: "Создать новую учетную запись"
-    create_new_order: "Создать новый заказ"
-    create_reimbursement:
-    created_at: "Создано в"
-    credit: "Кредит"
-    credit_card: "Кредитная карта"
-    credit_cards: "Кредитные карты"
-    credit_owed: "Кредитная задолженность"
-    credits:
-    currency: "Валюта"
-    currency_decimal_mark: "Десятичный знак валюты"
-    currency_settings: "Настройки валюты"
-    currency_symbol_position: "Положение символа валюты относительно суммы"
-    currency_thousands_separator: "Разделитель тысяч валюты"
-    current: "Текущий"
-    current_promotion_usage: "Использовано: %{count}"
-    customer: "Клиент"
-    customer_details: "Реквизиты клиента"
-    customer_details_updated: "Данные клиента были обновлены."
-    customer_return:
-    customer_returns: "Возвраты покупателю"
-    customer_search: "Поиск клиента"
-    cut:
-    cvv_response:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
+    coupon: Купон
+    coupon_code: Код купона
+    coupon_code_already_applied: Скидочный купон уже был применен к этому заказу
+    coupon_code_applied: Купон успешно применен к Вашему заказу.
+    coupon_code_better_exists: Предыдущий купон выгоднее
+    coupon_code_expired: Код купона истек
+    coupon_code_max_usage: Лимит использования кода купона превышен
+    coupon_code_not_eligible: Это скидочный купон не отвечает требованиям для этого заказа
+    coupon_code_not_found: Скидочный купон не существует. Пожалуйста, попробуйте еще раз.
+    coupon_code_unknown_error: 
+    create: Создать
+    create_a_new_account: Создать новую учетную запись
+    create_new_order: Создать новый заказ
+    create_reimbursement: 
+    created_at: Создано в
+    credit: Кредит
+    credit_card: Кредитная карта
+    credit_cards: Кредитные карты
+    credit_owed: Кредитная задолженность
+    credits: 
+    currency: Валюта
+    currency_decimal_mark: Десятичный знак валюты
+    currency_settings: Настройки валюты
+    currency_symbol_position: Положение символа валюты относительно суммы
+    currency_thousands_separator: Разделитель тысяч валюты
+    current: Текущий
+    current_promotion_usage: 'Использовано: %{count}'
+    customer: Клиент
+    customer_details: Реквизиты клиента
+    customer_details_updated: Данные клиента были обновлены.
+    customer_return: 
+    customer_returns: Возвраты покупателю
+    customer_search: Поиск клиента
+    cut: 
+    cvv_response: 
     dash:
       jirafe:
         app_id: ID приложения
         app_token: Token приложения
         currently_unavailable: Jirafe недоступен. Spree автоматически подключится к Jirafe снова, когда он будет доступен.
-        explanation: "Эти поля могут быть заполнены, если вы зарегистрируетесь в Jirafe из панели администрирования."
-        header: "Настройки Аналитики Jirafe"
+        explanation: Эти поля могут быть заполнены, если вы зарегистрируетесь в Jirafe из панели администрирования.
+        header: Настройки Аналитики Jirafe
         site_id: ID сайта
-        token: "Токен"
-      jirafe_settings_updated: "Настройки Jirafe обновлены."
-    date: "Дата"
-    date_completed: "Дата завершения"
+        token: Токен
+      jirafe_settings_updated: Настройки Jirafe обновлены.
+    date: Дата
+    date_completed: Дата завершения
     date_picker:
       first_day: 1
       format: "%d.%m.%Y"
       js_format: dd.mm.yy
-    date_range: "Период времени"
-    default: "По умолчанию"
-    default_refund_amount:
-    default_tax: "Стандартный налог"
-    default_tax_zone: "Стандартный налоговый регион"
-    delete: "Удалить"
-    deleted_variants_present:
-    delivery: "Доставка"
-    depth: "Глубина"
-    description: "Описание"
-    destination: "Назначение"
-    destroy: "Удалить"
-    details: "Описание товара"
-    discount_amount: "Сумма скидки"
-    dismiss_banner: "Нет, спасибо! Я не заинтересован. Не показывайте мне больше это сообщение."
-    display: "Показать"
-    display_currency: "Показывать валюту"
-    doesnt_track_inventory:
-    edit: "Редактировать"
-    editing_resource:
-    editing_rma_reason:
-    editing_user: "Редактирование пользователя"
+    date_range: Период времени
+    default: По умолчанию
+    default_refund_amount: 
+    default_tax: Стандартный налог
+    default_tax_zone: Стандартный налоговый регион
+    delete: Удалить
+    deleted_variants_present: 
+    delivery: Доставка
+    depth: Глубина
+    description: Описание
+    destination: Назначение
+    destroy: Удалить
+    details: Описание товара
+    discount_amount: Сумма скидки
+    dismiss_banner: Нет, спасибо! Я не заинтересован. Не показывайте мне больше это сообщение.
+    display: Показать
+    display_currency: Показывать валюту
+    doesnt_track_inventory: 
+    edit: Редактировать
+    editing_resource: 
+    editing_rma_reason: 
+    editing_user: Редактирование пользователя
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email: "Электронная почта"
-    empty: "пусто"
-    empty_cart: "Очистить корзину"
-    enable_mail_delivery: "Включить доставку почты"
-    end: "Конец"
-    ending_in: "Оканчивается"
-    environment: "Среда окружения"
-    error: "ошибка"
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
+    email: Электронная почта
+    empty: пусто
+    empty_cart: Очистить корзину
+    enable_mail_delivery: Включить доставку почты
+    end: Конец
+    ending_in: Оканчивается
+    environment: Среда окружения
+    error: ошибка
     errors:
       messages:
-        could_not_create_taxon: "Невозможно создать таксон"
-        no_payment_methods_available: "Для этого окружения не настроено ни одного способа оплаты"
-        no_shipping_methods_available: "Для указанного местоположения отсутствуют способы доставки, пожалуйста, смените адрес и попробуйте снова."
+        could_not_create_taxon: Невозможно создать таксон
+        no_payment_methods_available: Для этого окружения не настроено ни одного способа оплаты
+        no_shipping_methods_available: Для указанного местоположения отсутствуют способы доставки, пожалуйста, смените адрес и попробуйте снова.
     errors_prohibited_this_record_from_being_saved:
       few: "%{count} ошибки не позволяют сохранить запись в базе"
       many: "%{count} ошибок не позволяют сохранить запись в базе"
-      one: "Одна ошибка не позволяет сохранить запись в базе"
+      one: Одна ошибка не позволяет сохранить запись в базе
       other: "%{count} ошибки не позволяют сохранить запись в базе"
-    event: "Событие"
+    event: Событие
     events:
       spree:
         cart:
-          add: "Добавление в корзину"
+          add: Добавление в корзину
         checkout:
-          coupon_code_added: "Добавлен купон"
+          coupon_code_added: Добавлен купон
         content:
-          visited: "Посещение статической страницы"
+          visited: Посещение статической страницы
         order:
-          contents_changed: "Содержимое заказа изменилось"
-        page_view: "Просмотр статической страницы"
+          contents_changed: Содержимое заказа изменилось
+        page_view: Просмотр статической страницы
         user:
-          signup: "Новый пользователь"
+          signup: Новый пользователь
     exceptions:
-      count_on_hand_setter: "Невозможно установить значение count_on_hand вручную, т.к. оно устанавливается автоматически с помощью recalculate_count_on_hand callback'а. Вместо этого, используйте `update_column(:count_on_hand, value)`"
-    exchange_for:
-    excl: "искл."
-    existing_shipments:
-    expedited_exchanges_warning:
-    expiration: "Окончание действия"
-    extension: "Расширение"
-    failed_payment_attempts:
-    filename: "Имя файла"
-    fill_in_customer_info: "Заполните информацию о клиенте"
-    filter: "Фильтр"
-    filter_results: "Результаты фильтрации"
-    finalize: "Завершить"
-    finalized:
-    find_a_taxon: "Найти таксон"
-    first_item: "Начальная ставка"
-    first_name: "Имя"
-    first_name_begins_with: "Имя начинается с"
-    flat_percent: "Фиксированный процент"
-    flat_rate_per_order: "Фиксированная ставка (за заказ)"
-    flexible_rate: "Гибкая ставка"
-    forgot_password: "Забыли пароль?"
-    free_shipping: "Бесплатная доставка"
-    free_shipping_amount:
-    front_end: "в публичном интерфейсе"
-    gateway: "Платежный шлюз"
-    gateway_config_unavailable: "Шлюз не доступен для данного окружения"
-    gateway_error: "Ошибка платежного шлюза"
-    general: "Основные"
-    general_settings: "Общие настройки"
+      count_on_hand_setter: >-
+        Невозможно установить значение count_on_hand вручную, т.к. оно устанавливается автоматически с помощью recalculate_count_on_hand callback'а.
+        Вместо этого, используйте `update_column(:count_on_hand, value)`
+    exchange_for: 
+    excl: искл.
+    existing_shipments: 
+    expedited_exchanges_warning: 
+    expiration: Окончание действия
+    extension: Расширение
+    failed_payment_attempts: 
+    filename: Имя файла
+    fill_in_customer_info: Заполните информацию о клиенте
+    filter: Фильтр
+    filter_results: Результаты фильтрации
+    finalize: Завершить
+    finalized: 
+    find_a_taxon: Найти таксон
+    first_item: Начальная ставка
+    first_name: Имя
+    first_name_begins_with: Имя начинается с
+    flat_percent: Фиксированный процент
+    flat_rate_per_order: Фиксированная ставка (за заказ)
+    flexible_rate: Гибкая ставка
+    forgot_password: Забыли пароль?
+    free_shipping: Бесплатная доставка
+    free_shipping_amount: 
+    front_end: в публичном интерфейсе
+    gateway: Платежный шлюз
+    gateway_config_unavailable: Шлюз не доступен для данного окружения
+    gateway_error: Ошибка платежного шлюза
+    general: Основные
+    general_settings: Общие настройки
     google_analytics: Google Analytics
     google_analytics_id: Google Analytics ID
-    guest_checkout: "Гостевой заказ"
-    guest_user_account: "Оформить покупку как гость"
-    has_no_shipped_units: "не имеет отправленных единиц учёта"
-    height: "Высота"
-    hide_cents: "Скрыть центы"
-    home: "Домой"
+    guest_checkout: Гостевой заказ
+    guest_user_account: Оформить покупку как гость
+    has_no_shipped_units: не имеет отправленных единиц учёта
+    height: Высота
+    hide_cents: Скрыть центы
+    home: Домой
     i18n:
-      available_locales: "Доступные переводы"
-      language: "Язык"
-      localization_settings: "Настройки локализации"
+      available_locales: Доступные переводы
+      language: Язык
+      localization_settings: Настройки локализации
       this_file_language: Russian
-      translations: "Перевод"
-    icon: "Иконка"
-    identifier:
-    image: "Изображение"
-    images: "Изображения"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl: "вкл."
-    included_in_price: "Включено в цену"
-    included_price_validation: "не может быть выбрано, если только вы настроили зону налогообложения по умолчанию"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password: "Чтобы сбросить пароль, заполните форму ниже. Новый пароль будет отправлен вам по указанному email"
-    insufficient_stock: "Недостаточно единиц товара, только %{on_hand} есть в наличии"
-    insufficient_stock_lines_present:
-    intercept_email_address: "Перехват писем"
-    intercept_email_instructions: "Заменить email получателя на этот адрес."
-    internal_name: "Внутреннее имя"
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider: "Неверно указан способ оплаты"
-    invalid_promotion_action: "Неверная промо-акция"
-    invalid_promotion_rule: "Неверно указан принцип рекламной кампании"
-    inventory: "Товарная номенклатура"
-    inventory_adjustment: "Корректировки"
-    inventory_error_flash_for_insufficient_quantity: "Один из товаров вашей корзины стал недоступен."
-    inventory_state:
-    is_not_available_to_shipment_address: "не может быть применён к указанному адресу доставки"
-    iso_name: "Имя согласно ISO"
-    item: "Наименование"
-    item_description: "Описание товара"
-    item_total: "Итого (товары)"
+      translations: Перевод
+    icon: Иконка
+    identifier: 
+    image: Изображение
+    images: Изображения
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: вкл.
+    included_in_price: Включено в цену
+    included_price_validation: не может быть выбрано, если только вы настроили зону налогообложения по умолчанию
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
+    instructions_to_reset_password: Чтобы сбросить пароль, заполните форму ниже. Новый пароль будет отправлен вам по указанному email
+    insufficient_stock: Недостаточно единиц товара, только %{on_hand} есть в наличии
+    insufficient_stock_lines_present: 
+    intercept_email_address: Перехват писем
+    intercept_email_instructions: Заменить email получателя на этот адрес.
+    internal_name: Внутреннее имя
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: Неверно указан способ оплаты
+    invalid_promotion_action: Неверная промо-акция
+    invalid_promotion_rule: Неверно указан принцип рекламной кампании
+    inventory: Товарная номенклатура
+    inventory_adjustment: Корректировки
+    inventory_error_flash_for_insufficient_quantity: Один из товаров вашей корзины стал недоступен.
+    inventory_state: 
+    is_not_available_to_shipment_address: не может быть применён к указанному адресу доставки
+    iso_name: Имя согласно ISO
+    item: Наименование
+    item_description: Описание товара
+    item_total: Итого (товары)
     item_total_rule:
       operators:
-        gt: "больше"
-        gte: "больше или равно"
-        lt:
-        lte:
-    items_cannot_be_shipped: "К сожалению мы не можем доставить ваш товар на указанный адрес. Пожалуйста введите другой адрес."
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        gt: больше
+        gte: больше или равно
+        lt: 
+        lte: 
+    items_cannot_be_shipped: К сожалению мы не можем доставить ваш товар на указанный адрес. Пожалуйста введите другой адрес.
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
-      path: "Путь"
-    last_name: "Фамилия"
-    last_name_begins_with: "Фамилия начинается с"
-    learn_more: "Узнать больше"
-    lifetime_stats: "Статистика"
-    line_item_adjustments: "Корректировки позиций"
-    list: "Список"
-    loading: "Загружается"
-    locale_changed: "Язык изменён"
-    location: "Местоположение"
+      path: Путь
+    last_name: Фамилия
+    last_name_begins_with: Фамилия начинается с
+    learn_more: Узнать больше
+    lifetime_stats: Статистика
+    line_item_adjustments: Корректировки позиций
+    list: Список
+    loading: Загружается
+    locale_changed: Язык изменён
+    location: Местоположение
     lock: Lock
-    log_entries:
-    logged_in_as: "Пользователь"
-    logged_in_succesfully: "Вы вошли в систему"
-    logged_out: "Вы вышли из системы."
-    login: "Логин"
-    login_as_existing: "Войти как покупатель"
-    login_failed: "Вход не выполнен."
-    login_name: "Логин"
-    logout: "Выйти"
-    logs: "Журналы событий"
-    look_for_similar_items: "Посмотрите похожие товары"
-    make_refund: "Сделать возврат"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
-    master_price: "Основная цена"
+    log_entries: 
+    logged_in_as: Пользователь
+    logged_in_succesfully: Вы вошли в систему
+    logged_out: Вы вышли из системы.
+    login: Логин
+    login_as_existing: Войти как покупатель
+    login_failed: Вход не выполнен.
+    login_name: Логин
+    logout: Выйти
+    logs: Журналы событий
+    look_for_similar_items: Посмотрите похожие товары
+    make_refund: Сделать возврат
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
+    master_price: Основная цена
     match_choices:
-      all: "Всем"
-      none: "Ни одному"
-    max_items: "Максимальное число наименований по начальной ставке"
-    member_since: "Зарегистр. с"
-    memo:
-    meta_description: "Описание"
-    meta_keywords: "Ключевые слова"
-    meta_title:
-    metadata: "Метаданные"
-    minimal_amount: "Минимальная сумма"
-    month: "Месяц"
-    more: "Больше"
-    move_stock_between_locations: "Перемещение товаров между складами"
-    my_account: "Моя учетная запись"
-    my_orders: "Мои заказы"
-    name: "Наименование"
-    name_on_card:
-    name_or_sku: "Наименование или артикул"
-    new: "Новый"
-    new_adjustment: "Новая корректировка"
-    new_country: "Новая страна"
-    new_customer: "Для новых пользователей"
-    new_customer_return: "Новый возврат покупателю"
-    new_image: "Новое изображение"
-    new_option_type: "Новая опция"
-    new_order: "Новый заказ"
-    new_order_completed: "Оформление заказа завершено"
-    new_payment: "Новый платёж"
-    new_payment_method: "Новый способ оплаты"
-    new_product: "Новый товар"
-    new_promotion: "Новая акция"
-    new_promotion_category: "Новая категория акций"
-    new_property: "Новое свойство"
-    new_prototype: "Новый прототип"
-    new_refund:
-    new_refund_reason: "Новая причина возврата"
-    new_return_authorization: "Новое разрешение на возврат"
-    new_rma_reason: "Новая причина разрешения на возврат"
-    new_shipment_at_location:
-    new_shipping_category: "Новая категория доставки"
-    new_shipping_method: "Новый способ доставки"
-    new_state: "Новый регион/область"
-    new_stock_location: "Добавить новый склад"
-    new_stock_movement: "Новое движение товара"
-    new_stock_transfer: "Новое перемещение по складу"
-    new_tax_category: "Новая категория налогов"
-    new_tax_rate: "Новая ставка налога"
-    new_taxon: "Новый таксон"
-    new_taxonomy: "Новая таксономия"
-    new_tracker: "Новый трекер"
-    new_user: "Новый пользователь"
-    new_variant: "Новый вариант"
-    new_zone: "Новая зона"
-    next: "след."
-    no_actions_added: "Нет действий"
-    no_payment_found:
-    no_pending_payments: "Нет незавершённых платежей"
-    no_products_found: "Не найдено ни одного товара"
+      all: Всем
+      none: Ни одному
+    max_items: Максимальное число наименований по начальной ставке
+    member_since: Зарегистр. с
+    memo: 
+    meta_description: Описание
+    meta_keywords: Ключевые слова
+    meta_title: 
+    metadata: Метаданные
+    minimal_amount: Минимальная сумма
+    month: Месяц
+    more: Больше
+    move_stock_between_locations: Перемещение товаров между складами
+    my_account: Моя учетная запись
+    my_orders: Мои заказы
+    name: Наименование
+    name_on_card: 
+    name_or_sku: Наименование или артикул
+    new: Новый
+    new_adjustment: Новая корректировка
+    new_country: Новая страна
+    new_customer: Для новых пользователей
+    new_customer_return: Новый возврат покупателю
+    new_image: Новое изображение
+    new_option_type: Новая опция
+    new_order: Новый заказ
+    new_order_completed: Оформление заказа завершено
+    new_payment: Новый платёж
+    new_payment_method: Новый способ оплаты
+    new_product: Новый товар
+    new_promotion: Новая акция
+    new_promotion_category: Новая категория акций
+    new_property: Новое свойство
+    new_prototype: Новый прототип
+    new_refund: 
+    new_refund_reason: Новая причина возврата
+    new_return_authorization: Новое разрешение на возврат
+    new_rma_reason: Новая причина разрешения на возврат
+    new_shipment_at_location: 
+    new_shipping_category: Новая категория доставки
+    new_shipping_method: Новый способ доставки
+    new_state: Новый регион/область
+    new_stock_location: Добавить новый склад
+    new_stock_movement: Новое движение товара
+    new_stock_transfer: Новое перемещение по складу
+    new_tax_category: Новая категория налогов
+    new_tax_rate: Новая ставка налога
+    new_taxon: Новый таксон
+    new_taxonomy: Новая таксономия
+    new_tracker: Новый трекер
+    new_user: Новый пользователь
+    new_variant: Новый вариант
+    new_zone: Новая зона
+    next: след.
+    no_actions_added: Нет действий
+    no_payment_found: 
+    no_pending_payments: Нет незавершённых платежей
+    no_products_found: Не найдено ни одного товара
     no_resource_found: "%{resource} не найдены"
-    no_results: "Ничего не найдено"
-    no_returns_found:
-    no_rules_added: "Ни одного правила не задано"
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present: "Отсутствуют детали отслеживания"
-    none: "Ни одного"
-    none_selected:
-    normal_amount: "Обычная сумма"
-    not: "не"
-    not_available: "Не доступен"
-    not_enough_stock: "Недостаточно позиций в исходном местоположении для завершения движения"
+    no_results: Ничего не найдено
+    no_returns_found: 
+    no_rules_added: Ни одного правила не задано
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: Отсутствуют детали отслеживания
+    none: Ни одного
+    none_selected: 
+    normal_amount: Обычная сумма
+    not: не
+    not_available: Не доступен
+    not_enough_stock: Недостаточно позиций в исходном местоположении для завершения движения
     not_found: "%{resource} не найден"
-    note:
+    note: 
     notice_messages:
-      product_cloned: "Копия товара создана"
-      product_deleted: "Товар успешно удалён"
-      product_not_cloned: "Товар не может быть клонирован"
-      product_not_deleted: "Товар не может быть удалён"
-      variant_deleted: "Вариант успешно удалён"
-      variant_not_deleted: "Вариант не может быть удален"
-    num_orders: "Кол-во заказов"
-    on_hand: "В наличии"
-    open: "Открыть"
-    open_all_adjustments: "Открыть все корректировки"
-    option_type: "Товарная опция"
-    option_type_placeholder: "Выберите тип опции"
-    option_types: "Товарные опции"
-    option_value: "Возможное значение опции"
-    option_values: "Возможные значения опции"
-    optional: "Не обязательно"
-    options: "Опции"
-    or: "или"
-    or_over_price: "более чем %{price}"
-    order: "Заказ"
-    order_adjustments: "Корректировки заказа"
-    order_already_updated:
-    order_approved: "Заказ подтвержден"
-    order_canceled:
-    order_details: "Реквизиты заказа"
-    order_email_resent: "Письмо с описанием заказа выслано повторно"
-    order_information: "Информация"
+      product_cloned: Копия товара создана
+      product_deleted: Товар успешно удалён
+      product_not_cloned: Товар не может быть клонирован
+      product_not_deleted: Товар не может быть удалён
+      variant_deleted: Вариант успешно удалён
+      variant_not_deleted: Вариант не может быть удален
+    num_orders: Кол-во заказов
+    on_hand: В наличии
+    open: Открыть
+    open_all_adjustments: Открыть все корректировки
+    option_type: Товарная опция
+    option_type_placeholder: Выберите тип опции
+    option_types: Товарные опции
+    option_value: Возможное значение опции
+    option_values: Возможные значения опции
+    optional: Не обязательно
+    options: Опции
+    or: или
+    or_over_price: более чем %{price}
+    order: Заказ
+    order_adjustments: Корректировки заказа
+    order_already_updated: 
+    order_approved: Заказ подтвержден
+    order_canceled: 
+    order_details: Реквизиты заказа
+    order_email_resent: Письмо с описанием заказа выслано повторно
+    order_information: Информация
     order_mailer:
       cancel_email:
-        dear_customer: "Дорогой покупатель,\n"
-        instructions: "Ваш заказ был отменен. Сохраните эту информацию для истории."
-        order_summary_canceled: "Детали заказа [ОТМЕНЕНО]"
-        subject: "Аннулирование заказа"
-        subtotal:
-        total:
+        dear_customer: Дорогой покупатель,
+        instructions: Ваш заказ был отменен. Сохраните эту информацию для истории.
+        order_summary_canceled: Детали заказа [ОТМЕНЕНО]
+        subject: Аннулирование заказа
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer: "Дорогой покупатель,\n"
-        instructions: "Пожалуйста, проверьте детали заказа."
-        order_summary: "Детали заказа"
-        subject: "Подтверждение заказа"
-        subtotal:
-        thanks: "Спасибо, что выбрали нас."
-        total:
-    order_not_found: "Мы не смогли найти Ваш заказ. Попробуйте еще раз."
-    order_number: "Заказ %{number}"
-    order_processed_successfully: "Ваш заказ был успешно обработан"
-    order_resumed:
+        dear_customer: Дорогой покупатель,
+        instructions: Пожалуйста, проверьте детали заказа.
+        order_summary: Детали заказа
+        subject: Подтверждение заказа
+        subtotal: 
+        thanks: Спасибо, что выбрали нас.
+        total: 
+    order_not_found: Мы не смогли найти Ваш заказ. Попробуйте еще раз.
+    order_number: Заказ %{number}
+    order_processed_successfully: Ваш заказ был успешно обработан
+    order_resumed: 
     order_state:
-      address: "Адрес"
-      awaiting_return: "Ожидает возврата"
-      canceled: "Отменён"
-      cart: "Корзина"
-      complete: "Завершение"
-      confirm: "Подтверждение"
-      considered_risky:
-      delivery: "Доставка"
-      payment: "Оплата"
-      resumed: "Возобновлён"
-      returned: "Возвращён"
-    order_summary: "Сводка по заказу"
-    order_sure_want_to: "Вы уверены, что хотите %{event} этот заказ?"
-    order_total: "Итого заказ"
-    order_updated: "Заказ обновлен"
-    orders: "Заказы"
-    other_items_in_other:
-    out_of_stock: "Нет в наличии"
-    overview: "Обзор"
-    package_from: "Фасовку в"
+      address: Адрес
+      awaiting_return: Ожидает возврата
+      canceled: Отменён
+      cart: Корзина
+      complete: Завершение
+      confirm: Подтверждение
+      considered_risky: 
+      delivery: Доставка
+      payment: Оплата
+      resumed: Возобновлён
+      returned: Возвращён
+    order_summary: Сводка по заказу
+    order_sure_want_to: Вы уверены, что хотите %{event} этот заказ?
+    order_total: Итого заказ
+    order_updated: Заказ обновлен
+    orders: Заказы
+    other_items_in_other: 
+    out_of_stock: Нет в наличии
+    overview: Обзор
+    package_from: Фасовку в
     pagination:
-      next_page: "следующая страница »"
+      next_page: следующая страница »
       previous_page: "« предыдущая страница"
       truncate: "…"
-    password: "Пароль"
+    password: Пароль
     paste: Paste
-    path: "Путь"
-    pay: "оплатить"
-    payment: "Платеж"
-    payment_could_not_be_created:
-    payment_identifier:
-    payment_information: "Информация о платеже"
-    payment_method: "Способ оплаты"
-    payment_method_not_supported: "Этот способ оплаты не поддерживается"
-    payment_methods: "Способы оплаты"
-    payment_processing_failed: "Невозможно произвести платёж, пожалуйста, проверьте введённую информацию"
-    payment_processor_choose_banner_text: "Если Вам нужна помощь в выборе способа оплаты, пожалуйста, зайдите на"
-    payment_processor_choose_link: "наша страница оплаты"
-    payment_state: "Статус платежа"
+    path: Путь
+    pay: оплатить
+    payment: Платеж
+    payment_could_not_be_created: 
+    payment_identifier: 
+    payment_information: Информация о платеже
+    payment_method: Способ оплаты
+    payment_method_not_supported: Этот способ оплаты не поддерживается
+    payment_methods: Способы оплаты
+    payment_processing_failed: Невозможно произвести платёж, пожалуйста, проверьте введённую информацию
+    payment_processor_choose_banner_text: Если Вам нужна помощь в выборе способа оплаты, пожалуйста, зайдите на
+    payment_processor_choose_link: наша страница оплаты
+    payment_state: Статус платежа
     payment_states:
-      balance_due: "частично"
-      checkout: "оформляется"
-      completed: "завершен"
-      credit_owed: "в кредит"
-      failed: "ошибка"
-      paid: "оплачен"
-      pending: "в ожидании"
-      processing: "в обработке"
-      void: "аннулирован"
-    payment_updated: "Платёж обновлён"
-    payments: "Платежи"
-    pending:
-    percent: "Процент"
-    percent_per_item: "Процент с каждой единицы товара"
-    permalink: "Постоянная ссылка"
-    phone: "Телефон"
-    place_order: "Разместить заказ"
-    please_define_payment_methods: "Сначала определите способ оплаты."
-    populate_get_error: "Что-то пошло не так. Попробуйте добавить товар еще раз."
-    powered_by: "Работает на"
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
-    presentation: "Отображать как"
-    previous: "пред."
-    previous_state_missing:
-    price: "Цена"
-    price_range: "Ценовой диапазон"
+      balance_due: частично
+      checkout: оформляется
+      completed: завершен
+      credit_owed: в кредит
+      failed: ошибка
+      paid: оплачен
+      pending: в ожидании
+      processing: в обработке
+      void: аннулирован
+    payment_updated: Платёж обновлён
+    payments: Платежи
+    pending: 
+    percent: Процент
+    percent_per_item: Процент с каждой единицы товара
+    permalink: Постоянная ссылка
+    phone: Телефон
+    place_order: Разместить заказ
+    please_define_payment_methods: Сначала определите способ оплаты.
+    populate_get_error: Что-то пошло не так. Попробуйте добавить товар еще раз.
+    powered_by: Работает на
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
+    presentation: Отображать как
+    previous: пред.
+    previous_state_missing: 
+    price: Цена
+    price_range: Ценовой диапазон
     price_sack: Price Sack
-    process: "Обработать"
-    product: "Товар"
-    product_details: "Описание товара"
-    product_has_no_description: "У данного товара нет описания."
-    product_not_available_in_this_currency: "Этот товар недоступен в выбранной валюте."
-    product_properties: "Свойства товара"
+    process: Обработать
+    product: Товар
+    product_details: Описание товара
+    product_has_no_description: У данного товара нет описания.
+    product_not_available_in_this_currency: Этот товар недоступен в выбранной валюте.
+    product_properties: Свойства товара
     product_rule:
-      choose_products: "Выбранные товары"
-      label:
-      match_all: "все"
-      match_any: "хотя бы один"
-      match_none:
+      choose_products: Выбранные товары
+      label: 
+      match_all: все
+      match_any: хотя бы один
+      match_none: 
       product_source:
-        group: "Из группы товаров"
-        manual: "Выбрать вручную"
-    products: "Товары"
-    promotion: "Промо-акция"
-    promotion_action: "Промо-акция"
+        group: Из группы товаров
+        manual: Выбрать вручную
+    products: Товары
+    promotion: Промо-акция
+    promotion_action: Промо-акция
     promotion_action_types:
       create_adjustment:
-        description: "Создаёт промо-корректировки для заказа"
-        name: "Создать корректировку"
+        description: Создаёт промо-корректировки для заказа
+        name: Создать корректировку
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description: "Заполняет корзину указанным количеством вариантов"
-        name: "Создать элемент заказа"
+        description: Заполняет корзину указанным количеством вариантов
+        name: Создать элемент заказа
       free_shipping:
-        description:
-        name:
-    promotion_actions: "Акции"
+        description: 
+        name: 
+    promotion_actions: Акции
     promotion_form:
       match_policies:
-        all: "Соответствует всем этим правилам"
-        any: "Соответствует хотя бы одному правилу"
-    promotion_rule: "Правило"
+        all: Соответствует всем этим правилам
+        any: Соответствует хотя бы одному правилу
+    promotion_rule: Правило
     promotion_rule_types:
       first_order:
-        description: "Должен быть первым заказом покупателя"
-        name: "Первый заказ"
+        description: Должен быть первым заказом покупателя
+        name: Первый заказ
       item_total:
-        description: "Сумма заказа соответствует следующим критериям"
-        name: "Сумма заказа"
+        description: Сумма заказа соответствует следующим критериям
+        name: Сумма заказа
       landing_page:
-        description: "Покупатель должен был попасть на указанную страницу"
-        name: "Страница"
+        description: Покупатель должен был попасть на указанную страницу
+        name: Страница
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description: "Заказ включает указанные товары"
-        name: "Товары"
+        description: Заказ включает указанные товары
+        name: Товары
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
-        description: "Доступно только для указанных пользователей"
-        name: "Пользователи"
+        description: Доступно только для указанных пользователей
+        name: Пользователи
       user_logged_in:
-        description: "Доступно только зарегистрированным пользователям"
-        name: "Пользователь авторизовался"
-    promotion_uses:
-    promotionable:
-    promotions: "Промо-акции"
-    propagate_all_variants: "Применить ко всем вариантам"
-    properties: "Свойства"
-    property: "Свойство"
-    prototype: "Прототип"
-    prototypes: "Прототипы"
-    provider: "Провайдер"
-    provider_settings_warning: "Если вы меняете провайдера, вы должны сохранить это изменение, прежде чем вы сможете изменить настройки провайдера."
-    qty: "Кол-во"
-    quantity: "Количество"
-    quantity_returned: "Количество возврата"
-    quantity_shipped: "Отправленное количество"
-    quick_search: "Поиск . . ."
-    rate: "Ставка"
-    reason: "Причина"
-    receive: "Получить"
-    receive_stock: "Получить товар"
-    received: "Получен"
-    reception_status:
-    reference: "Ссылка"
-    refund: "Возврат"
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons: "Причины возврата денег"
-    return_reasons: "Причины возврата товара"
-    refunded_amount:
-    refunds:
-    register: "Зарегистрироваться как новый пользователь"
-    registration: "Регистрация"
-    reimburse:
-    reimbursed:
-    reimbursement:
+        description: Доступно только зарегистрированным пользователям
+        name: Пользователь авторизовался
+    promotion_uses: 
+    promotionable: 
+    promotions: Промо-акции
+    propagate_all_variants: Применить ко всем вариантам
+    properties: Свойства
+    property: Свойство
+    prototype: Прототип
+    prototypes: Прототипы
+    provider: Провайдер
+    provider_settings_warning: Если вы меняете провайдера, вы должны сохранить это изменение, прежде чем вы сможете изменить настройки провайдера.
+    qty: Кол-во
+    quantity: Количество
+    quantity_returned: Количество возврата
+    quantity_shipped: Отправленное количество
+    quick_search: Поиск . . .
+    rate: Ставка
+    reason: Причина
+    receive: Получить
+    receive_stock: Получить товар
+    received: Получен
+    reception_status: 
+    reference: Ссылка
+    refund: Возврат
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: Причины возврата денег
+    refunded_amount: 
+    refunds: 
+    register: Зарегистрироваться как новый пользователь
+    registration: Регистрация
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types: "Типы возврата"
-    reimbursements:
-    reject:
-    rejected:
-    remember_me: "Запомнить меня"
-    remove: "Убрать"
-    rename: "Переименовать"
-    report:
-    reports: "Отчеты"
-    resend: "Отправить повторно"
-    reset_password: "Сбросить мой пароль"
-    response_code: "Код ответа"
-    resume: "возобновить"
-    resumed: "Возобновлен"
-    return: "возвратить"
-    return_authorization: "Разрешение на возврат"
-    return_authorization_reasons: "Причины разрешения на возврат"
-    return_authorization_updated: "Разрешение на возврат обновлено"
-    return_authorizations: "Разрешения на возврат"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number: "Номер возврата"
-    return_quantity: "возвращенное количество"
-    returned: "Возвращенные"
-    returns: "Разрешения на возврат"
-    review: "Проверить"
-    risk:
-    risk_analysis:
-    risky:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: Типы возврата
+    reimbursements: 
+    reject: 
+    rejected: 
+    remember_me: Запомнить меня
+    remove: Убрать
+    rename: Переименовать
+    report: 
+    reports: Отчеты
+    resend: Отправить повторно
+    reset_password: Сбросить мой пароль
+    response_code: Код ответа
+    resume: возобновить
+    resumed: Возобновлен
+    return: возвратить
+    return_authorization: Разрешение на возврат
+    return_authorization_reasons: Причины разрешения на возврат
+    return_authorization_updated: Разрешение на возврат обновлено
+    return_authorizations: Разрешения на возврат
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: Номер возврата
+    return_quantity: возвращенное количество
+    return_reasons: Причины возврата товара
+    returned: Возвращенные
+    returns: Разрешения на возврат
+    review: Проверить
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA Credit
-    rma_number: "Номер RMA"
-    rma_value: "Сумма RMA"
-    roles: "Роли"
-    rules: "Правила"
-    safe: "Безопасный"
-    sales_total: "Итого (продажи)"
-    sales_total_description: "Общий объём продаж по всем заказам"
-    sales_totals: "Всего продано"
-    save_and_continue: "Сохранить и продолжить"
-    save_my_address: "Сохранить адрес"
-    say_no: "Нет"
-    say_yes: "Да"
-    scope: "Фильтр"
-    search: "Поиск"
-    search_results: "Результаты поиска по запросу '%{keywords}'"
-    searching: "Идёт поиск..."
-    secure_connection_type: "Тип защищенного соединения"
-    security_settings: "Настройки безопасности"
-    select: "Выбрать"
-    select_a_return_authorization_reason: "Выбрать причину разрешения на возврат"
-    select_a_stock_location: "Выбрать адрес склада"
-    select_from_prototype: "Выбрать из прототипов"
-    select_stock: "Выбрать склад"
-    selected_quantity_not_available: 'товара %{item} недостаточно.'
-    send_copy_of_all_mails_to: "Отсылать копии всех писем на"
-    send_mails_as: "Отсылать почту как"
-    server: "Сервер"
-    server_error: "На сервере произошла ошибка"
-    settings: "Настройки"
-    ship: "доставка"
-    ship_address: "Адрес доставки"
-    ship_total: "Всего к доставке"
-    shipment: "Отправка"
-    shipment_adjustments: "Корректировки доставки"
-    shipment_details:
+    rma_number: Номер RMA
+    rma_value: Сумма RMA
+    roles: Роли
+    rules: Правила
+    safe: Безопасный
+    sales_total: Итого (продажи)
+    sales_total_description: Общий объём продаж по всем заказам
+    sales_totals: Всего продано
+    save_and_continue: Сохранить и продолжить
+    save_my_address: Сохранить адрес
+    say_no: Нет
+    say_yes: Да
+    scope: Фильтр
+    search: Поиск
+    search_results: Результаты поиска по запросу '%{keywords}'
+    searching: Идёт поиск...
+    secure_connection_type: Тип защищенного соединения
+    security_settings: Настройки безопасности
+    select: Выбрать
+    select_a_return_authorization_reason: Выбрать причину разрешения на возврат
+    select_a_stock_location: Выбрать адрес склада
+    select_from_prototype: Выбрать из прототипов
+    select_stock: Выбрать склад
+    selected_quantity_not_available: товара %{item} недостаточно.
+    send_copy_of_all_mails_to: Отсылать копии всех писем на
+    send_mails_as: Отсылать почту как
+    server: Сервер
+    server_error: На сервере произошла ошибка
+    settings: Настройки
+    ship: доставка
+    ship_address: Адрес доставки
+    ship_total: Всего к доставке
+    shipment: Отправка
+    shipment_adjustments: Корректировки доставки
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer: "Дорогой покупатель,\n"
-        instructions: "Ваш заказ был успешно отправлен."
-        shipment_summary: "Детали доставки"
-        subject: "Уведомление о доставке"
-        thanks: "Спасибо, что выбрали нас."
-        track_information: "Детали отслеживания доставки: %{tracking}"
-        track_link: "Адрес трекинга: %{url}"
-    shipment_state: "Статус отправки"
+        dear_customer: Дорогой покупатель,
+        instructions: Ваш заказ был успешно отправлен.
+        shipment_summary: Детали доставки
+        subject: Уведомление о доставке
+        thanks: Спасибо, что выбрали нас.
+        track_information: 'Детали отслеживания доставки: %{tracking}'
+        track_link: 'Адрес трекинга: %{url}'
+    shipment_state: Статус отправки
     shipment_states:
-      backorder: "задерживается"
-      canceled:
-      partial: "частично"
-      pending: "ожидает"
-      ready: "готов"
-      shipped: "отправлен"
-    shipment_transfer_error:
-    shipment_transfer_success:
-    shipments: "Отправки"
-    shipped: "Отправлено"
-    shipping: "Доставка"
-    shipping_address: "Адрес доставки"
-    shipping_categories: "Категории доставки"
-    shipping_category: "Категория доставки"
-    shipping_flat_rate_per_item: "Фиксированная ставка за единицу товара"
-    shipping_flat_rate_per_order: "Фиксированная ставка"
-    shipping_flexible_rate: "Гибкая ставка за единицу товара"
-    shipping_instructions: "Иструкции по доставке"
-    shipping_method: "Способ доставки"
-    shipping_methods: "Способы доставки"
-    shipping_price_sack: "Подсчет стоимости доставки"
-    shipping_total: "Итого (доставка)"
+      backorder: задерживается
+      canceled: 
+      partial: частично
+      pending: ожидает
+      ready: готов
+      shipped: отправлен
+    shipment_transfer_error: 
+    shipment_transfer_success: 
+    shipments: Отправки
+    shipped: Отправлено
+    shipping: Доставка
+    shipping_address: Адрес доставки
+    shipping_categories: Категории доставки
+    shipping_category: Категория доставки
+    shipping_flat_rate_per_item: Фиксированная ставка за единицу товара
+    shipping_flat_rate_per_order: Фиксированная ставка
+    shipping_flexible_rate: Гибкая ставка за единицу товара
+    shipping_instructions: Иструкции по доставке
+    shipping_method: Способ доставки
+    shipping_methods: Способы доставки
+    shipping_price_sack: Подсчет стоимости доставки
+    shipping_total: Итого (доставка)
     shop_by_taxonomy: "%{taxonomy}"
-    shopping_cart: "Корзина"
-    show: "Показать"
-    show_active: "Показать активные"
-    show_deleted: "Показать удаленные"
-    show_only_complete_orders: "Показывать только завершённые заказы"
-    show_only_considered_risky:
-    show_rate_in_label: "Показывать процент в названии"
-    sku: "Артикул"
-    skus:
-    slug: "Ссылка"
-    source: "Источник"
-    special_instructions: "Дополнительные инструкции"
-    split: "Разделить"
-    spree_gateway_error_flash_for_checkout: "Возникли проблемы с Вашими реквизитами. Пожалуйста, проверьте их и попробуйте ещё раз."
+    shopping_cart: Корзина
+    show: Показать
+    show_active: Показать активные
+    show_deleted: Показать удаленные
+    show_only_complete_orders: Показывать только завершённые заказы
+    show_only_considered_risky: 
+    show_rate_in_label: Показывать процент в названии
+    sku: Артикул
+    skus: 
+    slug: Ссылка
+    source: Источник
+    special_instructions: Дополнительные инструкции
+    split: Разделить
+    spree_gateway_error_flash_for_checkout: Возникли проблемы с Вашими реквизитами. Пожалуйста, проверьте их и попробуйте ещё раз.
     ssl:
-      change_protocol:
-    start: "Начало"
-    state: "Регион/Область"
-    state_based: "Есть области"
+      change_protocol: 
+    start: Начало
+    state: Регион/Область
+    state_based: Есть области
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states: "Регионы/Области"
-    states_required: "Регионы обязательны"
-    status: "Статус"
-    stock: "Запасы"
-    stock_location: "Расположение склада"
-    stock_location_info: "Подробности расположения склада"
-    stock_locations: "Адреса складов"
-    stock_locations_need_a_default_country:
-    stock_management: "Управление запасами"
-    stock_management_requires_a_stock_location: "Добавьте расположение склада для управления запасами."
-    stock_movements: "Перемещения товаров"
-    stock_movements_for_stock_location: "Перемещения товаров для %{stock_location_name}"
-    stock_successfully_transferred: "Товары успешно перемещены с одного склада на другой."
-    stock_transfer: "Движение товаров"
-    stock_transfers: "Движения товаров"
-    stop: "Конец"
-    store: "В магазин"
-    street_address: "Адрес"
-    street_address_2: "Адрес (строка 2)"
-    subtotal: "Подытог"
-    subtract: "Вычет"
-    success:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
+    states: Регионы/Области
+    states_required: Регионы обязательны
+    status: Статус
+    stock: Запасы
+    stock_location: Расположение склада
+    stock_location_info: Подробности расположения склада
+    stock_locations: Адреса складов
+    stock_locations_need_a_default_country: 
+    stock_management: Управление запасами
+    stock_management_requires_a_stock_location: Добавьте расположение склада для управления запасами.
+    stock_movements: Перемещения товаров
+    stock_movements_for_stock_location: Перемещения товаров для %{stock_location_name}
+    stock_successfully_transferred: Товары успешно перемещены с одного склада на другой.
+    stock_transfer: Движение товаров
+    stock_transfers: Движения товаров
+    stop: Конец
+    store: В магазин
+    street_address: Адрес
+    street_address_2: Адрес (строка 2)
+    subtotal: Подытог
+    subtract: Вычет
+    success: 
     successfully_created: "%{resource} был успешно создан!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} был успешно удален!"
-    successfully_signed_up_for_analytics: "Успешно авторизованы в Spree Analytics"
+    successfully_signed_up_for_analytics: Успешно авторизованы в Spree Analytics
     successfully_updated: "%{resource} был успешно обновлен!"
-    summary: "Сводка"
-    tax: "Налог"
-    tax_categories: "Категории налогов"
-    tax_category: "Категория налогов"
-    tax_code:
-    tax_included: "Вкл. налоги"
-    tax_rate_amount_explanation: "Налоговые ставки вводятся как десятичные значения (напр. если налог 5%, то вводите 0.05)"
-    tax_rates: "Налоговые ставки"
-    taxon: "Таксон"
-    taxon_edit: "Редактировать таксон"
-    taxon_placeholder: "Добавить таксон"
+    summary: Сводка
+    tax: Налог
+    tax_categories: Категории налогов
+    tax_category: Категория налогов
+    tax_code: 
+    tax_included: Вкл. налоги
+    tax_rate_amount_explanation: Налоговые ставки вводятся как десятичные значения (напр. если налог 5%, то вводите 0.05)
+    tax_rates: Налоговые ставки
+    taxon: Таксон
+    taxon_edit: Редактировать таксон
+    taxon_placeholder: Добавить таксон
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
-    taxonomies: "Таксономии"
-    taxonomy: "Таксономия"
-    taxonomy_edit: "Редактирование таксономии"
-    taxonomy_tree_error: "Запрашиваемое изменение не было осуществленно и дерево возвращено в предыдущее состояние. Пожалуйста, попытайтесь снова."
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
+    taxonomies: Таксономии
+    taxonomy: Таксономия
+    taxonomy_edit: Редактирование таксономии
+    taxonomy_tree_error: Запрашиваемое изменение не было осуществленно и дерево возвращено в предыдущее состояние. Пожалуйста, попытайтесь снова.
     taxonomy_tree_instruction: "* Щёлкните правой кнопкой мыши на элеменете дерева для добавления, удаления или сортировки таксонов."
-    taxons: "Таксоны"
-    test: "Тест"
+    taxons: Таксоны
+    test: Тест
     test_mailer:
       test_email:
-        greeting: "Поздравляем!"
-        message: "Если Вы читаете это сообщение, значит почтовые настройки Spree верны."
-        subject: "Тестовое сообщение"
-    test_mode: "Тестовый режим"
-    thank_you_for_your_order: "Спасибо за покупку!"
-    there_are_no_items_for_this_order: "В этом заказе нет товаров. Добавьте товары, чтобы продолжить, пожалуйста."
-    there_were_problems_with_the_following_fields: "Возникли некоторые проблемы со следующими полями"
-    this_order_has_already_received_a_refund:
-    thumbnail: "Миниатюра"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time: "Время"
-    to_add_variants_you_must_first_define: "Перед добавлением вариантов, вы должны определить"
-    total: "Итого"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales: "Всего продано на"
-    track_inventory: "Отслеживать наличие"
-    tracking: "Отслеживание"
-    tracking_number: "Трекинговый номер"
-    tracking_url: "Трекинговый URL"
-    tracking_url_placeholder: "например, http://quickship.com/package?num=:tracking"
-    transaction_id:
-    transfer_from_location: "Перевести из"
-    transfer_stock: "Перевести Товар"
-    transfer_to_location: "Перевести на"
-    tree: "Дерево"
-    type: "Тип"
-    type_to_search: "Начните печатать чтобы активировать поиск"
-    unable_to_connect_to_gateway: "Не удалось подключиться к платёжному шлюзу."
-    unable_to_create_reimbursements:
-    under_price: "Дешевле %{price}"
-    unlock: "Разблокировать"
-    unrecognized_card_type: "Неизвестный тип карты"
-    unshippable_items: "Неотправляемые Товары"
-    update: "Изменить"
-    updating: "Обновление"
-    usage_limit: "Максимальное количество использований"
-    use_app_default: "По умолчанию"
-    use_billing_address: "Использовать платёжный адрес"
-    use_new_cc: "Использовать новую карту"
-    use_s3: "Использовать Amazon S3 для хранения изображений"
-    user: "Пользователь"
+        greeting: Поздравляем!
+        message: Если Вы читаете это сообщение, значит почтовые настройки Spree верны.
+        subject: Тестовое сообщение
+    test_mode: Тестовый режим
+    thank_you_for_your_order: Спасибо за покупку!
+    there_are_no_items_for_this_order: В этом заказе нет товаров. Добавьте товары, чтобы продолжить, пожалуйста.
+    there_were_problems_with_the_following_fields: Возникли некоторые проблемы со следующими полями
+    this_order_has_already_received_a_refund: 
+    thumbnail: Миниатюра
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: Время
+    to_add_variants_you_must_first_define: Перед добавлением вариантов, вы должны определить
+    total: Итого
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: Всего продано на
+    track_inventory: Отслеживать наличие
+    tracking: Отслеживание
+    tracking_number: Трекинговый номер
+    tracking_url: Трекинговый URL
+    tracking_url_placeholder: например, http://quickship.com/package?num=:tracking
+    transaction_id: 
+    transfer_from_location: Перевести из
+    transfer_stock: Перевести Товар
+    transfer_to_location: Перевести на
+    tree: Дерево
+    type: Тип
+    type_to_search: Начните печатать чтобы активировать поиск
+    unable_to_connect_to_gateway: Не удалось подключиться к платёжному шлюзу.
+    unable_to_create_reimbursements: 
+    under_price: Дешевле %{price}
+    unlock: Разблокировать
+    unrecognized_card_type: Неизвестный тип карты
+    unshippable_items: Неотправляемые Товары
+    update: Изменить
+    updating: Обновление
+    usage_limit: Максимальное количество использований
+    use_app_default: По умолчанию
+    use_billing_address: Использовать платёжный адрес
+    use_new_cc: Использовать новую карту
+    use_s3: Использовать Amazon S3 для хранения изображений
+    user: Пользователь
     user_rule:
-      choose_users: "Выбрать пользователей"
-    users: "Пользователи"
+      choose_users: Выбрать пользователей
+    users: Пользователи
     validation:
-      cannot_be_less_than_shipped_units: "не может быть меньше, чем количество отгруженных единиц"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock: "превышает количество на складе. Пожалуйста проверьте количество товара."
-      is_too_large: "слишком много - количество на складе меньше запрошенного количества!"
-      must_be_int: "должно быть целым числом"
-      must_be_non_negative: "должно быть неотрицательным числом"
-      unpaid_amount_not_zero:
-    value: "Значение"
-    variant: "Вариант"
-    variant_placeholder: "Выберите вариант"
-    variant_search_placeholder: "Выберите артикул или вариант"
-    variants: "Варианты"
-    version: "Версия"
-    void: "Аннулировать"
-    weight: "Вес"
-    what_is_a_cvv: "Что такое CVV?"
-    what_is_this: "Что это?"
-    width: "Ширина"
-    year: "Год"
-    you_have_no_orders_yet: "У Вас ещё нет заказов."
-    your_cart_is_empty: "Ваша корзина пуста"
-    your_order_is_empty_add_product: "Ваша корзина пуста, найдите и добавьте продукты, пожалуйста"
-    zip: "Индекс"
-    zipcode: "Почтовый индекс"
-    zone: "Торговая зона"
-    zones: "Торговые зоны"
+      cannot_be_less_than_shipped_units: не может быть меньше, чем количество отгруженных единиц
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: превышает количество на складе. Пожалуйста проверьте количество товара.
+      is_too_large: слишком много - количество на складе меньше запрошенного количества!
+      must_be_int: должно быть целым числом
+      must_be_non_negative: должно быть неотрицательным числом
+      unpaid_amount_not_zero: 
+    value: Значение
+    variant: Вариант
+    variant_placeholder: Выберите вариант
+    variant_search_placeholder: Выберите артикул или вариант
+    variants: Варианты
+    version: Версия
+    void: Аннулировать
+    weight: Вес
+    what_is_a_cvv: Что такое CVV?
+    what_is_this: Что это?
+    width: Ширина
+    year: Год
+    you_have_no_orders_yet: У Вас ещё нет заказов.
+    your_cart_is_empty: Ваша корзина пуста
+    your_order_is_empty_add_product: Ваша корзина пуста, найдите и добавьте продукты, пожалуйста
+    zip: Индекс
+    zipcode: Почтовый индекс
+    zone: Торговая зона
+    zones: Торговые зоны

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,30 +1,23 @@
+---
 sk:
-  number:
-    format:
-      delimiter: ","
-      separator: " "
-    currency:
-      format:
-        format: "%n %u"
-        unit: "€"
   activerecord:
     attributes:
       spree/address:
         address1: Adresa
         address2: Adresa (pokr.)
         city: Mesto/Obec
-        country: "Krajina"
-        firstname: "Krstné meno"
+        country: Krajina
+        firstname: Krstné meno
         lastname: Priezvisko
         phone: Telefón
         state: Kraj
-        zipcode: "PSČ"
+        zipcode: PSČ
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -32,1198 +25,1211 @@ sk:
         name: Názov
         numcode: ISO kód krajiny
       spree/credit_card:
-        base:
+        base: 
         cc_type: Typ
         month: Mesiac
-        name: "Meno"
-        number: "Číslo"
-        verification_value: "Overovací kód"
+        name: Meno
+        number: Číslo
+        verification_value: Overovací kód
         year: Rok
       spree/inventory_unit:
         state: Kraj
       spree/line_item:
         price: Cena
-        quantity: "Množstvo"
+        quantity: Množstvo
       spree/option_type:
         name: Názov
-        presentation: "Prezentácia"
+        presentation: Prezentácia
       spree/order:
-        checkout_complete: "Dokončiť objednávku"
-        completed_at: "Objednané"
-        considered_risky: "Rizikové"
-        coupon_code: "Kupónový kód"
-        created_at: "Dátum objednania"
+        checkout_complete: Dokončiť objednávku
+        completed_at: Objednané
+        considered_risky: Rizikové
+        coupon_code: Kupónový kód
+        created_at: Dátum objednania
         email: E-mail zákazníka
         ip_address: IP adresa
-        item_total: "Položka spolu"
-        number: "Číslo"
-        payment_state: "Stav platby"
-        shipment_state: "Stav doručenia"
-        special_instructions: "Zvláštne pokyny"
-        state: "Stav"
-        total: "Celkom"
+        item_total: Položka spolu
+        number: Číslo
+        payment_state: Stav platby
+        shipment_state: Stav doručenia
+        special_instructions: Zvláštne pokyny
+        state: Stav
+        total: Celkom
       spree/order/bill_address:
-        address1: "Fakturačná adresa - Ulica a č.d."
-        city: "Fakturačná adresa - Mesto/Obec"
-        firstname: "Fakturačná adresa - Krstné meno"
-        lastname: "Fakturačná adresa - Priezvisko"
-        phone: "Fakturačná adresa - Telefón"
-        state: "Fakturačná adresa - Kraj"
-        zipcode: "Fakturačná adresa - PSČ"
+        address1: Fakturačná adresa - Ulica a č.d.
+        city: Fakturačná adresa - Mesto/Obec
+        firstname: Fakturačná adresa - Krstné meno
+        lastname: Fakturačná adresa - Priezvisko
+        phone: Fakturačná adresa - Telefón
+        state: Fakturačná adresa - Kraj
+        zipcode: Fakturačná adresa - PSČ
       spree/order/ship_address:
-        address1: "Doručovacia adresa - Ulica a č.d."
-        city: "Doručovacia adresa - Mesto/Obec"
-        firstname: "Doručovacia adresa - Krstné meno"
-        lastname: "Doručovacia adresa - Priezvisko"
-        phone: "Doručovacia adresa - Telefón"
-        state: "Doručovacia adresa - Kraj"
-        zipcode: "Doručovacia adresa - PSČ"
+        address1: Doručovacia adresa - Ulica a č.d.
+        city: Doručovacia adresa - Mesto/Obec
+        firstname: Doručovacia adresa - Krstné meno
+        lastname: Doručovacia adresa - Priezvisko
+        phone: Doručovacia adresa - Telefón
+        state: Doručovacia adresa - Kraj
+        zipcode: Doručovacia adresa - PSČ
       spree/payment:
-        amount: "Suma"
+        amount: Suma
       spree/payment_method:
-        name: "Názov"
+        name: Názov
       spree/product:
-        available_on: "Dostupné v"
-        cost_currency: "Mena nákladov"
-        cost_price: "Cena nákladov"
-        description: "Popis"
-        master_price: "Základná cena"
-        name: "Názov"
-        on_hand: "Na sklade"
-        shipping_category: "Kategória doručenia"
-        tax_category: "Kategória dane"
+        available_on: Dostupné v
+        cost_currency: Mena nákladov
+        cost_price: Cena nákladov
+        description: Popis
+        master_price: Základná cena
+        name: Názov
+        on_hand: Na sklade
+        shipping_category: Kategória doručenia
+        tax_category: Kategória dane
       spree/promotion:
-        advertise: "Propagovať"
-        code: "Kód"
-        description: "Popis"
-        event_name: "Názov udalosti"
-        expires_at: "Platnosť vyprší"
-        name: "Názov"
-        path: "Cesta"
-        starts_at: "Začína"
-        usage_limit: "Obmedzenie použitia"
+        advertise: Propagovať
+        code: Kód
+        description: Popis
+        event_name: Názov udalosti
+        expires_at: Platnosť vyprší
+        name: Názov
+        path: Cesta
+        starts_at: Začína
+        usage_limit: Obmedzenie použitia
       spree/promotion_category:
-        name: "Názov"
-        code: "Kód"
+        code: Kód
+        name: Názov
       spree/property:
-        name: "Názov"
-        presentation: "Prezentácia"
+        name: Názov
+        presentation: Prezentácia
       spree/prototype:
-        name: "Názov"
+        name: Názov
       spree/return_authorization:
-        amount: "Suma"
+        amount: Suma
       spree/role:
-        name: "Názov"
+        name: Názov
       spree/state:
-        abbr: "Skratka"
-        name: "Názov"
+        abbr: Skratka
+        name: Názov
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type: "Typ"
-        updated: "Aktualizované"
-        user: "Používateľ"
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: Typ
+        updated: Aktualizované
+        user: Používateľ
       spree/store:
-        mail_from_address: "E-mailová adresa (Od:)"
-        meta_description: "Meta popis"
-        meta_keywords: "Meta kľúčové slová"
-        name: "Názov"
-        seo_title: "Nadpis pre SEO"
-        url: "URL webu"
+        mail_from_address: E-mailová adresa (Od:)
+        meta_description: Meta popis
+        meta_keywords: Meta kľúčové slová
+        name: Názov
+        seo_title: Nadpis pre SEO
+        url: URL webu
       spree/tax_category:
         description: Popis
-        name: "Názov"
+        name: Názov
       spree/tax_rate:
-        amount: "Suma"
-        included_in_price: "Zahrnutá v cene"
-        show_rate_in_label: "Zobraziť sadzbu v štítku"
+        amount: Suma
+        included_in_price: Zahrnutá v cene
+        show_rate_in_label: Zobraziť sadzbu v štítku
       spree/taxon:
-        name: "Názov"
+        name: Názov
         permalink: Permalink
-        position: "Umiestnenie"
+        position: Umiestnenie
       spree/taxonomy:
-        name: "Názov"
+        name: Názov
       spree/user:
-        email: "E-mail"
+        email: E-mail
         password: Heslo
         password_confirmation: Potvrdenie hesla
       spree/variant:
-        cost_currency: "Mena nákladov"
-        cost_price: "Cena nákladov"
-        depth: "Hĺbka"
-        height: "Výška"
+        cost_currency: Mena nákladov
+        cost_price: Cena nákladov
+        depth: Hĺbka
+        height: Výška
         price: Cena
         sku: SKU
-        weight: "Hmotnosť"
-        width: "Šírka"
+        weight: Hmotnosť
+        width: Šírka
       spree/zone:
         description: Popis
-        name: "Názov"
+        name: Názov
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked: "už je prepojený s týmto produktom"
+              already_linked: už je prepojený s týmto produktom
         spree/credit_card:
           attributes:
             base:
-              card_expired: "Platnosť karty vypršala"
-              expiry_invalid: "Platnosť karty je neplatná"
+              card_expired: Platnosť karty vypršala
+              expiry_invalid: Platnosť karty je neplatná
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency: "Musí zodpovedať mene objednávky"
+              must_match_order_currency: Musí zodpovedať mene objednávky
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed: "je väčšie ako povolené množstvo."
+              greater_than_allowed: je väčšie ako povolené množstvo.
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store: "Nemožno odstrániť predvolený obchod."
+              cannot_destroy_default_store: Nemožno odstrániť predvolený obchod.
     models:
       spree/address:
-        one: Adresa
         few: Adresy
+        one: Adresa
         other: Adries
       spree/country:
-        one: "Krajina"
-        few: "Krajiny"
-        other: "Krajín"
+        few: Krajiny
+        one: Krajina
+        other: Krajín
       spree/credit_card:
-        one: "Kreditná karta"
-        few: "Kreditné karty"
-        other: "Kreditných kariet"
-      spree/customer_return:
+        few: Kreditné karty
+        one: Kreditná karta
+        other: Kreditných kariet
+      spree/customer_return: 
       spree/inventory_unit:
-        one: "Skladová jednotka"
-        few: "Skladové jednotky"
-        other: "Skladových jednotiek"
+        few: Skladové jednotky
+        one: Skladová jednotka
+        other: Skladových jednotiek
       spree/line_item:
-        one: "Riadková položka"
-        few: "Riadkové položky"
-        other: "Riadkových položiek"
+        few: Riadkové položky
+        one: Riadková položka
+        other: Riadkových položiek
       spree/option_type:
-        one: "Typ voľby"
-        few: "Typy volieb"
-        other: "Typov volieb"
+        few: Typy volieb
+        one: Typ voľby
+        other: Typov volieb
       spree/option_value:
-        one: "Hodnota voľby"
-        few: "Hodnoty volieb"
-        other: "Hodnôt volieb"
+        few: Hodnoty volieb
+        one: Hodnota voľby
+        other: Hodnôt volieb
       spree/order:
-        one: "Objednávka"
-        few: "Objednávky"
-        other: "Objednávok"
+        few: Objednávky
+        one: Objednávka
+        other: Objednávok
       spree/payment:
-        one: Platba
         few: Platby
+        one: Platba
         other: Platieb
       spree/payment_method:
-        one: "Spôsob platby"
-        few: "Spôsoby platieb"
-        other: "Spôsobov platieb"
+        few: Spôsoby platieb
+        one: Spôsob platby
+        other: Spôsobov platieb
       spree/product:
-        one: Produkt
         few: Produkty
+        one: Produkt
         other: Produktov
       spree/promotion:
-        one: "Akcia"
-        few: "Akcie"
-        other: "Akcií"
+        few: Akcie
+        one: Akcia
+        other: Akcií
       spree/promotion_category:
-        one: "Kategória akcií"
-        few: "Kategórie akcií"
-        other: "Kategórií akcií"
+        few: Kategórie akcií
+        one: Kategória akcií
+        other: Kategórií akcií
       spree/property:
-        one: "Vlastnosť"
-        few: "Vlastnosti"
-        other: "Vlastností"
+        few: Vlastnosti
+        one: Vlastnosť
+        other: Vlastností
       spree/prototype:
-        one: Prototyp
         few: Prototypy
+        one: Prototyp
         other: Prototypov
       spree/refund_reason:
-        one: "Dôvod vrátenia platby"
-        few: "Dôvody vrátenia platieb"
-        other: "Dôvodov vrátenia platieb"
+        few: Dôvody vrátenia platieb
+        one: Dôvod vrátenia platby
+        other: Dôvodov vrátenia platieb
       spree/reimbursement:
-        one: "Náhrada"
-        few: "Náhrady"
-        other: "Náhrad"
+        few: Náhrady
+        one: Náhrada
+        other: Náhrad
       spree/reimbursement_type:
-        one: "Typ náhrady"
-        few: "Typy náhrad"
-        other: "Typov náhrad"
-      spree/return_authorization:
-      spree/return_authorization_reason:
+        few: Typy náhrad
+        one: Typ náhrady
+        other: Typov náhrad
+      spree/return_authorization: 
+      spree/return_authorization_reason: 
       spree/return_reason:
-        one: "Dôvod vrátenia objednávky"
-        few: "Dôvody vrátenia objednávky"
-        other: "Dôvodov vrátenia objednávky"
+        few: Dôvody vrátenia objednávky
+        one: Dôvod vrátenia objednávky
+        other: Dôvodov vrátenia objednávky
       spree/role:
-        one: Rola
         few: Roly
-        oher: "Rôl"
+        oher: Rôl
+        one: Rola
       spree/shipment:
-        one: "Doručenie"
-        few: "Doručenia"
-        other: "Doručení"
+        few: Doručenia
+        one: Doručenie
+        other: Doručení
       spree/shipping_category:
-        one: "Kategória doručenia"
-        few: "Kategórie doručenia"
-        other: "Kategórií doručenia"
+        few: Kategórie doručenia
+        one: Kategória doručenia
+        other: Kategórií doručenia
       spree/shipping_method:
-        one: "Spôsob doručenia"
-        few: "Spôsoby doručenia"
-        other: "Spôsobov doručenia"
+        few: Spôsoby doručenia
+        one: Spôsob doručenia
+        other: Spôsobov doručenia
       spree/state:
-        one: Kraj
         few: Kraje
+        one: Kraj
         other: Krajov
-      spree/state_change:
+      spree/state_change: 
       spree/stock_location:
-        one: "Umiestnenie skladu"
-        few: "Umiestnenia skladu"
-        other: "Umiestnení skladu"
+        few: Umiestnenia skladu
+        one: Umiestnenie skladu
+        other: Umiestnení skladu
       spree/stock_movement:
-        one: "Pohyb na sklade"
-        few: "Pohyby na sklade"
-        other: "Pohybov na sklade"
+        few: Pohyby na sklade
+        one: Pohyb na sklade
+        other: Pohybov na sklade
       spree/stock_transfer:
-        one: "Presun medzi skladmi"
-        few: "Presuny medzi skladmi"
-        other: "Presunov medzi skladmi"
+        few: Presuny medzi skladmi
+        one: Presun medzi skladmi
+        other: Presunov medzi skladmi
       spree/tax_category:
-        one: "Kategória daní"
-        few: "Kategórie daní"
-        other: "Kategórií daní"
+        few: Kategórie daní
+        one: Kategória daní
+        other: Kategórií daní
       spree/tax_rate:
-        one: "Sadzba dane"
-        few: "Sadzby dane"
-        other: "Sadzieb dane"
+        few: Sadzby dane
+        one: Sadzba dane
+        other: Sadzieb dane
       spree/taxon:
-        one: "Taxón"
-        few: "Taxóny"
-        other: "Taxónov"
+        few: Taxóny
+        one: Taxón
+        other: Taxónov
       spree/taxonomy:
-        one: "Taxonómia"
-        few: "Taxonómie"
-        other: "Taxonómií"
+        few: Taxonómie
+        one: Taxonómia
+        other: Taxonómií
       spree/tracker:
-        one: "Merač"
-        few: "Merače"
-        other: "Meračov"
+        few: Merače
+        one: Merač
+        other: Meračov
       spree/transfer_item:
-        one: "Položka presunu"
-        few: "Položky presunu"
-        other: "Položiek presunu"
+        few: Položky presunu
+        one: Položka presunu
+        other: Položiek presunu
       spree/user:
-        one: "Používateľ"
-        few: "Používatelia"
-        other: "Používateľov"
+        few: Používatelia
+        one: Používateľ
+        other: Používateľov
       spree/variant:
-        one: "Variant"
-        few: "Varianty"
-        other: "Variantov"
+        few: Varianty
+        one: Variant
+        other: Variantov
       spree/zone:
-        one: "Zóna"
-        few: "Zóny"
-        other: "Zón"
+        few: Zóny
+        one: Zóna
+        other: Zón
+  number:
+    currency:
+      format:
+        format: "%n %u"
+        unit: "€"
+    format:
+      delimiter: ","
+      separator: " "
   spree:
     abbreviation: Skratka
-    accept: "Prijať"
-    acceptance_errors: "Chyby prijatia"
-    acceptance_status: "Stav prijatia"
-    accepted: "Prijaté"
-    account: "Účet"
-    account_updated: "Účet aktualizovaný"
+    accept: Prijať
+    acceptance_errors: Chyby prijatia
+    acceptance_status: Stav prijatia
+    accepted: Prijaté
+    account: Účet
+    account_updated: Účet aktualizovaný
     action: Akcia
     actions:
-      cancel: "Zrušiť"
-      continue: "Pokračovať"
-      create: "Vytvoriť"
-      destroy: "Odstrániť"
-      edit: "Upraviť"
+      cancel: Zrušiť
+      continue: Pokračovať
+      create: Vytvoriť
+      destroy: Odstrániť
+      edit: Upraviť
       list: Zoznam
-      listing: "Výpis"
+      listing: Výpis
       new: Nový
-      refund: "Vrátiť"
-      save: "Uložiť"
-      update: "Aktualizovať"
-    activate: "Aktivovať"
-    active: "Aktívny"
-    add: "Pridať"
-    added: "Pridané"
-    add_action_of_type: "Pridať akciu typu"
-    add_country: "Pridať krajinu"
-    add_coupon_code: "Pridať kupónový kód"
-    add_new_header: "Pridať novú hlavičku"
-    add_new_style: "Pridať nový štýl"
-    add_one: "Pridať"
-    add_option_value: "Pridať novú voľbu"
-    add_product: "Pridať produkt"
-    add_product_properties: "Pridať vlastnosť produktu"
-    add_rule_of_type: "Pridať pravidlo typu"
-    add_state: "Pridať kraj"
-    add_stock: "Pridať sklad"
-    add_stock_management: "Pridať správu skladu"
-    add_to_cart: "Pridať do košíka"
-    add_variant: "Pridať variant"
-    additional_item: "Dodatočná položka"
+      refund: Vrátiť
+      save: Uložiť
+      update: Aktualizovať
+    activate: Aktivovať
+    active: Aktívny
+    add: Pridať
+    add_action_of_type: Pridať akciu typu
+    add_country: Pridať krajinu
+    add_coupon_code: Pridať kupónový kód
+    add_new_header: Pridať novú hlavičku
+    add_new_style: Pridať nový štýl
+    add_one: Pridať
+    add_option_value: Pridať novú voľbu
+    add_product: Pridať produkt
+    add_product_properties: Pridať vlastnosť produktu
+    add_rule_of_type: Pridať pravidlo typu
+    add_state: Pridať kraj
+    add_stock: Pridať sklad
+    add_stock_management: Pridať správu skladu
+    add_to_cart: Pridať do košíka
+    add_variant: Pridať variant
+    added: Pridané
+    additional_item: Dodatočná položka
     address1: Adresa
     address2: Adresa (pokr.)
-    adjustable: "Upraviteľné"
-    adjustment: "Úprava"
-    adjustment_amount: "Suma"
-    adjustment_successfully_closed: "Upravovanie bolo úspešne uzavreté!"
-    adjustment_successfully_opened: "Upravovanie bolo úspešne otvorené!"
-    adjustment_total: "Úpravy spolu"
-    adjustments: "Úpravy"
+    adjustable: Upraviteľné
+    adjustment: Úprava
+    adjustment_amount: Suma
+    adjustment_successfully_closed: Upravovanie bolo úspešne uzavreté!
+    adjustment_successfully_opened: Upravovanie bolo úspešne otvorené!
+    adjustment_total: Úpravy spolu
+    adjustments: Úpravy
     admin:
       tab:
-        configuration: "Konfigurácia"
-        management: "Správa"
-        option_types: "Typy volieb"
-        orders: "Objednávky"
-        overview: "Prehľad"
-        products: "Produkty"
-        promotions: "Akcie"
-        promotion_categories: "Kategórie akcií"
-        properties: "Vlastnosti"
-        prototypes: "Prototypy"
-        reports: "Výkazy"
-        taxonomies: "Taxonómie"
-        transfers: "Presuny"
-        taxons: "Taxóny"
-        users: "Používatelia"
+        configuration: Konfigurácia
+        management: Správa
+        option_types: Typy volieb
+        orders: Objednávky
+        overview: Prehľad
+        products: Produkty
+        promotion_categories: Kategórie akcií
+        promotions: Akcie
+        properties: Vlastnosti
+        prototypes: Prototypy
+        reports: Výkazy
+        taxonomies: Taxonómie
+        taxons: Taxóny
+        transfers: Presuny
+        users: Používatelia
       user:
-        account: "Účet"
-        addresses: "Adresy"
-        items: "Položky"
-        items_purchased: "Zakúpené položky"
-        order_history: "História objednávok"
-        order_num: "Objednávka č."
-        orders: "Objednávky"
-        user_information: "Informácie o používateľovi"
+        account: Účet
+        addresses: Adresy
+        items: Položky
+        items_purchased: Zakúpené položky
+        order_history: História objednávok
+        order_num: Objednávka č.
+        orders: Objednávky
+        user_information: Informácie o používateľovi
     administration: Administrácia
-    advertise: "Propagovať"
-    agree_to_privacy_policy: "Súhlas s politikou ochrany súkromia"
-    agree_to_terms_of_service: "Súhlas s obchodnými podmienkami"
-    all: "Všetky"
-    all_adjustments_closed: "Všetky úpravy sú úspešne uzavreté!"
-    all_adjustments_opened: "Všetky úpravy sú úspešne otvorené!"
-    all_departments: "Všetky oddelenia"
-    all_items_have_been_returned: "Všetky položky boli vrátené"
-    allow_ssl_in_development_and_test: "Povoliť SSL vo vývojovom a testovacom prostredí"
-    allow_ssl_in_production: "Povoliť SSL v produkčnom prostredí"
-    allow_ssl_in_staging: "Povoliť SSL v skúšobnom prostredí"
-    already_signed_up_for_analytics: "Už ste registrovaní pre Spree Analytics"
-    alt_text: "Alternatívny text"
+    advertise: Propagovať
+    agree_to_privacy_policy: Súhlas s politikou ochrany súkromia
+    agree_to_terms_of_service: Súhlas s obchodnými podmienkami
+    all: Všetky
+    all_adjustments_closed: Všetky úpravy sú úspešne uzavreté!
+    all_adjustments_opened: Všetky úpravy sú úspešne otvorené!
+    all_departments: Všetky oddelenia
+    all_items_have_been_returned: Všetky položky boli vrátené
+    allow_ssl_in_development_and_test: Povoliť SSL vo vývojovom a testovacom prostredí
+    allow_ssl_in_production: Povoliť SSL v produkčnom prostredí
+    allow_ssl_in_staging: Povoliť SSL v skúšobnom prostredí
+    already_signed_up_for_analytics: Už ste registrovaní pre Spree Analytics
+    alt_text: Alternatívny text
     alternative_phone: Iný telefónický kontakt
     amount: Suma
-    analytics_desc_header_1:
-    analytics_desc_header_2: "Okamžitá analytika integrovaná do vašej Spree kancelárie"
-    analytics_desc_list_1: "Dostávajte obchodné informácie hneď ako nastanú"
-    analytics_desc_list_2: "K aktivácii vyžaduje len bezplatný Spree účet"
-    analytics_desc_list_3: "Netreba inštalovať nijaký kód"
-    analytics_desc_list_4: "Je to úplne zdarma!"
+    analytics_desc_header_1: 
+    analytics_desc_header_2: Okamžitá analytika integrovaná do vašej Spree kancelárie
+    analytics_desc_list_1: Dostávajte obchodné informácie hneď ako nastanú
+    analytics_desc_list_2: K aktivácii vyžaduje len bezplatný Spree účet
+    analytics_desc_list_3: Netreba inštalovať nijaký kód
+    analytics_desc_list_4: Je to úplne zdarma!
     analytics_trackers: Merače analytiky
     and: a
-    approve: "Schváliť"
-    approved_at: "Schválené"
-    approver: "Schválil"
-    are_you_sure: "Ste si istí?"
-    are_you_sure_delete: "Ste si istí, že chcete zmazať tento záznam?"
-    associated_adjustment_closed:
-    at_symbol: '@'
-    authorization_failure: "Chyba pri autorizácii"
-    authorized: "Autorizované"
-    auto_capture: "Automaticky zachytiť"
-    available_on: "Dostupný dňa"
-    average_order_value: "Priemerná hodn. obj."
-    avs_response: "AVS odozva"
-    back: "Späť"
-    back_end: "v kancelárii"
-    back_to_adjustments_list: "Späť na zoznam úprav"
-    back_to_countries_list: "Späť na zoznam krajín"
-    back_to_images_list: "Späť na zoznam obrázkov"
-    back_to_option_types_list: "Späť na zoznam typov volieb"
-    back_to_orders_list: "Späť na zoznam objednávok"
-    back_to_payment: "Späť na platbu"
-    back_to_payment_methods_list: "Späť na zoznam spôsobov platieb"
-    back_to_payments_list: "Späť na zoznam platieb"
-    back_to_products_list: "Späť na zoznam produktov"
-    back_to_refund_reason_list: "Späť na zoznam dôvodov vracania platieb"
-    back_to_reports_list: "Späť na zoznam výkazov"
-    back_to_resource_list:
-    back_to_rma_reason_list: "Späť na zoznam dôvodov reklamácií"
-    back_to_shipping_categories: "Späť na kategórie doručenia"
-    back_to_shipping_categories_list: "Späť na zoznam kategórií doručenia"
-    back_to_shipping_methods_list: "Späť na zoznam spôsobov doručenia"
-    back_to_states_list: "Späť na zoznam štátov/provincií/krajov"
-    back_to_stock_locations_list: "Späť na zoznam umiestnení skladov"
-    back_to_stock_movements_list: "Späť na zoznam pohybov na skladoch"
-    back_to_stock_transfers_list: "Späť na zoznam presunov medzi skladmi"
-    back_to_store: "Späť do obchodu"
-    back_to_tax_categories_list: "Späť na zoznam kategórií daní"
-    back_to_tax_rates_list: "Späť na zoznam sadzieb daní"
-    back_to_taxonomies_list: "Späť na zoznam taxonómií"
-    back_to_trackers_list: "Späť na zoznam meračov"
-    back_to_users_list: "Späť na zoznam používateľov"
-    back_to_zones_list: "Späť na zoznam zón"
-    backorderable: "Objednateľné pri nedostupnosti"
-    backorderable_default: "Predvolená možnosť objednať nedostupné"
-    backorderable_header: "Objednateľné aj pri dočasnej nedostupnosti"
-    backordered:
-    backorders_allowed: "možno objednať nedostupné"
-    balance_due: "Neuhradené"
-    base_amount: "Základné množtvo"
-    base_percent: "Základné percento"
-    bill_address: "Účtovanie na adresu"
-    billing: "Fakturácia"
-    billing_address: "Fakturačná adresa"
-    both: "v oboch"
-    calculated_reimbursements: "Kalkulované náhrady"
+    approve: Schváliť
+    approved_at: Schválené
+    approver: Schválil
+    are_you_sure: Ste si istí?
+    are_you_sure_delete: Ste si istí, že chcete zmazať tento záznam?
+    associated_adjustment_closed: 
+    at_symbol: "@"
+    authorization_failure: Chyba pri autorizácii
+    authorized: Autorizované
+    auto_capture: Automaticky zachytiť
+    available_on: Dostupný dňa
+    average_order_value: Priemerná hodn. obj.
+    avs_response: AVS odozva
+    back: Späť
+    back_end: v kancelárii
+    back_to_adjustments_list: Späť na zoznam úprav
+    back_to_countries_list: Späť na zoznam krajín
+    back_to_images_list: Späť na zoznam obrázkov
+    back_to_option_types_list: Späť na zoznam typov volieb
+    back_to_orders_list: Späť na zoznam objednávok
+    back_to_payment: Späť na platbu
+    back_to_payment_methods_list: Späť na zoznam spôsobov platieb
+    back_to_payments_list: Späť na zoznam platieb
+    back_to_products_list: Späť na zoznam produktov
+    back_to_refund_reason_list: Späť na zoznam dôvodov vracania platieb
+    back_to_reports_list: Späť na zoznam výkazov
+    back_to_resource_list: 
+    back_to_rma_reason_list: Späť na zoznam dôvodov reklamácií
+    back_to_shipping_categories: Späť na kategórie doručenia
+    back_to_shipping_categories_list: Späť na zoznam kategórií doručenia
+    back_to_shipping_methods_list: Späť na zoznam spôsobov doručenia
+    back_to_states_list: Späť na zoznam štátov/provincií/krajov
+    back_to_stock_locations_list: Späť na zoznam umiestnení skladov
+    back_to_stock_movements_list: Späť na zoznam pohybov na skladoch
+    back_to_stock_transfers_list: Späť na zoznam presunov medzi skladmi
+    back_to_store: Späť do obchodu
+    back_to_tax_categories_list: Späť na zoznam kategórií daní
+    back_to_tax_rates_list: Späť na zoznam sadzieb daní
+    back_to_taxonomies_list: Späť na zoznam taxonómií
+    back_to_trackers_list: Späť na zoznam meračov
+    back_to_users_list: Späť na zoznam používateľov
+    back_to_zones_list: Späť na zoznam zón
+    backorderable: Objednateľné pri nedostupnosti
+    backorderable_default: Predvolená možnosť objednať nedostupné
+    backorderable_header: Objednateľné aj pri dočasnej nedostupnosti
+    backordered: 
+    backorders_allowed: možno objednať nedostupné
+    balance_due: Neuhradené
+    base_amount: Základné množtvo
+    base_percent: Základné percento
+    bill_address: Účtovanie na adresu
+    billing: Fakturácia
+    billing_address: Fakturačná adresa
+    both: v oboch
+    calculated_reimbursements: Kalkulované náhrady
     calculator: Kalkulačka
-    calculator_settings_warning: Ak si prajete zmenu typu kalkulačky, je potrebné nastavenia najprv uložiť pred daľšími zmenami v nastaveniach kalkulačky.
-    cancel_inventory: "Zrušiť položku"
+    calculator_settings_warning: Ak si prajete zmenu typu kalkulačky, je potrebné nastavenia najprv uložiť pred daľšími zmenami v nastaveniach
+      kalkulačky.
     cancel: zrušiť
-    canceled_at: "Zrušené"
-    canceler: "Zrušil"
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: "Nemožete vytvoriť platbu za objednávku bez toho, aby boli definované nejaké spôsoby platieb."
-    cannot_create_returns:
-    cannot_perform_operation: "Operácia sa nedá vykonať"
-    cannot_set_shipping_method_without_address: "Nemožno nastaviť spôsob doručenia, pokiaľ nie sú poskytnuté údaje o zákazníkovi."
-    capture: "Zachytiť"
-    capture_events: "Udalosti zachytenia"
+    cancel_inventory: Zrušiť položku
+    canceled_at: Zrušené
+    canceler: Zrušil
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: Nemožete vytvoriť platbu za objednávku bez toho, aby boli definované nejaké spôsoby platieb.
+    cannot_create_returns: 
+    cannot_perform_operation: Operácia sa nedá vykonať
+    cannot_set_shipping_method_without_address: Nemožno nastaviť spôsob doručenia, pokiaľ nie sú poskytnuté údaje o zákazníkovi.
+    capture: Zachytiť
+    capture_events: Udalosti zachytenia
     card_code: Kód karty
-    card_number: "Číslo karty"
-    card_type: "Typ karty"
+    card_number: Číslo karty
+    card_type: Typ karty
     card_type_is: Typ karty je
     cart: Košík
     cart_subtotal:
-      one: 'Medzisúčet (1 položka)'
-      few: 'Medzisúčet (%{count} položky)'
-      other: 'Medzisúčet (%{count} položiek)'
+      few: Medzisúčet (%{count} položky)
+      one: Medzisúčet (1 položka)
+      other: Medzisúčet (%{count} položiek)
     categories: Kategórie
     category: Kategória
-    charged:
-    check_for_spree_alerts:
-    checkout: "Pokladňa"
-    check_stock_on_transfer: "Skontrolovať sklad pri presune"
-    choose_a_customer: "Zvoliť zákazníka"
-    choose_a_taxon_to_sort_products_for: "Zvoľte taxón pre filtrovanie produktov"
-    choose_currency: "Zvoliť menu"
-    choose_dashboard_locale: "Zvoliť národné prostredie pre nástenku"
-    choose_location: "Zvoliť miesto"
-    city: "Mesto/Obec"
-    clear_cache: "Vyčistiť vyrovnávaciu pamäť"
-    clear_cache_ok: "Vyrovnávacia pamäť bola vyčistená"
-    clear_cache_warning: "Vyčistenie vyrovnávacej pamäte dočasne zníži výkon vášho obchodu."
-    click_and_drag_on_the_products_to_sort_them: "Zvoľte taxón pre triedenie produktov"
-    clone: "Klonovať"
-    close: "Zavrieť"
-    close_all_adjustments: "Uzavrieť všetky úpravy"
+    charged: 
+    check_for_spree_alerts: 
+    check_stock_on_transfer: Skontrolovať sklad pri presune
+    checkout: Pokladňa
+    choose_a_customer: Zvoliť zákazníka
+    choose_a_taxon_to_sort_products_for: Zvoľte taxón pre filtrovanie produktov
+    choose_currency: Zvoliť menu
+    choose_dashboard_locale: Zvoliť národné prostredie pre nástenku
+    choose_location: Zvoliť miesto
+    city: Mesto/Obec
+    clear_cache: Vyčistiť vyrovnávaciu pamäť
+    clear_cache_ok: Vyrovnávacia pamäť bola vyčistená
+    clear_cache_warning: Vyčistenie vyrovnávacej pamäte dočasne zníži výkon vášho obchodu.
+    click_and_drag_on_the_products_to_sort_them: Zvoľte taxón pre triedenie produktov
+    clone: Klonovať
+    close: Zavrieť
+    close_all_adjustments: Uzavrieť všetky úpravy
     code: Kód
-    company: "Spoločnosť"
-    complete: "dokončiť"
+    company: Spoločnosť
+    complete: dokončiť
     configuration: Nastavenie
     configurations: Nastavenia
-    confirm: "Potvrdiť"
-    confirm_delete: "Potvriť zmazanie"
+    confirm: Potvrdiť
+    confirm_delete: Potvriť zmazanie
     confirm_password: Potvrdenie hesla
-    continue: "Pokračovať"
-    continue_shopping: "Pokračovať v nákupe"
-    cost_currency: "Mena nákladov"
-    cost_price: "Suma nákladov"
-    could_not_connect_to_jirafe: "Nedá sa pripojiť k Jirafe na synchronizovanie údajov. Bude to automaticky opakované neskôr."
-    could_not_create_customer_return:
-    could_not_create_stock_movement: "Vyskytol sa problém pri ukladaní tohoto skladového pohybu. Skúste prosím znova"
-    count_on_hand: "Počet na sklade"
-    countries: "Krajiny"
-    country: "Krajina"
+    continue: Pokračovať
+    continue_shopping: Pokračovať v nákupe
+    cost_currency: Mena nákladov
+    cost_price: Suma nákladov
+    could_not_connect_to_jirafe: Nedá sa pripojiť k Jirafe na synchronizovanie údajov. Bude to automaticky opakované neskôr.
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: Vyskytol sa problém pri ukladaní tohoto skladového pohybu. Skúste prosím znova
+    count_on_hand: Počet na sklade
+    countries: Krajiny
+    country: Krajina
     country_based: Krajina
-    country_name: "Názov"
+    country_name: Názov
     country_names:
-      CA: "Kanada"
-      FRA: "Francúzsko"
-      ITA: "Taliansko"
-      US: "Spojené štáty americké"
-    coupon: "Kupón"
-    coupon_code: "Kupónový kód"
-    coupon_code_already_applied: "Na túto objednávku už bol uplatnený kupónový kód"
-    coupon_code_applied: "Kupónový kód bol úspešne uplatnený na vašu objednávku."
-    coupon_code_better_exists: "Predtým uplatnený kupónový kód viedol k lepšej cene"
-    coupon_code_expired: "Platnosť kupónového kódu vypršala"
-    coupon_code_max_usage: "Presiahnutý maximálny počet použiteľných kupónových kódov"
-    coupon_code_not_eligible: "Tento kupónový kód nie je použiteľný na túto objednávku"
-    coupon_code_not_found: "Kupónový kód, ktorý ste zadali nejestvuje. Skúste prosím znova."
-    coupon_code_unknown_error: "Momentálne nie je možné uplatniť na nákup tento kupónový kód."
-    create: "Vytvoriť"
-    create_a_new_account: "Vytvoriť nový účet"
-    create_new_order: "Vytvoriť novú objednávku"
-    create_reimbursement: "Vytvoriť náhradu"
-    created_at: "Vytvorené"
-    created_by: "Vytvoril"
-    credit: "Kredit"
-    credit_card: "Kreditná karta"
-    credit_cards: "Kreditné karty"
-    credit_owed: "Dlhovaný kredit"
-    credits: "Kredity"
-    currency: "Mena"
-    currency_decimal_mark: "Znak desatinnej čiarky"
-    currency_settings: "Nastavenia meny"
-    currency_symbol_position: "Umiestniť znak meny pred, alebo za sumu?"
-    currency_thousands_separator: "Oddeľovač tisícov"
-    current: "Aktuálny"
-    current_promotion_usage: ! 'Aktuálne použitie: %{count}'
-    customer: "Zákazník"
-    customer_details: "Podrobnosti o zákazíkovi"
-    customer_details_updated: "Podrobnosti o zákazníkovi boli aktualizované."
-    customer_return:
-    customer_returns:
-    customer_search: "Vyhľadávanie zákazníkov"
-    cut: "Vyrezať"
-    cvv_response: "CVV odozva"
+      CA: Kanada
+      FRA: Francúzsko
+      ITA: Taliansko
+      US: Spojené štáty americké
+    coupon: Kupón
+    coupon_code: Kupónový kód
+    coupon_code_already_applied: Na túto objednávku už bol uplatnený kupónový kód
+    coupon_code_applied: Kupónový kód bol úspešne uplatnený na vašu objednávku.
+    coupon_code_better_exists: Predtým uplatnený kupónový kód viedol k lepšej cene
+    coupon_code_expired: Platnosť kupónového kódu vypršala
+    coupon_code_max_usage: Presiahnutý maximálny počet použiteľných kupónových kódov
+    coupon_code_not_eligible: Tento kupónový kód nie je použiteľný na túto objednávku
+    coupon_code_not_found: Kupónový kód, ktorý ste zadali nejestvuje. Skúste prosím znova.
+    coupon_code_unknown_error: Momentálne nie je možné uplatniť na nákup tento kupónový kód.
+    create: Vytvoriť
+    create_a_new_account: Vytvoriť nový účet
+    create_new_order: Vytvoriť novú objednávku
+    create_reimbursement: Vytvoriť náhradu
+    created_at: Vytvorené
+    created_by: Vytvoril
+    credit: Kredit
+    credit_card: Kreditná karta
+    credit_cards: Kreditné karty
+    credit_owed: Dlhovaný kredit
+    credits: Kredity
+    currency: Mena
+    currency_decimal_mark: Znak desatinnej čiarky
+    currency_settings: Nastavenia meny
+    currency_symbol_position: Umiestniť znak meny pred, alebo za sumu?
+    currency_thousands_separator: Oddeľovač tisícov
+    current: Aktuálny
+    current_promotion_usage: 'Aktuálne použitie: %{count}'
+    customer: Zákazník
+    customer_details: Podrobnosti o zákazíkovi
+    customer_details_updated: Podrobnosti o zákazníkovi boli aktualizované.
+    customer_return: 
+    customer_returns: 
+    customer_search: Vyhľadávanie zákazníkov
+    cut: Vyrezať
+    cvv_response: CVV odozva
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable: "Jirafe je aktuálne nedostupné. Spree sa automaticky spojí s Jirafe akonáhle bude opäť dostupné."
-        explanation: "Nasledujúce polia môžu byť predvyplnené ak sa rozhodnete registrovať do Jirafe z kancelárie správcu."
-        header: "Nastavenia Jirafe Analytics"
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date: "Dátum"
-    date_completed: "Objednané"
+        app_id: 
+        app_token: 
+        currently_unavailable: Jirafe je aktuálne nedostupné. Spree sa automaticky spojí s Jirafe akonáhle bude opäť dostupné.
+        explanation: Nasledujúce polia môžu byť predvyplnené ak sa rozhodnete registrovať do Jirafe z kancelárie správcu.
+        header: Nastavenia Jirafe Analytics
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: Dátum
+    date_completed: Objednané
     date_picker:
       first_day: 1
       format: "%d.%m.%Y"
       js_format: dd.mm.rr
-    date_range: "Obdobie"
-    default: "Predvolené"
-    default_refund_amount:
-    default_tax: "Predvolená daň"
-    default_tax_zone: "Predvolená zóna dane"
-    delete: "Zmazať"
-    deleted_variants_present: "Niektoré riadkové položky v tejto objednávke obsahujú produkty, ktoré už viac nie sú v ponuke."
+    date_range: Obdobie
+    default: Predvolené
+    default_refund_amount: 
+    default_tax: Predvolená daň
+    default_tax_zone: Predvolená zóna dane
+    delete: Zmazať
+    deleted_variants_present: Niektoré riadkové položky v tejto objednávke obsahujú produkty, ktoré už viac nie sú v ponuke.
     delivery: Doručenie
-    depth: "Hĺbka"
+    depth: Hĺbka
     description: Popis
-    destination: "Miesto doručenia"
-    destination_location: "Cieľové umiestnenie"
-    destroy: "Zrušiť"
-    details: "podrobnosti"
-    discount_amount: "Objem zľavy"
-    dismiss_banner: "Nie, ďakujem! Nezaujíma ma to, túto správu znova nezobrazovať."
-    display: "Zobraziť"
-    display_currency:
-    doesnt_track_inventory:
-    edit: "Upraviť"
-    editing_country: "Úprava krajiny"
-    editing_option_type: "Úprava typu volieb"
-    editing_promotion_category: "Úprava kategórie akcií"
-    editing_product: "Úprava produktu"
-    editing_resource:
-    editing_rma_reason: "Úprava dôvodu reklamácie"
-    editing_shipping_category: "Úprava kategórie doručenia"
-    editing_shipping_method: "Úprava spôsobu doručenia"
-    editing_state: "Úprava štátu/provincie/kraja"
-    editing_stock_location: "Úprava umiestnenia skladu"
-    editing_stock_movement: "Úprava pohybu na sklade"
-    editing_stock_transfer: "Úprava presunu medzi skladmi"
-    editing_tax_category: "Úprava kategórie dane"
-    editing_tax_rate: "Úprava sadzby dane"
-    editing_tracker: "Úprava merača"
-    editing_user: "Úprava používateľa"
-    editing_zone: "Úprava zóny"
+    destination: Miesto doručenia
+    destination_location: Cieľové umiestnenie
+    destroy: Zrušiť
+    details: podrobnosti
+    discount_amount: Objem zľavy
+    dismiss_banner: Nie, ďakujem! Nezaujíma ma to, túto správu znova nezobrazovať.
+    display: Zobraziť
+    display_currency: 
+    doesnt_track_inventory: 
+    edit: Upraviť
+    editing_country: Úprava krajiny
+    editing_option_type: Úprava typu volieb
+    editing_product: Úprava produktu
+    editing_promotion_category: Úprava kategórie akcií
+    editing_resource: 
+    editing_rma_reason: Úprava dôvodu reklamácie
+    editing_shipping_category: Úprava kategórie doručenia
+    editing_shipping_method: Úprava spôsobu doručenia
+    editing_state: Úprava štátu/provincie/kraja
+    editing_stock_location: Úprava umiestnenia skladu
+    editing_stock_movement: Úprava pohybu na sklade
+    editing_stock_transfer: Úprava presunu medzi skladmi
+    editing_tax_category: Úprava kategórie dane
+    editing_tax_rate: Úprava sadzby dane
+    editing_tracker: Úprava merača
+    editing_user: Úprava používateľa
+    editing_zone: Úprava zóny
     eligibility_errors:
       messages:
-        has_excluded_product: "Váš košík obsahuje produkt, ktorý znemožňuje uplatnenie tohoto kupónového kódu."
-        item_total_less_than: "Tento kupónový kód nemôže byť uplatnený na objednávku za sumu menšiu ako %{amount}."
-        item_total_less_than_or_equal: "Tento kupónový kód nemôže byť uplatnený na objednávku za sumu menšiu alebo rovnajúcu sa %{amount}."
-        item_total_more_than: "Tento kupónový kód nemôže byť uplatnený na objednávku za sumu väčšiu ako %{amount}."
-        item_total_more_than_or_equal: "Tento kupónový kód nemôže byť uplatnený na objednávku za sumu väčšiu alebo rovnajúcu sa %{amount}."
-        limit_once_per_user: "Tento kupónový kód môže byť každým používateľom uplatnený len raz."
-        missing_product: "Tento kupónový kód nemôže byť uplatnený, pretože nemáte v košíku všetky potrebné produkty."
-        missing_taxon: "Pred uplatnením tohoto kupónového kódu treba pridať produkt zo všetkých požadovaných kategórií."
-        no_applicable_products: "Pred uplatnením tohoto kupónového kódu treba pridať požadovaný produkt."
-        no_matching_taxons: "Pred uplatnením tohoto kupónového kódu treba pridať produkt z požadovanej kategórie."
-        no_user_or_email_specified: "Pred uplatnením tohoto kupónového kódu sa treba prihlásiť alebo zadať váš e-mail."
-        no_user_specified: "Pred uplatnením tohoto kupónového kódu sa treba prihlásiť."
-        not_first_order: "Tento kupónový kód je možné uplatniť len na vašu prvú objednávku."
-    email: "E-mail"
+        has_excluded_product: Váš košík obsahuje produkt, ktorý znemožňuje uplatnenie tohoto kupónového kódu.
+        item_total_less_than: Tento kupónový kód nemôže byť uplatnený na objednávku za sumu menšiu ako %{amount}.
+        item_total_less_than_or_equal: Tento kupónový kód nemôže byť uplatnený na objednávku za sumu menšiu alebo rovnajúcu sa %{amount}.
+        item_total_more_than: Tento kupónový kód nemôže byť uplatnený na objednávku za sumu väčšiu ako %{amount}.
+        item_total_more_than_or_equal: Tento kupónový kód nemôže byť uplatnený na objednávku za sumu väčšiu alebo rovnajúcu sa %{amount}.
+        limit_once_per_user: Tento kupónový kód môže byť každým používateľom uplatnený len raz.
+        missing_product: Tento kupónový kód nemôže byť uplatnený, pretože nemáte v košíku všetky potrebné produkty.
+        missing_taxon: Pred uplatnením tohoto kupónového kódu treba pridať produkt zo všetkých požadovaných kategórií.
+        no_applicable_products: Pred uplatnením tohoto kupónového kódu treba pridať požadovaný produkt.
+        no_matching_taxons: Pred uplatnením tohoto kupónového kódu treba pridať produkt z požadovanej kategórie.
+        no_user_or_email_specified: Pred uplatnením tohoto kupónového kódu sa treba prihlásiť alebo zadať váš e-mail.
+        no_user_specified: Pred uplatnením tohoto kupónového kódu sa treba prihlásiť.
+        not_first_order: Tento kupónový kód je možné uplatniť len na vašu prvú objednávku.
+    email: E-mail
     empty: Prázdny
-    empty_cart: "Vyprázdniť košík"
+    empty_cart: Vyprázdniť košík
     enable_mail_delivery: Povolenie doručenia e-mailom
-    end: "Koniec"
-    ending_in: "Končí"
-    environment:
+    end: Koniec
+    ending_in: Končí
+    environment: 
     error: chyba
     errors:
       messages:
-        could_not_create_taxon: "Nemožno vytvoriť taxón"
-        no_payment_methods_available: "Pre toto prostredie nie sú nastavené žiadne spôsoby platby"
-        no_shipping_methods_available: "Pre zvolenú lokalitu nie sú dostupné žiadne spôsoby doručenia, zmeňte prosím vašu adresu"
+        could_not_create_taxon: Nemožno vytvoriť taxón
+        no_payment_methods_available: Pre toto prostredie nie sú nastavené žiadne spôsoby platby
+        no_shipping_methods_available: Pre zvolenú lokalitu nie sú dostupné žiadne spôsoby doručenia, zmeňte prosím vašu adresu
     errors_prohibited_this_record_from_being_saved:
-      one: "1 chyba znemožnila uložiť tento záznam"
       few: "%{count} chyby znemožnily uložiť tento záznam"
-      other:  "%{count} chýb znemožnilo uložiť tento záznam"
-    event: "Udalosť"
+      one: 1 chyba znemožnila uložiť tento záznam
+      other: "%{count} chýb znemožnilo uložiť tento záznam"
+    event: Udalosť
     events:
       spree:
         cart:
-          add: "Pridať do košíka"
+          add: Pridať do košíka
         checkout:
-          coupon_code_added: "Kupónový kód pridaný"
+          coupon_code_added: Kupónový kód pridaný
         content:
-          visited: "Navštíviť stránku so statickým obsahom"
+          visited: Navštíviť stránku so statickým obsahom
         order:
-          contents_changed: "Obsah objednávky zmenený"
-        page_view: "Statická stránka pozretá"
+          contents_changed: Obsah objednávky zmenený
+        page_view: Statická stránka pozretá
         user:
-          signup: "Registrácia používateľa"
+          signup: Registrácia používateľa
     exceptions:
-      count_on_hand_setter: "Nemožno nastaviť počet na sklade manuálne, pretože je nastavený automaticky spätným volaním recalculate_count_on_hand. Namiesto toho prosím použite `update_column(:count_on_hand, value)`."
-    exchange_for: "Zámena za"
-    excl: "nezahr."
-    existing_shipments: "Jestvujúce doručovania"
-    expected: "Očakávané"
-    expected_items: "Očakávané položky"
-    expedited_exchanges_warning: "Všetky uvedené zámeny budú zákazníkovi odoslané ihneď po prijatí pôvodného tovaru. V prípade, že ho zákazník nevráti v lehote %{days_window}, bude mu naúčtovaná suma za všetok dodaný tovar."
+      count_on_hand_setter: >-
+        Nemožno nastaviť počet na sklade manuálne, pretože je nastavený automaticky spätným volaním recalculate_count_on_hand. Namiesto toho prosím
+        použite `update_column(:count_on_hand, value)`.
+    exchange_for: Zámena za
+    excl: nezahr.
+    existing_shipments: Jestvujúce doručovania
+    expected: Očakávané
+    expected_items: Očakávané položky
+    expedited_exchanges_warning: >-
+      Všetky uvedené zámeny budú zákazníkovi odoslané ihneď po prijatí pôvodného tovaru. V prípade, že ho zákazník nevráti v lehote %{days_window},
+      bude mu naúčtovaná suma za všetok dodaný tovar.
     expiration: Expirácia
     extension: Rozšírenie
-    failed_payment_attempts: "Neúspešné pokusy o zaplatenie"
+    failed_payment_attempts: Neúspešné pokusy o zaplatenie
     filename: Názov súboru
-    fill_in_customer_info: "Vyplňte prosím údaje o zákazníkovi"
-    filter_results: "Výsledky filtrovania"
-    finalize: "Dokončiť"
-    finalized: "Dokončené"
-    find_a_taxon: "Nájsť taxón"
+    fill_in_customer_info: Vyplňte prosím údaje o zákazníkovi
+    filter_results: Výsledky filtrovania
+    finalize: Dokončiť
+    finalized: Dokončené
+    find_a_taxon: Nájsť taxón
     first_item: Cena prvej položky
-    first_name: "Krstné meno"
-    first_name_begins_with: "Krstné meno začína na"
-    flat_percent: "Pevné percento"
-    flat_rate_per_order: "Pevná sadzba (za objednávku)"
-    flexible_rate: "Pružná sadzba"
-    forgot_password: "Zabudnuté heslo"
-    free_shipping: "Doručenie zdarma"
-    free_shipping_amount:
-    from: "Z"
-    front_end: "v obchode"
-    fulfillable_stock: "Naplniteľný sklad"
-    gateway: "Platobná brána"
-    gateway_config_unavailable: "Brána je pre toto prostredie neprístupná"
+    first_name: Krstné meno
+    first_name_begins_with: Krstné meno začína na
+    flat_percent: Pevné percento
+    flat_rate_per_order: Pevná sadzba (za objednávku)
+    flexible_rate: Pružná sadzba
+    forgot_password: Zabudnuté heslo
+    free_shipping: Doručenie zdarma
+    free_shipping_amount: 
+    from: Z
+    front_end: v obchode
+    fulfillable_stock: Naplniteľný sklad
+    gateway: Platobná brána
+    gateway_config_unavailable: Brána je pre toto prostredie neprístupná
     gateway_error: Chyba brány
     general: Všeobecné
     general_settings: Všeobecné nastavenia
-    google_analytics:
-    google_analytics_id:
-    guest_checkout: "Ako hosť (bez registrácie)"
+    google_analytics: 
+    google_analytics_id: 
+    guest_checkout: Ako hosť (bez registrácie)
     guest_user_account: K pokladnici ako hosť
-    has_no_shipped_units:
+    has_no_shipped_units: 
     height: Výška
-    hide_cents: "Skryť centy"
+    hide_cents: Skryť centy
     home: Domov
     i18n:
-      available_locales: "Dostupné národné prostredia"
-      language: "Jazyk"
-      localization_settings: "Nastavenia národného prostredia"
+      available_locales: Dostupné národné prostredia
+      fields: Polia
+      language: Jazyk
+      localization_settings: Nastavenia národného prostredia
+      only_complete: Len dokončené
+      only_incomplete: Len nedokončené
+      select_locale: Zvoľte národné prostredie
+      show_only: Len zobraziť
+      supported_locales: Podporované národné prostredia
       this_file_language: Slovenčina
-      supported_locales: "Podporované národné prostredia"
-      fields: "Polia"
-      only_incomplete: "Len nedokončené"
-      only_complete: "Len dokončené"
-      select_locale: "Zvoľte národné prostredie"
-      show_only: "Len zobraziť"
-      translations: "Preklady"
-    icon: "Ikona"
-    identifier: "Identifikátor"
+      translations: Preklady
+    icon: Ikona
+    identifier: Identifikátor
     image: Obrázok
     images: Obrázky
-    implement_eligible_for_return: "Treba implementovať #eligible_for_return? pre váš EligibilityValidator."
-    implement_requires_manual_intervention: "Treba implementovať #requires_manual_intervention? pre váš EligibilityValidator."
-    inactive: "Neaktívny"
+    implement_eligible_for_return: 'Treba implementovať #eligible_for_return? pre váš EligibilityValidator.'
+    implement_requires_manual_intervention: 'Treba implementovať #requires_manual_intervention? pre váš EligibilityValidator.'
+    inactive: Neaktívny
     incl: vrát.
-    included_in_price: "Zahrnuté v cene"
-    included_price_validation: "nemôže byť zvolené pokiaľ nemáte nastavenú predvolenú zónu dane"
-    incomplete: "Nedokončené"
+    included_in_price: Zahrnuté v cene
+    included_price_validation: nemôže byť zvolené pokiaľ nemáte nastavenú predvolenú zónu dane
+    incomplete: Nedokončené
     info_number_of_skus_not_shown:
-      one: "a jedno ďalšie"
-      few: "a %{count} ďalšie"
-      other: "a %{count} ďalších"
+      few: a %{count} ďalšie
+      one: a jedno ďalšie
+      other: a %{count} ďalších
     info_product_has_multiple_skus:
-      one: "Tento produkt má %{count} variant:"
-      few: "Tento produkt má %{count} varianty:"
-      other: "Tento produkt má %{count} variantov:"
-    instructions_to_reset_password: "Zadajte prosím váš e-mail do nasledujúceho formulára"
-    insufficient_stock: "Nedostatok v sklade, zostáva len %{on_hand}"
-    insufficient_stock_lines_present: "Niektoré riadkové položky v tejto objednávke nie sú dostupné v dostatočnom množstve."
-    intercept_email_address:
-    intercept_email_instructions: "Nahradiť e-mail príjemcu touto adresou."
-    internal_name: "Vlastný názov"
-    invalid_credit_card: "Neplatná kreditná karta."
-    invalid_exchange_variant: "Neplatný variant zámeny."
-    invalid_payment_provider: "Neplatný poskytovateľ platby."
-    invalid_promotion_action: "Neplatná akciová činnosť."
-    invalid_promotion_rule:
+      few: 'Tento produkt má %{count} varianty:'
+      one: 'Tento produkt má %{count} variant:'
+      other: 'Tento produkt má %{count} variantov:'
+    instructions_to_reset_password: Zadajte prosím váš e-mail do nasledujúceho formulára
+    insufficient_stock: Nedostatok v sklade, zostáva len %{on_hand}
+    insufficient_stock_lines_present: Niektoré riadkové položky v tejto objednávke nie sú dostupné v dostatočnom množstve.
+    intercept_email_address: 
+    intercept_email_instructions: Nahradiť e-mail príjemcu touto adresou.
+    internal_name: Vlastný názov
+    invalid_credit_card: Neplatná kreditná karta.
+    invalid_exchange_variant: Neplatný variant zámeny.
+    invalid_payment_provider: Neplatný poskytovateľ platby.
+    invalid_promotion_action: Neplatná akciová činnosť.
+    invalid_promotion_rule: 
     inventory: Sklad
-    inventory_adjustment: "Úprava skladu"
-    inventory_error_flash_for_insufficient_quantity: "Položka vo vašom košíku sa stala nedostupnou."
-    inventory_state:
-    is_not_available_to_shipment_address:
-    iso_name: "ISO názov"
+    inventory_adjustment: Úprava skladu
+    inventory_error_flash_for_insufficient_quantity: Položka vo vašom košíku sa stala nedostupnou.
+    inventory_state: 
+    is_not_available_to_shipment_address: 
+    iso_name: ISO názov
     item: Položka
     item_description: Popis položky
-    item_total: "Položky spolu"
+    item_total: Položky spolu
     item_total_rule:
       operators:
-        gt: "väčšie ako"
-        gte: "väčšie ako alebo rovné"
-        lt: "menšie ako"
-        lte: "menšie ako alebo rovné"
-    items_cannot_be_shipped: "Nie sme schopní vypočítať poplatky za doručenie pre zvolené položky"
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        gt: väčšie ako
+        gte: väčšie ako alebo rovné
+        lt: menšie ako
+        lte: menšie ako alebo rovné
+    items_cannot_be_shipped: Nie sme schopní vypočítať poplatky za doručenie pre zvolené položky
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
+    jirafe: 
     landing_page_rule:
       path: Cesta
     last_name: Priezvisko
-    last_name_begins_with: "Priezvisko začína na"
-    learn_more: "Viac informácií"
-    lifetime_stats: "Celkové štatistiky"
-    line_item_adjustments:
+    last_name_begins_with: Priezvisko začína na
+    learn_more: Viac informácií
+    lifetime_stats: Celkové štatistiky
+    line_item_adjustments: 
     list: Zoznam
-    listing_countries: "Zoznam krajín"
-    listing_orders: "Zoznam objednávok"
-    listing_products: "Zoznam produktov"
-    listing_reports: "Zoznam výkazov"
-    listing_tax_categories: "Zoznam kategórií daní"
-    listing_users: "Zoznam používateľov"
-    loading: "Načítavanie"
-    locale_changed: "Národné prostredie zmenené"
-    location: "Umiestnenie"
-    lock: "Zamknúť"
-    log_entries: "Zaznamenané zápisy"
-    logged_in_as: "Prihlásený ako"
-    logged_in_succesfully: "Úspešné prihlásenie"
+    listing_countries: Zoznam krajín
+    listing_orders: Zoznam objednávok
+    listing_products: Zoznam produktov
+    listing_reports: Zoznam výkazov
+    listing_tax_categories: Zoznam kategórií daní
+    listing_users: Zoznam používateľov
+    loading: Načítavanie
+    locale_changed: Národné prostredie zmenené
+    location: Umiestnenie
+    lock: Zamknúť
+    log_entries: Zaznamenané zápisy
+    logged_in_as: Prihlásený ako
+    logged_in_succesfully: Úspešné prihlásenie
     logged_out: Odhlásili ste sa.
-    login: "Prihlásenie"
+    login: Prihlásenie
     login_as_existing: Prihláste sa ako náš zákazník
     login_failed: Nesprávne prihlasovacie údaje.
     login_name: Prihlásenie
     logout: Odhlásenie
-    logs: "Záznamy"
-    look_for_similar_items: "Hľadať podobný tovar"
-    make_refund:
-    make_sure_the_above_reimbursement_amount_is_correct:
-    management: "Správa"
-    manage_promotion_categories:
-    manage_stock: "Správa skladu"
-    manage_variants: "Spravovať varianty"
-    manual_intervention_required:
+    logs: Záznamy
+    look_for_similar_items: Hľadať podobný tovar
+    make_refund: 
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_stock: Správa skladu
+    manage_variants: Spravovať varianty
+    management: Správa
+    manual_intervention_required: 
     master_price: Hlavná cena
     match_choices:
-      all: "Všetko"
-      none: "Žiadne"
+      all: Všetko
+      none: Žiadne
     max_items: Maximálny počet položiek
-    member_since: "Členom od"
-    memo:
+    member_since: Členom od
+    memo: 
     meta_description: Meta-popis
     meta_keywords: Meta-kľúčové slová
-    meta_title:
+    meta_title: 
     metadata: Metaúdaje
-    minimal_amount: "Minimálne množstvo"
+    minimal_amount: Minimálne množstvo
     month: Mesiac
     more: Viac
-    move_stock_between_locations:
+    move_stock_between_locations: 
     my_account: Môj účet
     my_orders: Moje objednávky
-    name: "Názov"
-    name_on_card: "Meno na karte"
-    name_or_sku: "Názov alebo SKU (uveďte aspoň prvé 4 znaky názvu produktu)"
+    name: Názov
+    name_on_card: Meno na karte
+    name_or_sku: Názov alebo SKU (uveďte aspoň prvé 4 znaky názvu produktu)
     new: Nové
-    new_adjustment: "Nová úprava"
-    new_country: "Nová krajina"
+    new_adjustment: Nová úprava
+    new_country: Nová krajina
     new_customer: Nový zákazník
-    new_customer_return:
+    new_customer_return: 
     new_image: Nový obrázok
     new_option_type: Nový typ volieb
     new_order: Nová objednávka
-    new_order_completed:
-    new_payment: "Nová platba"
-    new_payment_method: "Nový spôsob platby"
+    new_order_completed: 
+    new_payment: Nová platba
+    new_payment_method: Nový spôsob platby
     new_product: Nový produkt
-    new_promotion: "Nová akcia"
-    new_promotion_category: "Nová kategória akcií"
+    new_promotion: Nová akcia
+    new_promotion_category: Nová kategória akcií
     new_property: Nová vlastnosť
     new_prototype: Nový prototyp
-    new_refund:
-    new_refund_reason: "Nový dôvod vracania platby"
-    new_return_authorization:
-    new_rma_reason: "Nový dôvod reklamácie"
-    new_shipment_at_location:
+    new_refund: 
+    new_refund_reason: Nový dôvod vracania platby
+    new_return_authorization: 
+    new_rma_reason: Nový dôvod reklamácie
+    new_shipment_at_location: 
     new_shipping_category: Nová kategória doručenia
-    new_shipping_method: "Nový spôsob doručenia"
-    new_state: "Nový štát/provincia/kraj"
-    new_stock_location: "Nové umiestnenie skladu"
-    new_stock_movement: "Nový pohyb na sklade"
-    new_stock_transfer: "Nový presun medzi skladmi"
+    new_shipping_method: Nový spôsob doručenia
+    new_state: Nový štát/provincia/kraj
+    new_stock_location: Nové umiestnenie skladu
+    new_stock_movement: Nový pohyb na sklade
+    new_stock_transfer: Nový presun medzi skladmi
     new_tax_category: Nová kategória dane
     new_tax_rate: Nová sadzba dane
     new_taxon: Nový taxón
     new_taxonomy: Nová taxonómia
-    new_tracker: "Nový merač"
+    new_tracker: Nový merač
     new_user: Nový používateľ
     new_variant: Nový variant
     new_zone: Nová zóna
-    next: "Ďalšie"
-    no_actions_added: "Neboli pridané žiadne akcie"
-    no_payment_found: "Nenašla sa žiadna platba"
-    no_pending_payments: "Žiadne čakajúce platby"
-    no_products_found: "Nenašiel sa žiadny produkt"
-    no_resource_found: ! 'Žiadnych %{resource} zatiaľ niet... '
-    no_results: "Žiadne výsledky"
-    no_returns_found:
-    no_rules_added: "Neboli pridané žiadne pravidlá"
-    no_shipping_method_selected:
-    no_state_changes:
+    next: Ďalšie
+    no_actions_added: Neboli pridané žiadne akcie
+    no_payment_found: Nenašla sa žiadna platba
+    no_pending_payments: Žiadne čakajúce platby
+    no_products_found: Nenašiel sa žiadny produkt
+    no_resource_found: 'Žiadnych %{resource} zatiaľ niet... '
+    no_results: Žiadne výsledky
+    no_returns_found: 
+    no_rules_added: Neboli pridané žiadne pravidlá
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: Neposkytnuté žiadne podrobnosti o sledovaní.
-    none: "Žiadny"
-    none_selected:
-    normal_amount:
+    none: Žiadny
+    none_selected: 
+    normal_amount: 
     not: nie
     not_available: N/A
-    not_enough_stock: "V zdrojovom umiestnení nie je pre dokončenie tohoto presunu dostatok zásob."
-    not_found: ! '%{resource} nenájdené'
-    note: "Poznámka"
+    not_enough_stock: V zdrojovom umiestnení nie je pre dokončenie tohoto presunu dostatok zásob.
+    not_found: "%{resource} nenájdené"
+    note: Poznámka
     notice_messages:
-      product_cloned: "Produkt bol naklonovaný"
-      product_deleted: "Produkt bol zmazaný"
-      product_not_cloned: "Produkt nemohol byť naklonovaný"
-      product_not_deleted: "Produkt nemohol byť zmazaný"
-      variant_deleted: "Variant bol zmazaný"
-      variant_not_deleted: "Variant nemohol byť zmazaný"
-    number: "Číslo"
+      product_cloned: Produkt bol naklonovaný
+      product_deleted: Produkt bol zmazaný
+      product_not_cloned: Produkt nemohol byť naklonovaný
+      product_not_deleted: Produkt nemohol byť zmazaný
+      variant_deleted: Variant bol zmazaný
+      variant_not_deleted: Variant nemohol byť zmazaný
+    num_orders: Počet obj.
+    number: Číslo
     number_of_codes:
-      one: ! '%{count} kód'
-      few: ! '%{count} kódy'
-      other: ! '%{count} kódov'
-    num_orders: "Počet obj."
+      few: "%{count} kódy"
+      one: "%{count} kód"
+      other: "%{count} kódov"
     on_hand: Na sklade
-    open: "Otvoriť"
-    open_all_adjustments: "Otvoriť všetky úpravy"
-    option_type: "Typ voľby"
-    option_type_placeholder: "Zvoľte typ voľby"
-    option_types: "Typy volieb"
-    option_value: "Hodnota voľby"
-    option_values: "Hodnoty volieb"
-    optional: "Voliteľný"
-    options: "Voľby"
+    open: Otvoriť
+    open_all_adjustments: Otvoriť všetky úpravy
+    option_type: Typ voľby
+    option_type_placeholder: Zvoľte typ voľby
+    option_types: Typy volieb
+    option_value: Hodnota voľby
+    option_values: Hodnoty volieb
+    optional: Voliteľný
+    options: Voľby
     or: alebo
     or_over_price: "%{price} alebo viac"
-    order: "Objednávka"
+    order: Objednávka
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved: "Objednávka schválená"
-    order_canceled: "Objednávka zrušená"
+    order_already_updated: 
+    order_approved: Objednávka schválená
+    order_canceled: Objednávka zrušená
     order_details: Detaily objednávky
-    order_email_resent: "E-mail o objednávke bol znova odoslaný"
-    order_information: "Informácie o objednávke"
+    order_email_resent: E-mail o objednávke bol znova odoslaný
+    order_information: Informácie o objednávke
     order_mailer:
       cancel_email:
-        dear_customer: "Vážený zákazník,"
-        instructions: "Vaša objednávka bola ZRUŠENÁ. Uschovajte si prosím pre vaše potreby túto informáciu o jej zrušení."
-        order_summary_canceled: "Sumár objednávky [ZRUŠENÁ]"
-        subject: "Zrušenie objednávky"
-        subtotal: ! 'Medzisúčet:'
-        total: ! 'Objednávka celkom:'
+        dear_customer: Vážený zákazník,
+        instructions: Vaša objednávka bola ZRUŠENÁ. Uschovajte si prosím pre vaše potreby túto informáciu o jej zrušení.
+        order_summary_canceled: Sumár objednávky [ZRUŠENÁ]
+        subject: Zrušenie objednávky
+        subtotal: 'Medzisúčet:'
+        total: 'Objednávka celkom:'
       confirm_email:
-        dear_customer: "Vážený zákazník,"
-        instructions: "Prezrite a uschovajte si prosím pre vaše potreby nasledujúcu informáciu o objednávke."
-        order_summary: "Sumár objednávky"
-        subject: "Potvrdenie objednávky"
-        subtotal: ! 'Medzisúčet:'
-        thanks: "Ďakujeme za Vašu objednávku"
-        total: ! 'Objednávka celkom:'
-    order_not_found: "Nedokázali sme nájsť vašu objednávku. Skúste to prosím znova."
-    order_number: "Objednávka %{number}"
-    order_processed_successfully: "Vaša objednávka bola úspešne spracovaná"
-    order_resumed:
+        dear_customer: Vážený zákazník,
+        instructions: Prezrite a uschovajte si prosím pre vaše potreby nasledujúcu informáciu o objednávke.
+        order_summary: Sumár objednávky
+        subject: Potvrdenie objednávky
+        subtotal: 'Medzisúčet:'
+        thanks: Ďakujeme za Vašu objednávku
+        total: 'Objednávka celkom:'
+    order_not_found: Nedokázali sme nájsť vašu objednávku. Skúste to prosím znova.
+    order_number: Objednávka %{number}
+    order_processed_successfully: Vaša objednávka bola úspešne spracovaná
+    order_resumed: 
     order_state:
       address: adresa
-      awaiting_return: "čaká na vrátenie"
+      awaiting_return: čaká na vrátenie
       canceled: zrušené
       cart: košík
       complete: dokončiť
       confirm: potvrdenie
-      considered_risky: "považované za rizikové"
+      considered_risky: považované za rizikové
       delivery: doručenie
       payment: platba
       resumed: obnovené
       returned: vrátené
     order_summary: Sumár objednávky
-    order_sure_want_to: "Ste si istí, že chcete %{event} túto objednávku?"
+    order_sure_want_to: Ste si istí, že chcete %{event} túto objednávku?
     order_total: Objednávka celkom
-    order_updated: "Objednávka aktualizovaná"
+    order_updated: Objednávka aktualizovaná
     orders: Objednávky
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Nie je na sklade
     overview: Prehľad
-    package_from: "balík z"
+    package_from: balík z
     pagination:
       next_page: ďalšia strana &raquo;
-      previous_page: ! '&laquo; predchádzajúca strana'
-      truncate:
+      previous_page: "&laquo; predchádzajúca strana"
+      truncate: 
     password: Heslo
-    paste: "Vložiť"
+    paste: Vložiť
     path: Cesta
-    pay: "platiť"
+    pay: platiť
     payment: Platba
-    payment_could_not_be_created: "Platba nemohla byť vytvorená."
-    payment_identifier: "Identifikátor platby"
-    payment_information: "Informácia o platbe"
-    payment_method: "Spôsob platby"
-    payment_method_not_supported: "Taký spôsob platby nie je podporovaný. Zvoľte prosím iný."
-    payment_methods: "Spôsoby platieb"
-    payment_processing_failed: "Platba nemohla byť uskutočnená, skontrolujte prosím údaje, ktoré ste zadali"
-    payment_processor_choose_banner_text: "Ak potrebujete pomoc pri voľboe platobného procesora, navštívte prosím"
-    payment_processor_choose_link: "našu stránku o platbách"
-    payment_state: "Stav úhrady"
+    payment_could_not_be_created: Platba nemohla byť vytvorená.
+    payment_identifier: Identifikátor platby
+    payment_information: Informácia o platbe
+    payment_method: Spôsob platby
+    payment_method_not_supported: Taký spôsob platby nie je podporovaný. Zvoľte prosím iný.
+    payment_methods: Spôsoby platieb
+    payment_processing_failed: Platba nemohla byť uskutočnená, skontrolujte prosím údaje, ktoré ste zadali
+    payment_processor_choose_banner_text: Ak potrebujete pomoc pri voľboe platobného procesora, navštívte prosím
+    payment_processor_choose_link: našu stránku o platbách
+    payment_state: Stav úhrady
     payment_states:
-      balance_due: "Neuhradené"
-      checkout: "Na pokladni"
-      completed: "Dokončené"
-      credit_owed: "Dlžný kredit"
-      failed: "Chybné"
-      paid: "Uhradené"
-      pending: "Čakajúce"
-      processing: "Spracúvané"
-      void: "Anulované"
-    payment_updated:
+      balance_due: Neuhradené
+      checkout: Na pokladni
+      completed: Dokončené
+      credit_owed: Dlžný kredit
+      failed: Chybné
+      paid: Uhradené
+      pending: Čakajúce
+      processing: Spracúvané
+      void: Anulované
+    payment_updated: 
     payments: Platba
-    pending: "Čakajúce"
-    percent:
-    percent_per_item: "Percent na položku"
-    permalink:
+    pending: Čakajúce
+    percent: 
+    percent_per_item: Percent na položku
+    permalink: 
     phone: Telefón
-    place_order: "Objednať"
-    please_define_payment_methods:
-    populate_get_error:
+    place_order: Objednať
+    please_define_payment_methods: 
+    populate_get_error: 
     powered_by: pod kapotou
-    preference_source_none: '(vlastný)'
-    preference_source_using:
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preference_source_none: "(vlastný)"
+    preference_source_using: 
+    preferred_reimbursement_type: 
     presentation: Prezentácia
     previous: Predchádzajúci
-    previous_state_missing:
+    previous_state_missing: 
     price: Cena
     price_range: Cenové rozpätie
-    price_sack:
+    price_sack: 
     process: Spracuj
-    product:
+    product: 
     product_details: Detaily o produkte
     product_has_no_description: Produkt nemá popis
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: Vlastnosti produktu
     product_rule:
-      choose_products: "Zvoliť produkty"
+      choose_products: Zvoliť produkty
       label: Objednávka musí obsahovať %{select} z týchto produktov
-      match_all: "všetky;"
-      match_any: "ktorýkoľvek"
-      match_none: "žiadny"
+      match_all: všetky;
+      match_any: ktorýkoľvek
+      match_none: žiadny
       product_source:
-        group: "Zo skupiny produktov"
-        manual: "Vybrať ručne"
-    products: "Produkty"
-    promotion: "Akcia"
-    promotion_action: "Akciová činnosť"
+        group: Zo skupiny produktov
+        manual: Vybrať ručne
+    products: Produkty
+    promotion: Akcia
+    promotion_action: Akciová činnosť
     promotion_action_types:
       create_adjustment:
-        description: "Vytvorí nastavenie akciového kreditu na objednávke"
-        name: "Vytvoriť celoobjednávkové nastavenie"
+        description: Vytvorí nastavenie akciového kreditu na objednávke
+        name: Vytvoriť celoobjednávkové nastavenie
       create_item_adjustments:
-        description: "Vytvorí nastavenie akciového kreditu na riadkovej položke"
-        name: "Vytvoriť nastavenie zvlášť pre každú riadkovú položku"
+        description: Vytvorí nastavenie akciového kreditu na riadkovej položke
+        name: Vytvoriť nastavenie zvlášť pre každú riadkovú položku
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description: "Učiní všetky doručovania objednávky bezplatnými"
-        name: "Bezplatné doručenie"
-    promotion_actions: "Akcie"
+        description: Učiní všetky doručovania objednávky bezplatnými
+        name: Bezplatné doručenie
+    promotion_actions: Akcie
     promotion_form:
       match_policies:
-        all: "Spĺňa všetky tieto pravidlá"
-        any: "Spĺňa ktorékoľvek z týchto pravidiel"
-    promotion_rule:
+        all: Spĺňa všetky tieto pravidlá
+        any: Spĺňa ktorékoľvek z týchto pravidiel
+    promotion_rule: 
     promotion_rule_types:
       first_order:
-        description: "Musí byť zákazníkova prvá objednávka"
-        name: "Prvá objednávka"
+        description: Musí byť zákazníkova prvá objednávka
+        name: Prvá objednávka
       item_total:
-        description: "Sumár za objednávku spĺňa tieto kritériá"
-        name: "Položka spolu"
+        description: Sumár za objednávku spĺňa tieto kritériá
+        name: Položka spolu
       landing_page:
-        description: "Zákazník musí mať navštívenú určenú stránku"
-        name: "Záchytná stránka"
+        description: Zákazník musí mať navštívenú určenú stránku
+        name: Záchytná stránka
       one_use_per_user:
-        description: "Len jedno použitie na používateľa"
-        name: "Jedno použitie na používateľa"
+        description: Len jedno použitie na používateľa
+        name: Jedno použitie na používateľa
       option_value:
-        description: "Objednávka obsahuje určený/é produkt/y, ktorý/é sa zhodujú s hodnotou/ami voľby"
-        name: "Hodnota/y voľby"
+        description: Objednávka obsahuje určený/é produkt/y, ktorý/é sa zhodujú s hodnotou/ami voľby
+        name: Hodnota/y voľby
       product:
-        description: "Objednávka obsahuje určený/é produkt(y)"
-        name: "Produkt(y)"
+        description: Objednávka obsahuje určený/é produkt(y)
+        name: Produkt(y)
       taxon:
-        description: "Objednávka obsahuje produkty s určeným(i) taxónom/mi"
-        name: "Taxón(y)"
+        description: Objednávka obsahuje produkty s určeným(i) taxónom/mi
+        name: Taxón(y)
       user:
-        description: "Dostupné len určeným používateľom"
-        name: "Používateľ"
+        description: Dostupné len určeným používateľom
+        name: Používateľ
       user_logged_in:
-        description: "Dostupné len prihláseným používateľom"
-        name: "Prihlásený používateľ"
-    promotion_uses: "Akcia používa"
-    promotionable: "Použiteľné v akcii"
-    promotions: "Akcie"
-    propagate_all_variants: "Propagovať všetky varianty"
+        description: Dostupné len prihláseným používateľom
+        name: Prihlásený používateľ
+    promotion_uses: Akcia používa
+    promotionable: Použiteľné v akcii
+    promotions: Akcie
+    propagate_all_variants: Propagovať všetky varianty
     properties: Vlastnosti
     property: Vlastnosť
     prototype: Prototyp
     prototypes: Prototypy
-    provider: "Poskytovateľ"
-    provider_settings_warning: "Ak meníte typ poskytovateľa, musíte si to najskôr uložiť, aby ste mohli upraviť nastavenia poskytovateľa"
-    qty: "Množ."
-    quantity: "Množstvo"
-    quantity_returned: "Vrátené množstvo"
-    quantity_shipped: "Doručované množstvo"
-    quick_search:
+    provider: Poskytovateľ
+    provider_settings_warning: Ak meníte typ poskytovateľa, musíte si to najskôr uložiť, aby ste mohli upraviť nastavenia poskytovateľa
+    qty: Množ.
+    quantity: Množstvo
+    quantity_returned: Vrátené množstvo
+    quantity_shipped: Doručované množstvo
+    quick_search: 
     rate: Sadzba
-    ready_to_ship: "Pripravené na prepravu"
-    reason: "Dôvod"
-    receive: "prijať"
-    receive_stock: "Prijímací sklad"
-    received: "Prijaté"
-    reception_status: "Stav prijímania"
-    reference: "Referencia"
-    refund: "Vrátiť platbu"
-    refund_amount_must_be_greater_than_zero: "Vracaná čiastka musí byť väčšia ako nula"
-    refund_reasons: "Dôvody vracania platieb"
-    refunded_amount: "Vrátená suma"
-    refunds: "Vrátenia platby"
-    register: "Registrovať sa ako nový používateľ"
+    ready_to_ship: Pripravené na prepravu
+    reason: Dôvod
+    receive: prijať
+    receive_stock: Prijímací sklad
+    received: Prijaté
+    reception_status: Stav prijímania
+    reference: Referencia
+    refund: Vrátiť platbu
+    refund_amount_must_be_greater_than_zero: Vracaná čiastka musí byť väčšia ako nula
+    refund_reasons: Dôvody vracania platieb
+    refunded_amount: Vrátená suma
+    refunds: Vrátenia platby
+    register: Registrovať sa ako nový používateľ
     registration: Registrácia
-    reimburse: "Nahradiť"
-    reimbursed: "Nahradené"
-    reimbursement: "Náhrada"
+    reimburse: Nahradiť
+    reimbursed: Nahradené
+    reimbursement: Náhrada
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send: ! 'Máte %{days} dní na doručenie späť všetkých položiek čakajúcich na zámenu.'
-        dear_customer: "Vážený zákazník,"
-        exchange_summary: "Prehľad zámeny"
-        for: "pre"
-        instructions: "Vaša náhrada bola spracovaná."
-        refund_summary: "Zhrnutie vrátenia platby"
-        subject: "Upozornenie o náhrade"
-        total_refunded: ! 'Vrátená suma celkom: %{total}'
-    reimbursement_perform_failed: "Náhrada nemôže byť vykonaná.  Chyba: %{error}"
-    reimbursement_status: "Stav náhrady"
-    reimbursement_type: "Typ náhrady"
-    reimbursement_type_override:
-    reimbursement_types: "Typy náhrad"
-    reimbursements: "Náhrady"
-    reject: "Zamietnuť"
-    rejected: "Zamietnuté"
+        days_to_send: Máte %{days} dní na doručenie späť všetkých položiek čakajúcich na zámenu.
+        dear_customer: Vážený zákazník,
+        exchange_summary: Prehľad zámeny
+        for: pre
+        instructions: Vaša náhrada bola spracovaná.
+        refund_summary: Zhrnutie vrátenia platby
+        subject: Upozornenie o náhrade
+        total_refunded: 'Vrátená suma celkom: %{total}'
+    reimbursement_perform_failed: 'Náhrada nemôže byť vykonaná.  Chyba: %{error}'
+    reimbursement_status: Stav náhrady
+    reimbursement_type: Typ náhrady
+    reimbursement_type_override: 
+    reimbursement_types: Typy náhrad
+    reimbursements: Náhrady
+    reject: Zamietnuť
+    rejected: Zamietnuté
     remember_me: Zapamätaj si ma
-    remove: "Odstrániť"
-    rename: "Premenovať"
-    report: "Výkaz"
-    reports: "Výkazy"
-    resend: "Zaslať znova"
+    remove: Odstrániť
+    rename: Premenovať
+    report: Výkaz
+    reports: Výkazy
+    resend: Zaslať znova
     reset_password: Vygeneruj heslo
     response_code: Kód odpovede
-    restock_inventory: "Doplňovanie zásob"
+    restock_inventory: Doplňovanie zásob
     resume: pokračovať
     resumed: Obnovený
     return: vrátiť sa
-    return_authorization: "Povolenie vrátenia"
-    return_authorization_reasons:
-    return_authorization_updated: "Povolenie vrátenia aktualizované"
-    return_authorizations: "Povolenia vrátení"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity:
-    return_reasons: "Dôvody vracania objednávok"
+    return_authorization: Povolenie vrátenia
+    return_authorization_reasons: 
+    return_authorization_updated: Povolenie vrátenia aktualizované
+    return_authorizations: Povolenia vrátení
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
+    return_quantity: 
+    return_reasons: Dôvody vracania objednávok
     returned: Vrátené
-    returns:
+    returns: 
     review: Review
-    risk: "Riziko"
-    risk_analysis: "Analýza rizík"
-    risky: "Riskantné"
+    risk: Riziko
+    risk_analysis: Analýza rizík
+    risky: Riskantné
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
     roles: Roly
-    rules: "Pravidlá"
-    safe: "Bezpečný"
-    sales_total: "Tržby spolu"
-    sales_total_description: "Tržby spolu za všetky objednávky"
-    sales_totals: "Obchody spolu"
-    save_and_continue: "Uložiť a pokračovať"
-    save_my_address: "Uložiť moju adresu"
-    say_no: "Nie"
-    say_yes: "Áno"
+    rules: Pravidlá
+    safe: Bezpečný
+    sales_total: Tržby spolu
+    sales_total_description: Tržby spolu za všetky objednávky
+    sales_totals: Obchody spolu
+    save_and_continue: Uložiť a pokračovať
+    save_my_address: Uložiť moju adresu
+    say_no: Nie
+    say_yes: Áno
     scope: Scope
-    search: "Hľadať"
-    search_results: "Výsledky vyhľadávania pre %{keywords}"
-    searching: "Vyhľadávanie"
-    secure_connection_type: "Bezpečný typ spojenia"
+    search: Hľadať
+    search_results: Výsledky vyhľadávania pre %{keywords}
+    searching: Vyhľadávanie
+    secure_connection_type: Bezpečný typ spojenia
     security_settings: Security Settings
     select: Vyber
-    select_a_return_authorization_reason:
-    select_a_stock_location: "Zvoliť umiestnenie skladu"
+    select_a_return_authorization_reason: 
+    select_a_stock_location: Zvoliť umiestnenie skladu
     select_from_prototype: Vyber z prototypov
-    select_stock: "Zvoliť sklad"
+    select_stock: Zvoliť sklad
     send_copy_of_all_mails_to: Pošli kópiu všetkých emailov na
     send_mails_as: Pošli email ako
     server: Server
@@ -1231,260 +1237,260 @@ sk:
     settings: Nastavenia
     ship: zašli
     ship_address: Adresa zásielky
-    ship_total: "Doprava"
+    ship_total: Doprava
     shipment: Zásielka
-    shipment_adjustments: "Nastavenia doručovania"
-    shipment_details: "Z %{stock_location} prostredníctvom %{shipping_method}"
+    shipment_adjustments: Nastavenia doručovania
+    shipment_details: Z %{stock_location} prostredníctvom %{shipping_method}
     shipment_mailer:
       shipped_email:
-        dear_customer: "Vážený zákazník,"
-        instructions: "Vaša objednávka bola vyexpedovaná"
-        shipment_summary: "Sumár doručenia;"
-        subject: "Upozornenie o doručení"
-        thanks: "Ďakujeme za Vašu objednávku."
-        track_information: ! 'Pokyny pre sledovanie zásielky: %{tracking}'
-        track_link: ! 'Odkaz na sledovanie: %{url}'
-    shipment_number: "Číslo doručenia"
-    shipment_numbers: "Čísla doručení"
-    shipment_state: "Stav doručenia"
+        dear_customer: Vážený zákazník,
+        instructions: Vaša objednávka bola vyexpedovaná
+        shipment_summary: Sumár doručenia;
+        subject: Upozornenie o doručení
+        thanks: Ďakujeme za Vašu objednávku.
+        track_information: 'Pokyny pre sledovanie zásielky: %{tracking}'
+        track_link: 'Odkaz na sledovanie: %{url}'
+    shipment_number: Číslo doručenia
+    shipment_numbers: Čísla doručení
+    shipment_state: Stav doručenia
     shipment_states:
-      backorder: "Dočasne nedostupné"
-      canceled: "Zrušené"
-      partial: "Čiastočne"
-      pending: "Čakajúce"
-      ready: "Pripravené"
-      shipped: "Doručované"
-    shipment_transfer_error: "Vysktla sa chyba pri prenose variantov"
-    shipment_transfer_success: "Varianty úspešne prenesené"
-    shipments: "Doručenia"
+      backorder: Dočasne nedostupné
+      canceled: Zrušené
+      partial: Čiastočne
+      pending: Čakajúce
+      ready: Pripravené
+      shipped: Doručované
+    shipment_transfer_error: Vysktla sa chyba pri prenose variantov
+    shipment_transfer_success: Varianty úspešne prenesené
+    shipments: Doručenia
     shipped: Zaslané
     shipping: Doručenie
-    shipping_address: "Adresa pre doručenie"
+    shipping_address: Adresa pre doručenie
     shipping_categories: Kategórie doručenia
     shipping_category: Kategórie doručenia
-    shipping_flat_rate_per_item: "Pevná sadzba za položku"
-    shipping_flat_rate_per_order: "Pevná sadzba za objednávku"
-    shipping_flexible_rate: "Pružná sadzba za položku v balíku"
-    shipping_instructions: "Pokyny pre doručenie"
-    shipping_method: "Spôsob doručenia"
-    shipping_methods: "Spôsoby doručenia"
-    shipping_price_sack:
-    shipping_total: "Doprava spolu"
+    shipping_flat_rate_per_item: Pevná sadzba za položku
+    shipping_flat_rate_per_order: Pevná sadzba za objednávku
+    shipping_flexible_rate: Pružná sadzba za položku v balíku
+    shipping_instructions: Pokyny pre doručenie
+    shipping_method: Spôsob doručenia
+    shipping_methods: Spôsoby doručenia
+    shipping_price_sack: 
+    shipping_total: Doprava spolu
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: Nákupný košík
-    show: "Zobraziť"
-    show_active: "Zobraziť aktívne"
-    show_deleted: "Zobraziť vymazané"
-    show_only_complete_orders: "Zobraziť len dokončené objednávky"
-    show_only_considered_risky: "Zobraziť len riskantné objednávky"
-    show_only_open_transfers: "Zobraziť len otvorené presuny"
-    show_rate_in_label: "Zobraziť sadzbu v štítku"
-    sku:
-    skus: "SKU-čka"
-    slug: "Strojový názov"
-    source: "Zdroj"
-    special_instructions: "Zvláštne pokyny"
-    split: "Rozdeliť"
-    spree_gateway_error_flash_for_checkout: "Vyskytol sa problém s vašimi platobnými údajmi. Skontrolujte ich prosím a skúste znova."
+    show: Zobraziť
+    show_active: Zobraziť aktívne
+    show_deleted: Zobraziť vymazané
+    show_only_complete_orders: Zobraziť len dokončené objednávky
+    show_only_considered_risky: Zobraziť len riskantné objednávky
+    show_only_open_transfers: Zobraziť len otvorené presuny
+    show_rate_in_label: Zobraziť sadzbu v štítku
+    sku: 
+    skus: SKU-čka
+    slug: Strojový názov
+    source: Zdroj
+    special_instructions: Zvláštne pokyny
+    split: Rozdeliť
+    spree_gateway_error_flash_for_checkout: Vyskytol sa problém s vašimi platobnými údajmi. Skontrolujte ich prosím a skúste znova.
     ssl:
-      change_protocol: "Prepnite prosím na použitie HTTP (radšej ako HTTPS) a skúste znova túto požiadavku."
-    start: "Začiatok"
-    state: "Kraj"
-    state_based: "Štát/Provincia/Kraj"
+      change_protocol: Prepnite prosím na použitie HTTP (radšej ako HTTPS) a skúste znova túto požiadavku.
+    start: Začiatok
+    state: Kraj
+    state_based: Štát/Provincia/Kraj
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states: "Štáty/Provincie/Kraje"
-    states_required: "Vyžadované regióny"
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
+    states: Štáty/Provincie/Kraje
+    states_required: Vyžadované regióny
     status: Stavy
-    stock: "Sklad"
-    stock_item: "Skladová položka"
-    stock_location: "Umiestnenie skladu"
-    stock_location_info: "Údaje o umiestnení skladu"
-    stock_locations: "Umiestnenia skladov"
-    stock_locations_need_a_default_country: "Pred vytvorením umiestnenia skladu musíte vytvoriť predvolenú krajinu."
-    stock_management: "Správa skladu"
-    stock_management_requires_a_stock_location: "Vytvorte prosím umiestnenie skladu za účelom jeho správy."
-    stock_movements: "Pohyby na sklade"
-    stock_movements_for_stock_location: "Pohyby na sklade pre %{stock_location_name}"
-    stock_successfully_transferred: "Sklad bol úspešne prenesený medzi umiestneniami."
-    stock_transfer: "Presun medzi skladmi"
-    stock_transfers: "Presuny medzi skladmi"
-    stop: "Koniec"
+    stock: Sklad
+    stock_item: Skladová položka
+    stock_location: Umiestnenie skladu
+    stock_location_info: Údaje o umiestnení skladu
+    stock_locations: Umiestnenia skladov
+    stock_locations_need_a_default_country: Pred vytvorením umiestnenia skladu musíte vytvoriť predvolenú krajinu.
+    stock_management: Správa skladu
+    stock_management_requires_a_stock_location: Vytvorte prosím umiestnenie skladu za účelom jeho správy.
+    stock_movements: Pohyby na sklade
+    stock_movements_for_stock_location: Pohyby na sklade pre %{stock_location_name}
+    stock_successfully_transferred: Sklad bol úspešne prenesený medzi umiestneniami.
+    stock_transfer: Presun medzi skladmi
+    stock_transfers: Presuny medzi skladmi
+    stop: Koniec
     store: Obchod
     store_credit:
       actions:
-        invalidate: "Zneplatniť"
-      credit_allocation_memo: "Toto je kredit z ID Obchodného kreditu %{id}"
-      currency_mismatch: "Mena Obchodného kreditu nezodpovedá mene objednávky"
+        invalidate: Zneplatniť
+      credit_allocation_memo: Toto je kredit z ID Obchodného kreditu %{id}
+      currency_mismatch: Mena Obchodného kreditu nezodpovedá mene objednávky
       display_action:
         adjustment: Adjustment
-        allocation: "Pridané"
-        capture: "Použité"
-        credit: "Kredit"
-        invalidate: "Zneplatnené"
-        void: "Kredit"
         admin:
-          authorize: "Oprávnený"
-          eligible: "Spôsobilosť overená"
-          void: "Anulované"
+          authorize: Oprávnený
+          eligible: Spôsobilosť overená
+          void: Anulované
+        allocation: Pridané
+        capture: Použité
+        credit: Kredit
+        invalidate: Zneplatnené
+        void: Kredit
       errors:
-        unable_to_fund: "Nie je možné uhradiť objednávku použitím Obchodného kreditu"
-        cannot_invalidate_uncaptured_authorization:
-      expiring: "Expirujúce"
-      insufficient_authorized_amount:
-      insufficient_funds: "Zostávajúce množstvo Obchodného kreditu nie je postačujúce"
-      non_expiring: "Neexpirujúci"
-      select_one_store_credit:
-      store_credit: "Obchodný kredit"
-      successful_action:
-      unable_to_credit:
-      unable_to_void: "Nemožno anulovať kód: %{auth_code}"
-      unable_to_find: "Nemožno nájsť Obchodný kredit"
-      unable_to_find_for_action:
-      user_has_no_store_credits: "Používateľ nemá k dispozícii žiaden Obchodný kredit"
+        cannot_invalidate_uncaptured_authorization: 
+        unable_to_fund: Nie je možné uhradiť objednávku použitím Obchodného kreditu
+      expiring: Expirujúce
+      insufficient_authorized_amount: 
+      insufficient_funds: Zostávajúce množstvo Obchodného kreditu nie je postačujúce
+      non_expiring: Neexpirujúci
+      select_one_store_credit: 
+      store_credit: Obchodný kredit
+      successful_action: 
+      unable_to_credit: 
+      unable_to_find: Nemožno nájsť Obchodný kredit
+      unable_to_find_for_action: 
+      unable_to_void: 'Nemožno anulovať kód: %{auth_code}'
+      user_has_no_store_credits: Používateľ nemá k dispozícii žiaden Obchodný kredit
     street_address: Ulica
     street_address_2: Ulica (pokr.)
     subtotal: Medzisúčet
     subtract: Odrátaj
-    success: "Úspech"
-    successfully_created: ! '%{resource} bolo úspešne vytvorené!'
-    successfully_refunded: ! '%{resource} bolo úspešne vrátené!'
-    successfully_removed: ! '%{resource} bolo úspešne odstránené!'
-    successfully_signed_up_for_analytics: "Úspešne registrované pre Spree Analytics"
-    successfully_updated: ! '%{resource} bolo úspešne aktualizované!'
-    summary: "Zhrnutie"
+    success: Úspech
+    successfully_created: "%{resource} bolo úspešne vytvorené!"
+    successfully_refunded: "%{resource} bolo úspešne vrátené!"
+    successfully_removed: "%{resource} bolo úspešne odstránené!"
+    successfully_signed_up_for_analytics: Úspešne registrované pre Spree Analytics
+    successfully_updated: "%{resource} bolo úspešne aktualizované!"
+    summary: Zhrnutie
     tax: Daň
     tax_categories: Kategórie daní
     tax_category: Kategória daní
-    tax_code: "Kód dane"
-    tax_included: "Daň (zahrnutá)"
-    tax_rate_amount_explanation: "Sadzby daní sú desatinné čiastky na pomoc pri kalkuláciách, (napr. ak je daň 5% potom zadajte 0,05)"
+    tax_code: Kód dane
+    tax_included: Daň (zahrnutá)
+    tax_rate_amount_explanation: Sadzby daní sú desatinné čiastky na pomoc pri kalkuláciách, (napr. ak je daň 5% potom zadajte 0,05)
     tax_rates: Sadzby daní
     taxon: Taxón
-    taxon_edit: "Upraviť taxón"
-    taxon_placeholder: "Pridať taxón"
+    taxon_edit: Upraviť taxón
+    taxon_placeholder: Pridať taxón
     taxon_rule:
-      choose_taxons: "Zvoľte taxóny"
-      label: "Objednávka musí osahovať %{select}"
-      match_all: "všetky tieto taxóny"
-      match_any: "aspoň jeden z týchto taxónov"
+      choose_taxons: Zvoľte taxóny
+      label: Objednávka musí osahovať %{select}
+      match_all: všetky tieto taxóny
+      match_any: aspoň jeden z týchto taxónov
     taxonomies: Taxonómie
-    taxonomy: "Taxonómia"
-    taxonomy_edit: "Upraviť taxonómiu"
+    taxonomy: Taxonómia
+    taxonomy_edit: Upraviť taxonómiu
     taxonomy_tree_error: Požadovaná zmena nebola akceptovaná a strom bol zmenený do predchádzajúceho stavu, prosím skúste znova.
     taxonomy_tree_instruction: "* Pravým klikom na potomok v strome pristúpite k menu na pridávanie, mazanie a triedenie potomkov."
     taxons: Taxóny
-    test: "Testovať"
+    test: Testovať
     test_mailer:
       test_email:
         greeting: Blahoželáme!
-        message: "Ak ste dostali tento e-mail, potom sú vaše nastavenia e-mailu správne."
-        subject: "Testovací e-mail"
-    test_mode: "Testovcí mód"
-    thank_you_for_your_order: "Ďakujeme za Vašu objednávku. Vytlačte si prosím kópiu tejto stránky ako jej potvrdenie."
-    there_are_no_items_for_this_order: "Pre túto objednávku nejestvujú žiadne položky. Pre pokračovanie prosím pridajte do objednávky nejakú položku."
-    there_were_problems_with_the_following_fields: "Vyskytli sa problémy s nasledujúcimi poliami"
-    this_order_has_already_received_a_refund: "Za túto objednávku už bola vrátená platba"
+        message: Ak ste dostali tento e-mail, potom sú vaše nastavenia e-mailu správne.
+        subject: Testovací e-mail
+    test_mode: Testovcí mód
+    thank_you_for_your_order: Ďakujeme za Vašu objednávku. Vytlačte si prosím kópiu tejto stránky ako jej potvrdenie.
+    there_are_no_items_for_this_order: Pre túto objednávku nejestvujú žiadne položky. Pre pokračovanie prosím pridajte do objednávky nejakú položku.
+    there_were_problems_with_the_following_fields: Vyskytli sa problémy s nasledujúcimi poliami
+    this_order_has_already_received_a_refund: Za túto objednávku už bola vrátená platba
     thumbnail: Miniatúra
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time: "Čas"
-    to: "Do"
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: Čas
+    to: Do
     to_add_variants_you_must_first_define: K pridaniu variánt, najprv musíte určiť
     total: Celkom
-    total_per_item: "Celkom za položku"
-    total_pre_tax_refund:
-    total_price: "Cena spolu"
-    total_sales: "Obrat spolu"
-    track_inventory: "Sledovať zásoby"
+    total_per_item: Celkom za položku
+    total_pre_tax_refund: 
+    total_price: Cena spolu
+    total_sales: Obrat spolu
+    track_inventory: Sledovať zásoby
     tracking: Sledovanie
-    tracking_number: "Číslo pre sledovanie"
-    tracking_url: "URL pre sledovanie"
-    tracking_url_placeholder: "napr. http://quickship.com/package?num=:tracking"
-    transaction_id: "ID transakcie"
-    transfers: "Presuny"
-    transfer_items: "Položky presunov"
-    transfer_from_location: "Presun z"
-    transfer_number: "Číslo presunu"
-    transfer_stock: "Presunúť sklad"
-    transfer_to_location: "Presun do"
+    tracking_number: Číslo pre sledovanie
+    tracking_url: URL pre sledovanie
+    tracking_url_placeholder: napr. http://quickship.com/package?num=:tracking
+    transaction_id: ID transakcie
+    transfer_from_location: Presun z
+    transfer_items: Položky presunov
+    transfer_number: Číslo presunu
+    transfer_stock: Presunúť sklad
+    transfer_to_location: Presun do
+    transfers: Presuny
     tree: Strom
     type: Typ
-    type_to_search:
-    unable_to_connect_to_gateway: "Nie je možné sa spojiť s bránou."
-    unable_to_create_reimbursements: "Nemožno vytvoriť náhradu, pretože jestvujú položky čakajúce na manuálne spracovanie."
+    type_to_search: 
+    unable_to_connect_to_gateway: Nie je možné sa spojiť s bránou.
+    unable_to_create_reimbursements: Nemožno vytvoriť náhradu, pretože jestvujú položky čakajúce na manuálne spracovanie.
     under_price: Menej ako %{price}
-    unlock: "Odomknúť"
+    unlock: Odomknúť
     unrecognized_card_type: Neznámy typ kreditnej karty
-    unshippable_items:
+    unshippable_items: 
     update: Aktualizovať
     updating: Obnovuje sa
     usage_limit: Limit použitia
-    use_app_default: "Použiť predvoľby aplikácie"
+    use_app_default: Použiť predvoľby aplikácie
     use_billing_address: Použiť fakturačnú adresu
-    use_new_cc: "Použiť novú kartu"
-    use_s3: "Použiť Amazon S3 pre obrázky"
+    use_new_cc: Použiť novú kartu
+    use_s3: Použiť Amazon S3 pre obrázky
     user: Používateľ
     user_rule:
-      choose_users:
+      choose_users: 
     users: Používatelia
     validation:
-      cannot_be_less_than_shipped_units: "nemôže byť menej ako počet doručených jednotiek."
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock: "presahuje dostupné zásoby. Uistite sa, že riadkové položky majú platné množstvé."
-      is_too_large: "je príliš veľké -- tovar na sklade nemôže pokryť požadované množstvo!"
-      must_be_int: "musí byť celé číslo"
-      must_be_non_negative: "nesmie byť záporná hodnota"
-      unpaid_amount_not_zero: "Nebola uskutočnená plná náhrada. Zostáva ešte: %{amount}"
+      cannot_be_less_than_shipped_units: nemôže byť menej ako počet doručených jednotiek.
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: presahuje dostupné zásoby. Uistite sa, že riadkové položky majú platné množstvé.
+      is_too_large: je príliš veľké -- tovar na sklade nemôže pokryť požadované množstvo!
+      must_be_int: musí byť celé číslo
+      must_be_non_negative: nesmie byť záporná hodnota
+      unpaid_amount_not_zero: 'Nebola uskutočnená plná náhrada. Zostáva ešte: %{amount}'
     value: Hodnota
     variant: Variant
-    variant_placeholder: "Zvoľte variant"
-    variant_properties: "Vlastnosti variantu"
-    variant_search_placeholder: "SKU alebo hodnota voľby"
-    variant_to_add: "Variant na pridanie"
+    variant_placeholder: Zvoľte variant
+    variant_properties: Vlastnosti variantu
+    variant_search_placeholder: SKU alebo hodnota voľby
+    variant_to_add: Variant na pridanie
     variants: Varianty
     version: Verzia
-    void: "Anulovať"
+    void: Anulovať
     weight: Váha
-    what_is_a_cvv: "Čo je (CVV) kód kreditnej karty?"
-    what_is_this: "Čo to je?"
-    width: "Šírka"
+    what_is_a_cvv: Čo je (CVV) kód kreditnej karty?
+    what_is_this: Čo to je?
+    width: Šírka
     year: Rok
-    you_have_no_orders_yet: "Nemáte zatiaľ žiadnu objednávku"
+    you_have_no_orders_yet: Nemáte zatiaľ žiadnu objednávku
     your_cart_is_empty: Váš košík je prázdny
-    your_order_is_empty_add_product: "Vaša objednávka je prázdna, vyššie vyhľadajte produkt na pridanie"
+    your_order_is_empty_add_product: Vaša objednávka je prázdna, vyššie vyhľadajte produkt na pridanie
     zip: PSČ
-    zipcode:
+    zipcode: 
     zone: Zóna
     zones: Zóny

--- a/config/locales/sl-SI.yml
+++ b/config/locales/sl-SI.yml
@@ -1,409 +1,410 @@
+---
 sl-SI:
   activerecord:
     attributes:
       spree/address:
-        address1:
-        address2:
-        city:
-        country:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        address2: 
+        city: 
+        country: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
-        iso:
-        iso3:
-        iso_name:
-        name:
-        numcode:
+        iso: 
+        iso3: 
+        iso_name: 
+        name: 
+        numcode: 
       spree/credit_card:
-        base:
-        cc_type:
-        month:
-        name:
-        number:
-        verification_value:
-        year:
+        base: 
+        cc_type: 
+        month: 
+        name: 
+        number: 
+        verification_value: 
+        year: 
       spree/inventory_unit:
-        state:
+        state: 
       spree/line_item:
-        price:
-        quantity:
+        price: 
+        quantity: 
       spree/option_type:
-        name:
-        presentation:
+        name: 
+        presentation: 
       spree/order:
-        checkout_complete:
-        completed_at:
-        considered_risky:
-        coupon_code:
-        created_at:
-        email:
-        ip_address:
-        item_total:
-        number:
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
-        total:
+        checkout_complete: 
+        completed_at: 
+        considered_risky: 
+        coupon_code: 
+        created_at: 
+        email: 
+        ip_address: 
+        item_total: 
+        number: 
+        payment_state: 
+        shipment_state: 
+        special_instructions: 
+        state: 
+        total: 
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: 
+        city: 
+        firstname: 
+        lastname: 
+        phone: 
+        state: 
+        zipcode: 
       spree/payment:
-        amount:
+        amount: 
       spree/payment_method:
-        name:
+        name: 
       spree/product:
-        available_on:
-        cost_currency:
-        cost_price:
-        description:
-        master_price:
-        name:
-        on_hand:
-        shipping_category:
-        tax_category:
+        available_on: 
+        cost_currency: 
+        cost_price: 
+        description: 
+        master_price: 
+        name: 
+        on_hand: 
+        shipping_category: 
+        tax_category: 
       spree/promotion:
-        advertise:
-        code:
-        description:
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        advertise: 
+        code: 
+        description: 
+        event_name: 
+        expires_at: 
+        name: 
+        path: 
+        starts_at: 
+        usage_limit: 
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
-        name:
-        presentation:
+        name: 
+        presentation: 
       spree/prototype:
-        name:
+        name: 
       spree/return_authorization:
-        amount:
+        amount: 
       spree/role:
-        name:
+        name: 
       spree/state:
-        abbr:
-        name:
+        abbr: 
+        name: 
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
-        description:
-        name:
+        description: 
+        name: 
       spree/tax_rate:
-        amount:
-        included_in_price:
-        show_rate_in_label:
+        amount: 
+        included_in_price: 
+        show_rate_in_label: 
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: 
+        permalink: 
+        position: 
       spree/taxonomy:
-        name:
+        name: 
       spree/user:
-        email:
-        password:
-        password_confirmation:
+        email: 
+        password: 
+        password_confirmation: 
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_currency: 
+        cost_price: 
+        depth: 
+        height: 
+        price: 
+        sku: 
+        weight: 
+        width: 
       spree/zone:
-        description:
-        name:
+        description: 
+        name: 
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
-      spree/address:
-      spree/country:
-      spree/credit_card:
-      spree/customer_return:
-      spree/inventory_unit:
-      spree/line_item:
-      spree/option_type:
-      spree/option_value:
-      spree/order:
-      spree/payment:
-      spree/payment_method:
-      spree/product:
-      spree/promotion:
-      spree/promotion_category:
-      spree/property:
-      spree/prototype:
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
-      spree/return_authorization:
-      spree/return_authorization_reason:
-      spree/role:
-      spree/shipment:
-      spree/shipping_category:
-      spree/shipping_method:
-      spree/state:
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
-      spree/tax_category:
-      spree/tax_rate:
-      spree/taxon:
-      spree/taxonomy:
-      spree/tracker:
-      spree/user:
-      spree/variant:
-      spree/zone:
+      spree/address: 
+      spree/country: 
+      spree/credit_card: 
+      spree/customer_return: 
+      spree/inventory_unit: 
+      spree/line_item: 
+      spree/option_type: 
+      spree/option_value: 
+      spree/order: 
+      spree/payment: 
+      spree/payment_method: 
+      spree/product: 
+      spree/promotion: 
+      spree/promotion_category: 
+      spree/property: 
+      spree/prototype: 
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
+      spree/return_authorization: 
+      spree/return_authorization_reason: 
+      spree/role: 
+      spree/shipment: 
+      spree/shipping_category: 
+      spree/shipping_method: 
+      spree/state: 
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
+      spree/tax_category: 
+      spree/tax_rate: 
+      spree/taxon: 
+      spree/taxonomy: 
+      spree/tracker: 
+      spree/user: 
+      spree/variant: 
+      spree/zone: 
   spree:
     abbreviation: Okrajšava
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Uporabniški račun
     account_updated: Uporabniški račun osvežen!
     action: Možnosti
     actions:
       cancel: Prekini
-      continue:
+      continue: 
       create: Ustvari
       destroy: Izbriši
-      edit:
+      edit: 
       list: Prikaz
       listing: Prikazujem
       new: Dodaj
-      refund:
-      save:
+      refund: 
+      save: 
       update: Posodobi
     activate: Activate
     active: Objavljeno
     add: Dodaj
     add_action_of_type: Add action of type
     add_country: Dodaj Državo
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: 
     add_option_value: Dodaj izbiro
     add_product: Dodaj izdelek
     add_product_properties: Dodaj lastnosti izdelka
     add_rule_of_type: Dodaj tip pravila
     add_state: Dodaj pokraijno
-    add_stock:
-    add_stock_management:
+    add_stock: 
+    add_stock_management: 
     add_to_cart: Dodaj v košarico
-    add_variant:
+    add_variant: 
     additional_item: Additional Item Cost
-    address1:
-    address2:
-    adjustable:
+    address1: 
+    address2: 
+    adjustable: 
     adjustment: Prilagoditev
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: 
+    adjustment_successfully_closed: 
+    adjustment_successfully_opened: 
     adjustment_total: Prilagoditev Skupaj
     adjustments: Prilagoditve
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Administracija
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: 
+    agree_to_privacy_policy: 
+    agree_to_terms_of_service: 
     all: Vse
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: 
+    all_adjustments_opened: 
     all_departments: Vsi oddelki
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
+    all_items_have_been_returned: 
+    allow_ssl_in_development_and_test: 
+    allow_ssl_in_production: 
+    allow_ssl_in_staging: 
+    already_signed_up_for_analytics: 
     alt_text: Alternativni tekst
     alternative_phone: Drugi telefon
     amount: Znesek
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: 
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 
     analytics_trackers: Statistike
-    and:
-    approve:
-    approved_at:
-    approver:
+    and: 
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Ste prepričani?
     are_you_sure_delete: Ste prepričani, da želite izbrisati ta vnos?
-    associated_adjustment_closed:
-    at_symbol: '@'
+    associated_adjustment_closed: 
+    at_symbol: "@"
     authorization_failure: Napaka pri avtorizaciji
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Na voljo
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Nazaj
     back_end: Nazaj na Konec
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Nazaj v trgovino
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_users_list: 
+    backorderable: 
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Balance Due
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Naslov za Račun
     billing: Račun
     billing_address: Naslov za Račun
     both: Oboje
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Kalkulator
-    calculator_settings_warning: "Če spreminjate tip kalkulatorja, morate pred urejanjem nastavitev najprej shraniti."
+    calculator_settings_warning: Če spreminjate tip kalkulatorja, morate pred urejanjem nastavitev najprej shraniti.
     cancel: prekini
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Ne morem generirati vračil, ker naročilo še ni bilo poslano.
     cannot_perform_operation: Ni mogoče izvesti zahtevane operacije
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: 
     capture: zajemi
-    capture_events:
+    capture_events: 
     card_code: Koda Kartice
-    card_number: "Številka Kartice"
-    card_type:
+    card_number: Številka Kartice
+    card_type: 
     card_type_is: Tip kartice je
     cart: Košarica
-    cart_subtotal:
+    cart_subtotal: 
     categories: Kategorije
     category: Kategorija
-    charged:
-    check_for_spree_alerts:
+    charged: 
+    check_for_spree_alerts: 
     checkout: Naročilo
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: 
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 
+    choose_dashboard_locale: 
+    choose_location: 
     city: Mesto
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Kloniraj
-    close:
-    close_all_adjustments:
+    close: 
+    close_all_adjustments: 
     code: Koda
-    company:
+    company: 
     complete: complete
     configuration: Nastavitev
     configurations: Nastavitve
@@ -412,152 +413,152 @@ sl-SI:
     confirm_password: Potrditev gesla
     continue: Nadaljuj
     continue_shopping: Nadaljuj z nakupovanjem
-    cost_currency:
+    cost_currency: 
     cost_price: Nabavna Cena
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: 
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 
+    countries: 
     country: Država
     country_based: Glede na Države
-    country_name:
+    country_name: 
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Kupon
     coupon_code: Koda kupona
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_already_applied: 
+    coupon_code_applied: 
+    coupon_code_better_exists: 
+    coupon_code_expired: 
+    coupon_code_max_usage: 
+    coupon_code_not_eligible: 
+    coupon_code_not_found: 
+    coupon_code_unknown_error: 
     create: Ustvari
     create_a_new_account: Ustvari nov račun
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: 
+    create_reimbursement: 
+    created_at: 
     credit: Kredit
     credit_card: Kreditna kartica
-    credit_cards:
-    credit_owed:
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credit_cards: 
+    credit_owed: 
+    credits: 
+    currency: 
+    currency_decimal_mark: 
+    currency_settings: 
+    currency_symbol_position: 
+    currency_thousands_separator: 
     current: Trenutno
-    current_promotion_usage:
+    current_promotion_usage: 
     customer: Stranka
     customer_details: Podrobnosti stranke
-    customer_details_updated:
-    customer_return:
-    customer_returns:
+    customer_details_updated: 
+    customer_return: 
+    customer_returns: 
     customer_search: Iskanje strank
-    cut:
-    cvv_response:
+    cut: 
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
-    date_completed:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
+        explanation: 
+        header: 
+        site_id: 
+        token: 
+      jirafe_settings_updated: 
+    date: 
+    date_completed: 
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 
+      format: 
+      js_format: 
     date_range: Obdobje
     default: Privzeto
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default_refund_amount: 
+    default_tax: 
+    default_tax_zone: 
     delete: Izbriši
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Delivery
     depth: Globina
     description: Opis
-    destination:
+    destination: 
     destroy: Izbriši
-    details:
+    details: 
     discount_amount: Znesek popusta
-    dismiss_banner:
+    dismiss_banner: 
     display: Prikaži
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: 
     edit: Uredi
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Urejanje uporabnika
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
+    email: 
     empty: Izprazni
     empty_cart: Izprazni košarico
     enable_mail_delivery: Vklopi pošiljanje emailov
-    end:
-    ending_in:
+    end: 
+    ending_in: 
     environment: Okolje
     error: napaka
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available:
-        no_shipping_methods_available:
-    errors_prohibited_this_record_from_being_saved:
+        could_not_create_taxon: 
+        no_payment_methods_available: 
+        no_shipping_methods_available: 
+    errors_prohibited_this_record_from_being_saved: 
     event: Dogodek
     events:
       spree:
         cart:
-          add:
+          add: 
         checkout:
-          coupon_code_added:
+          coupon_code_added: 
         content:
-          visited:
+          visited: 
         order:
-          contents_changed:
-        page_view:
+          contents_changed: 
+        page_view: 
         user:
-          signup:
+          signup: 
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: 
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Velja do
     extension: Razširitev
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Datoteka
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: 
+    filter_results: 
     finalize: Zaključi
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: Strošek prvega izdelka
     first_name: Ime
     first_name_begins_with: Ime se začne z
@@ -566,7 +567,7 @@ sl-SI:
     flexible_rate: Fleksibilna cena
     forgot_password: Ne spomnim se gesla
     free_shipping: Brezplačna dostava
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Front End
     gateway: Ponudnik
     gateway_config_unavailable: Gateway unavailable for environment
@@ -579,43 +580,43 @@ sl-SI:
     guest_user_account: Naroči kot gost
     has_no_shipped_units: nima prodajnih enot
     height: Višina
-    hide_cents:
+    hide_cents: 
     home: Domov
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: Slovenščina (SL)
     icon: Ikona
-    identifier:
+    identifier: 
     image: Slika
     images: Slike
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: 
+    included_price_validation: 
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: 'Izpolnite spodnji obrazec in navodila za ponastavitev gesla vam bomo poslali na email:'
-    insufficient_stock:
-    insufficient_stock_lines_present:
+    insufficient_stock: 
+    insufficient_stock_lines_present: 
     intercept_email_address: Prestrezi Email naslov
     intercept_email_instructions: Zamenjaj prejemnika email sporočila s tem naslovom
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 
+    invalid_promotion_action: 
+    invalid_promotion_rule: 
     inventory: Inventar
     inventory_adjustment: Prilagoditev inventarja
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: 
+    inventory_state: 
     is_not_available_to_shipment_address: ni na voljo za ta naslov pošiljanja
-    iso_name:
+    iso_name: 
     item: Izdelek
     item_description: Opis izdelka
     item_total: Izdelki skupaj
@@ -623,26 +624,26 @@ sl-SI:
       operators:
         gt: večje
         gte: večje ali enako
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
+    jirafe: 
     landing_page_rule:
-      path:
+      path: 
     last_name: Priimek
     last_name_begins_with: Priimek se začne z
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Seznam
     loading: Nalagam
     locale_changed: Locale Changed
-    location:
-    lock:
-    log_entries:
+    location: 
+    lock: 
+    log_entries: 
     logged_in_as: Prijavljeni ste kot
     logged_in_succesfully: Prijava uspešna
     logged_out: Uspešno ste se odjavili.
@@ -651,38 +652,38 @@ sl-SI:
     login_failed: Prijava ni uspela.
     login_name: Uporabniško ime
     logout: Odjava
-    logs:
+    logs: 
     look_for_similar_items: Poišči podobne izdelke
-    make_refund:
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_refund: 
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Osnovna cena
     match_choices:
       all: All
       none: None
     max_items: Max Izdelkov
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Meta opis
     meta_keywords: Meta ključne besede
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Minimalni znesek
     month: Mesec
     more: More
-    move_stock_between_locations:
+    move_stock_between_locations: 
     my_account: Moj račun
     my_orders: Moja naročila
     name: Ime
-    name_on_card:
+    name_on_card: 
     name_or_sku: Ime ali šifra
     new: Novo
     new_adjustment: Nova prilagoditev
-    new_country:
+    new_country: 
     new_customer: Nova stranka
-    new_customer_return:
+    new_customer_return: 
     new_image: Dodaj sliko
     new_option_type: Nova možnost izbire
     new_order: Novo naročilo
@@ -691,20 +692,20 @@ sl-SI:
     new_payment_method: Nov način plačila
     new_product: Dodaj Izdelek
     new_promotion: Dodaj promocijo
-    new_promotion_category:
+    new_promotion_category: 
     new_property: Dodaj lastnost
     new_prototype: Dodaj prototip
-    new_refund:
-    new_refund_reason:
+    new_refund: 
+    new_refund_reason: 
     new_return_authorization: Nova avtorizacija vračila
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Dodaj kategorijo poštnine
     new_shipping_method: Dodaj tip dostave
     new_state: Nova Zvezna Država
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: 
+    new_stock_movement: 
+    new_stock_transfer: 
     new_tax_category: Dodaj davčno stopnjo
     new_tax_rate: Dodaj davčno stopnjo
     new_taxon: Dodaj takson
@@ -714,25 +715,25 @@ sl-SI:
     new_variant: Dodaj varianto
     new_zone: Dodaj območje
     next: Naprej
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: 
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: Ni izdelkov
-    no_resource_found:
+    no_resource_found: 
     no_results: Ni zadetkov
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: Ni dodanih pravil
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
     none: Noben
-    none_selected:
+    none_selected: 
     normal_amount: Normalna količina
     not: ne
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: 
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
       product_cloned: Izdelek je bil podvojen
       product_deleted: Izdelek je bil izbrisan
@@ -740,55 +741,55 @@ sl-SI:
       product_not_deleted: Izdelka ni mogoče izbrisati
       variant_deleted: Varianta je bila izbrisana
       variant_not_deleted: Variante ni mogoče izbrisati
-    num_orders:
+    num_orders: 
     on_hand: Na zalogi
-    open:
-    open_all_adjustments:
+    open: 
+    open_all_adjustments: 
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Možnosti izbire
     option_value: Option Value
     option_values: Izbire
-    optional:
+    optional: 
     options: Možnosti
     or: ali
     or_over_price: "%{price} or over"
     order: Naročilo
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_adjustments: 
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Podrobnosti naročila
     order_email_resent: Email z naročilom je bil ponovno poslan.
-    order_information:
+    order_information: 
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: 
+        instructions: 
+        order_summary_canceled: 
+        subject: 
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: 
+        instructions: 
+        order_summary: 
+        subject: 
+        subtotal: 
+        thanks: 
+        total: 
+    order_not_found: 
+    order_number: 
     order_processed_successfully: Vaše naročilo je bilo uspešno obdelano
-    order_resumed:
+    order_resumed: 
     order_state:
       address: naslov
-      awaiting_return: "čakajo na vrnitev"
+      awaiting_return: čakajo na vrnitev
       canceled: preklicana
       cart: košarica
       complete: končaj
       confirm: potrdi
-      considered_risky:
+      considered_risky: 
       delivery: dostava
       payment: plačilo
       resumed: resumed
@@ -798,92 +799,92 @@ sl-SI:
     order_total: Naročilo skupaj
     order_updated: Naročilo osveženo
     orders: Naročila
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Ni na zalogi
     overview: Pregled
-    package_from:
+    package_from: 
     pagination:
-      next_page:
-      previous_page:
+      next_page: 
+      previous_page: 
       truncate: "…"
     password: Geslo
     paste: Paste
     path: Pot
     pay: plačaj
     payment: Plačilo
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Podatki o plačilu
     payment_method: Način plačila
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Načini plačila
     payment_processing_failed: Plačila ni možno izvesti, prosimo preverite vnešene podatke
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
+    payment_processor_choose_banner_text: 
+    payment_processor_choose_link: 
     payment_state: Stanje plačila
     payment_states:
-      balance_due:
-      checkout:
-      completed:
-      credit_owed:
-      failed:
+      balance_due: 
+      checkout: 
+      completed: 
+      credit_owed: 
+      failed: 
       paid: plačano
-      pending:
-      processing:
-      void:
+      pending: 
+      processing: 
+      void: 
     payment_updated: Plačilo osveženo
     payments: Plačila
-    pending:
-    percent:
-    percent_per_item:
+    pending: 
+    percent: 
+    percent_per_item: 
     permalink: Povezava
     phone: Telefon
     place_order: Oddaj naročilo
-    please_define_payment_methods:
-    populate_get_error:
+    please_define_payment_methods: 
+    populate_get_error: 
     powered_by: Poganja
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Prikazano ime
     previous: Nazaj
-    previous_state_missing:
+    previous_state_missing: 
     price: Cena
-    price_range:
-    price_sack:
+    price_range: 
+    price_sack: 
     process: Procesiraj
     product: Izdelek
     product_details: Podrobnosti izdelka
     product_has_no_description: Izdelek nima opisa
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: 
     product_properties: Lastnosti izdelka
     product_rule:
       choose_products: Izberite izdelke
-      label:
+      label: 
       match_all: vse
       match_any: vsaj en
-      match_none:
+      match_none: 
       product_source:
         group: Iz skupine izdelkov
         manual: Ročno izberi
     products: Izdelki
-    promotion:
-    promotion_action:
+    promotion: 
+    promotion_action: 
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: 
+        name: 
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: 
+        name: 
+    promotion_actions: 
     promotion_form:
       match_policies:
         all: Ujemaj se s katerim koli izmed teh pravil
@@ -900,77 +901,77 @@ sl-SI:
         description: Customer must have visited the specified page
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Naročilo vsebuje določene izdelke
         name: Izdelek(i)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Na vojo samo za določene uporabnike
         name: Uporabnik
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
+        description: 
+        name: 
+    promotion_uses: 
+    promotionable: 
     promotions: Promocije
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Lastnosti
     property: Lastnost
     prototype: Prototip
     prototypes: Prototipi
     provider: Ponudnik
-    provider_settings_warning: "Če spreminjate tip ponudnika, morate najprej shraniti predno lahko urejate nastavitve ponudnika"
+    provider_settings_warning: Če spreminjate tip ponudnika, morate najprej shraniti predno lahko urejate nastavitve ponudnika
     qty: Količina
-    quantity:
+    quantity: 
     quantity_returned: Quantity Returned
     quantity_shipped: Poslana količina
-    quick_search:
+    quick_search: 
     rate: Stopnja
     reason: Razlog
     receive: prejmi
-    receive_stock:
+    receive_stock: 
     received: Prejeto
-    reception_status:
-    reference:
+    reception_status: 
+    reference: 
     refund: Povračilo
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Registriraj se kot nov uporabnik
     registration: Registracija
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Zapomni si me
     remove: Odstrani
-    rename:
-    report:
+    rename: 
+    report: 
     reports: Poročila
     resend: Pošlji ponovno
     reset_password: Ponastavi moje geslo
@@ -979,36 +980,36 @@ sl-SI:
     resumed: Nadaljevana
     return: vračilo
     return_authorization: Avtorizacija vračila
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Avtorizacija vračila spremenjena
     return_authorizations: Avtorizacije vračil
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Količina za vračilo
     returned: Vrnjeno
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
+    returns: 
+    review: 
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA kredit
     rma_number: RMA šifra
     rma_value: RMA vrednost
     roles: Vloge
-    rules:
-    safe:
+    rules: 
+    safe: 
     sales_total: Skupaj
     sales_total_description: Sales Total For All Orders
-    sales_totals:
+    sales_totals: 
     save_and_continue: Shrani in nadaljuj
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: 
+    say_no: 
+    say_yes: 
     scope: Pravilo
     search: Najdi
     search_results: Iskalni razultati za '%{keywords}'
@@ -1016,10 +1017,10 @@ sl-SI:
     secure_connection_type: Tip varne povezave
     security_settings: Security Settings
     select: Izberi
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Izberi iz prototipa
-    select_stock:
+    select_stock: 
     send_copy_of_all_mails_to: Pošlji kopijo vseh emailov na
     send_mails_as: Pošiljatelj izhodnih emailov
     server: Strežnik
@@ -1027,10 +1028,10 @@ sl-SI:
     settings: Nastavitve
     ship: pošlji
     ship_address: Naslov za dostavo
-    ship_total:
+    ship_total: 
     shipment: Pošiljka
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1039,126 +1040,126 @@ sl-SI:
         subject: Shipment Notification
         thanks: Thank you for your business.
         track_information: 'Tracking Information: %{tracking}'
-        track_link:
+        track_link: 
     shipment_state: Stanje pošiljke
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: 
       partial: delno
       pending: v teku
       ready: pripravljeno
       shipped: poslano
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Pošiljke
     shipped: Poslano
     shipping: Poštnina
     shipping_address: Naslov za dostavo
     shipping_categories: Kategorije poštnine
     shipping_category: Kategorija poštnine
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: 
+    shipping_flat_rate_per_order: 
+    shipping_flexible_rate: 
     shipping_instructions: Navodila za dostavo
     shipping_method: Način dostave
     shipping_methods: Načini dostave
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: 
+    shipping_total: 
     shop_by_taxonomy: Preglej %{taxonomy}
     shopping_cart: Nakupovalna košarica
     show: Prikaži
     show_active: Prikaži objavljene
     show_deleted: Prikaži izbrisane
     show_only_complete_orders: Prikaži le dokončana naročila
-    show_only_considered_risky:
-    show_rate_in_label:
-    sku: "šifra"
-    skus:
-    slug:
-    source:
+    show_only_considered_risky: 
+    show_rate_in_label: 
+    sku: šifra
+    skus: 
+    slug: 
+    source: 
     special_instructions: Special Instructions
-    split:
+    split: 
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Od
     state: Pokrajina
     state_based: Na osnovi pokrajin
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Pokrajine
-    states_required:
+    states_required: 
     status: Status
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: 
+    stock_location: 
+    stock_location_info: 
+    stock_locations: 
+    stock_locations_need_a_default_country: 
+    stock_management: 
+    stock_management_requires_a_stock_location: 
+    stock_movements: 
+    stock_movements_for_stock_location: 
+    stock_successfully_transferred: 
+    stock_transfer: 
+    stock_transfers: 
     stop: Do
     store: Trgovina
     street_address: Ulica in hišna številka
     street_address_2: Ulica dodatno
     subtotal: Skupaj
     subtract: Odštej
-    success:
+    success: 
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} has been successfully removed!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: 
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: 
     tax: DDV
     tax_categories: Davčne kategorije
     tax_category: Davčna kategorija
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
     tax_rates: Davčne stopnje
     taxon: Takson
     taxon_edit: Uredi takson
-    taxon_placeholder:
+    taxon_placeholder: 
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taksonomije
     taxonomy: Taxonomy
     taxonomy_edit: Uredi taksonomijo
@@ -1173,42 +1174,42 @@ sl-SI:
         subject: Testmail
     test_mode: Testni način
     thank_you_for_your_order: Hvala za zaupanje. Prosimo natisnite si kopijo te potrditvene strani za lastno referenco.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Mala slika
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: 
     to_add_variants_you_must_first_define: Za dodajanje variant, morate najprej definirati
     total: Skupaj
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Sledenje
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
     tree: Drevo
     type: Tip
     type_to_search: Vrsta iskanja
     unable_to_connect_to_gateway: Povezava do ponudnika plačilnih storitev ni uspela
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
-    unlock:
+    unlock: 
     unrecognized_card_type: Neznan tip kartice
-    unshippable_items:
+    unshippable_items: 
     update: Spremeni
     updating: Osvežujem
     usage_limit: Omejitev uporabe
-    use_app_default:
+    use_app_default: 
     use_billing_address: Uporabi naslov za račun
     use_new_cc: Uporabi drugo kreditno karico
     use_s3: Use Amazon S3 For Images
@@ -1218,27 +1219,27 @@ sl-SI:
     users: Uporabniki
     validation:
       cannot_be_less_than_shipped_units: ne more biti manjše od števila prodanih enot.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 
       is_too_large: je prevelika -- na zalogi ni dovolj naročenih izdelkov!
       must_be_int: mora biti celo število
       must_be_non_negative: mora biti pozitivna vrednost
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Vrednost
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: 
     variants: Variante
     version: Verzija
     void: Neveljaven
     weight: Teža
     what_is_a_cvv: Kaj je CVV varnostna številka kreditne kartice?
     what_is_this: Kaj je to?
-    width: "Širina"
+    width: Širina
     year: Leto
     you_have_no_orders_yet: You have no orders yet.
     your_cart_is_empty: Vaša nakupovalna košarica je prazna
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: 
     zip: Poštna številka
-    zipcode:
+    zipcode: 
     zone: Območje
     zones: Območja

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,3 +1,4 @@
+---
 sv:
   activerecord:
     attributes:
@@ -24,13 +25,13 @@ sv:
         name: Namn
         numcode: ISO-kod
       spree/credit_card:
-        base:
+        base: 
         cc_type: Typ
         month: Månad
         name: Namn
         number: Nummer
         verification_value: Verifikationvärde
-        year: "År"
+        year: År
       spree/inventory_unit:
         state: Status
       spree/line_item:
@@ -170,7 +171,7 @@ sv:
         spree/classification:
           attributes:
             taxon_id:
-              already_linked: "är redan länkad till denna produkt"
+              already_linked: är redan länkad till denna produkt
         spree/credit_card:
           attributes:
             base:
@@ -183,7 +184,7 @@ sv:
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed: "är större än tillåten mängd."
+              greater_than_allowed: är större än tillåten mängd.
         spree/reimbursement:
           attributes:
             base:
@@ -248,8 +249,8 @@ sv:
         one: Prototype
         other: Prototyper
       spree/refund_reason:
-        one: "Återbetalning skäl"
-        other: "Återbetalning skäl"
+        one: Återbetalning skäl
+        other: Återbetalning skäl
       spree/reimbursement:
         one: Ersättning
         other: Ersättningar
@@ -283,7 +284,7 @@ sv:
       spree/stock_location:
         one: Leverans plats
         other: Leverans platser
-      spree/stock_movement:
+      spree/stock_movement: 
       spree/stock_transfer:
         one: Lageröverföring
         other: Lageröverföringar
@@ -319,7 +320,7 @@ sv:
     accepted: Godkänd
     account: Konto
     account_updated: Konto uppdaterat
-    action: "Åtgärd"
+    action: Åtgärd
     actions:
       cancel: Avbryt
       continue: Fortsätt
@@ -329,7 +330,7 @@ sv:
       list: Lista
       listing: Lista
       new: Ny
-      refund: "Återbetalning"
+      refund: Återbetalning
       save: Spara
       update: Uppdatera
     activate: Aktivera
@@ -356,19 +357,19 @@ sv:
     adjustable: Justerbar
     adjustment: Justering
     adjustment_amount: Belopp
-    adjustment_successfully_closed: "Ändring är framgångsrikt stängd!"
-    adjustment_successfully_opened: "Ändring är framgångsrikt öppnad!"
+    adjustment_successfully_closed: Ändring är framgångsrikt stängd!
+    adjustment_successfully_opened: Ändring är framgångsrikt öppnad!
     adjustment_total: Summa justeringar
-    adjustments: "Ändringar"
+    adjustments: Ändringar
     admin:
       tab:
         configuration: Konfiguration
         option_types: Tillvalstyper
         orders: Beställningar
-        overview: "Översikt"
+        overview: Översikt
         products: Produkter
-        promotions: Kampanjer
         promotion_categories: Kampanjkategorier
+        promotions: Kampanjer
         properties: Egenskaper
         prototypes: Prototyper
         reports: Rapporter
@@ -411,10 +412,10 @@ sv:
     approve: godkänn
     approved_at: Datum godkänt
     approver: Attestant
-    are_you_sure: "Är du säker?"
-    are_you_sure_delete: "Är du säker på att du vill ta bort denna post?"
+    are_you_sure: Är du säker?
+    are_you_sure_delete: Är du säker på att du vill ta bort denna post?
     associated_adjustment_closed: Den tillhörande justeringen är stängd, och blir inte omräknad. Vill du öppna den?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Auktorisationen misslyckades
     authorized: Auktoriserad
     auto_capture: Auto-capture
@@ -429,8 +430,8 @@ sv:
     back_to_store: Tillbaka till butiken
     back_to_users_list: Tillbaka till användarlistan
     backorderable: Möjligt att förhandsbeställa
-    backorderable_default:
-    backordered:
+    backorderable_default: 
+    backordered: 
     backorders_allowed: förhandsbeställning tillåtet
     balance_due: Summa att betala
     base_amount: Basbelopp
@@ -451,7 +452,7 @@ sv:
     cannot_perform_operation: Kan inte utföra efterfrågad aktivitet
     cannot_set_shipping_method_without_address: Kan inte använda fraktmetod förrän kunddetaljerna är angivna
     capture: Fånga
-    capture_events:
+    capture_events: 
     card_code: Säkerhetskod
     card_number: Kortnummer
     card_type: Varumärke
@@ -556,7 +557,7 @@ sv:
       js_format: yy/mm/dd
     date_range: Datumintervall
     default: Förvald
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Förvald moms
     default_tax_zone: Förvald moms-zon
     delete: Ta bort
@@ -622,11 +623,13 @@ sv:
         user:
           signup: Användarregistrering
     exceptions:
-      count_on_hand_setter: Kan inte sätta tillgängligt manuellt eftersom det ställs in automatisk av recalculate_count_on_hand callback. Använd istället 'update_column(:count_on_hand, value)'
-    exchange_for:
+      count_on_hand_setter: >-
+        Kan inte sätta tillgängligt manuellt eftersom det ställs in automatisk av recalculate_count_on_hand callback. Använd istället 'update_column(:count_on_hand,
+        value)'
+    exchange_for: 
     excl: exkl.
     existing_shipments: Existerande leveranser
-    expedited_exchanges_warning:
+    expedited_exchanges_warning: 
     expiration: Upphörande
     extension: Utökning
     failed_payment_attempts: Misslyckade betalningsförsök
@@ -696,7 +699,7 @@ sv:
     inventory_adjustment: Inventariejustering
     inventory_error_flash_for_insufficient_quantity: En artikel i din varukorg är inte längre tillgänglig.
     inventory_state: Lagerstatus
-    is_not_available_to_shipment_address: "är inte tillgänglig till fraktadress"
+    is_not_available_to_shipment_address: är inte tillgänglig till fraktadress
     iso_name: Iso namn
     item: Artikel
     item_description: Artikelbeskrivning
@@ -708,9 +711,9 @@ sv:
         lt: mindre än
         lte: mindre än eller lika med
     items_cannot_be_shipped: Vi kan inte skicka till den angivna adressen. Var vänlig välj en annan adress.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Sökväg
@@ -718,7 +721,7 @@ sv:
     last_name_begins_with: Efternamn börjar med
     learn_more: Mer info
     lifetime_stats: Livstids statistik
-    line_item_adjustments:
+    line_item_adjustments: 
     list: Lista
     loading: Laddar
     locale_changed: Språket har ändrats
@@ -736,10 +739,10 @@ sv:
     logs: Loggar
     look_for_similar_items: Visa liknande artiklar
     make_refund: Gör återbetalning
-    make_sure_the_above_reimbursement_amount_is_correct:
+    make_sure_the_above_reimbursement_amount_is_correct: 
     manage_promotion_categories: Hantera kampanjkategorier
     manage_variants: Hantera varianter
-    manual_intervention_required:
+    manual_intervention_required: 
     master_price: Grundpris
     match_choices:
       all: Alla
@@ -824,8 +827,8 @@ sv:
       variant_not_deleted: Varianten kunde inte tas bort
     num_orders: "# Beställningar"
     on_hand: Tillgängligt
-    open: "Öppen"
-    open_all_adjustments: "Öppna alla ändringar"
+    open: Öppen
+    open_all_adjustments: Öppna alla ändringar
     option_type: Alternativtyp
     option_type_placeholder: Välj typ av alternativ
     option_types: Alternativtyper
@@ -876,13 +879,13 @@ sv:
       resumed: fortsatt
       returned: returnerad
     order_summary: Ordersammanfattning
-    order_sure_want_to: "Är du säker på att du vill %{event} denna order?"
+    order_sure_want_to: Är du säker på att du vill %{event} denna order?
     order_total: Summa att betala
     order_updated: Order uppdaterad
     orders: Ordrar
     other_items_in_other: Andra artiklar i beställningen
     out_of_stock: Ej i lager
-    overview: "Översikt"
+    overview: Översikt
     package_from: paket från
     pagination:
       next_page: nästa sida »
@@ -924,13 +927,13 @@ sv:
     please_define_payment_methods: Definiera först någon betalningsmetod
     populate_get_error: Något gick fel. Försök att lägga till artikeln igen.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type: "Önskad ersättningstyp"
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: Önskad ersättningstyp
     presentation: Presentation
     previous: Föregående
-    previous_state_missing:
+    previous_state_missing: 
     price: Pris
     price_range: Prisintervall
     price_sack: Prisgräns
@@ -957,8 +960,8 @@ sv:
         description: Skapa en justerad kampanjkredit på ordern
         name: Skapa ändring
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Fyll varukorgen med det angivna antalet av variant
         name: Skapa radartiklar
@@ -999,10 +1002,10 @@ sv:
       user_logged_in:
         description: Tillgänglig endast för inloggade användare
         name: Användare inloggad
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Kampanjer
-    propagate_all_variants:
+    propagate_all_variants: 
     properties: Egenskaper
     property: Egenskap
     prototype: Prototyp
@@ -1019,32 +1022,32 @@ sv:
     receive: ta emot
     receive_stock: Motta lager
     received: Mottaget
-    reception_status:
+    reception_status: 
     reference: Referens
-    refund: "Återbetala"
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons: "Återbetalning anledning"
-    refunded_amount: "Återbetalningsbelopp"
-    refunds: "Återbetalning"
+    refund: Återbetala
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: Återbetalning anledning
+    refunded_amount: Återbetalningsbelopp
+    refunds: Återbetalning
     register: Registrera dig
     registration: Registrering
     reimburse: Ersätta
-    reimbursed:
+    reimbursed: 
     reimbursement: Ersättning
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
+        days_to_send: 
         dear_customer: Kära kund,\n
-        exchange_summary:
+        exchange_summary: 
         for: för
         instructions: Din ersättning har behandlats.
-        refund_summary: "Återbetalnings sammanfattning"
+        refund_summary: Återbetalnings sammanfattning
         subject: Ersättnings notifiering
-        total_refunded:
-    reimbursement_perform_failed:
+        total_refunded: 
+    reimbursement_perform_failed: 
     reimbursement_status: Ersättningsstatus
     reimbursement_type: Ersättningstyp
-    reimbursement_type_override:
+    reimbursement_type_override: 
     reimbursement_types: Ersättningstyper
     reimbursements: Ersättningar
     reject: Avvisa
@@ -1055,21 +1058,21 @@ sv:
     report: Rapport
     reports: Rapporter
     resend: Skicka igen
-    reset_password: "Återställ mitt lösenord"
+    reset_password: Återställ mitt lösenord
     response_code: Svarskod
-    resume: "återuppta"
-    resumed: "Återupptagen"
+    resume: återuppta
+    resumed: Återupptagen
     return: returera
     return_authorization: Returauktorisation
-    return_authorization_reasons:
+    return_authorization_reasons: 
     return_authorization_updated: Returauktorisation uppdaterad
     return_authorizations: Returauktorisation
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
     return_items: Retur artklar
-    return_items_cannot_be_associated_with_multiple_orders:
+    return_items_cannot_be_associated_with_multiple_orders: 
     return_number: Returnummer
     return_quantity: Returantal
     returned: Returnerad
@@ -1098,7 +1101,7 @@ sv:
     secure_connection_type: Säker anslutningstyp
     security_settings: Säkerhetsinställningar
     select: Välj
-    select_a_return_authorization_reason:
+    select_a_return_authorization_reason: 
     select_a_stock_location: Välj lager pats
     select_from_prototype: Välj från prototyp
     select_stock: Välj lager
@@ -1172,7 +1175,7 @@ sv:
       authorized: Auktoriserad
       awaiting: Inväntar
       awaiting_return: Inväntar retur
-      backordered:
+      backordered: 
       canceled: Avbruten
       cart: Kundvagn
       checkout: Kassan
@@ -1183,18 +1186,18 @@ sv:
       delivery: Leverans
       errored: Fel uppstod
       failed: Misslyckades
-      given_to_customer:
+      given_to_customer: 
       invalid: Ogiltigt
-      manual_intervention_required:
+      manual_intervention_required: 
       on_hand: I lager
-      open: "Öppen"
+      open: Öppen
       order: Beställning
       payment: Betalning
       pending: Avvaktande
       processing: Under bearbetning
       ready: Klar
-      reimbursed: "Återbetald"
-      resumed: "Återupptagen"
+      reimbursed: Återbetald
+      resumed: Återupptagen
       returned: Returnerad
       shipped: Skickad
       void: Void
@@ -1238,13 +1241,13 @@ sv:
     taxon_placeholder: Lägg till klass
     taxon_rule:
       choose_taxons: Välj grupp
-      label:
+      label: 
       match_all: alla
       match_any: minst en
     taxonomies: Klassificeringar
     taxonomy: Klassificering
-    taxonomy_edit: "Ändra Klassificering"
-    taxonomy_tree_error: "Ändringen har inte accepterats och trädet har återställts till sitt tidigare tillstånd. Var god försök igen."
+    taxonomy_edit: Ändra Klassificering
+    taxonomy_tree_error: Ändringen har inte accepterats och trädet har återställts till sitt tidigare tillstånd. Var god försök igen.
     taxonomy_tree_instruction: "* Högerklicka på en kategori för att komma åt menyn för att lägga till, ta bort eller sortera klasser."
     taxons: Klasser
     test: Test
@@ -1257,16 +1260,16 @@ sv:
     thank_you_for_your_order: Tack för ditt köp. Var god skriv ut denna sida för framtida korrespondens.
     there_are_no_items_for_this_order: Det finns inga produkter för denna order. Lägg till en produkt för att fortsätta.
     there_were_problems_with_the_following_fields: Det var problem med följande fält
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: 
     thumbnail: Tumnagelbild
-    tiered_flat_rate:
-    tiered_percent:
+    tiered_flat_rate: 
+    tiered_percent: 
     tiers: Nivåer
     time: Tid
     to_add_variants_you_must_first_define: För att lägga till varianter måste du först definiera
     total: Totalt
     total_per_item: Totalt per artikel
-    total_pre_tax_refund:
+    total_pre_tax_refund: 
     total_price: Total pris
     total_sales: Total försäljning
     track_inventory: Spåra inventering
@@ -1275,9 +1278,9 @@ sv:
     tracking_url: Spårnings URL
     tracking_url_placeholder: ex. http://quickship.com/package?num=:tracking
     transaction_id: Transaktions ID
-    transfer_from_location: "Överflyttning från"
-    transfer_stock: "Överflyttning lager"
-    transfer_to_location: "Överflyttning till"
+    transfer_from_location: Överflyttning från
+    transfer_stock: Överflyttning lager
+    transfer_to_location: Överflyttning till
     tree: Träd
     type: Typ
     type_to_search: Skriv för sökning
@@ -1300,9 +1303,9 @@ sv:
     users: Användare
     validation:
       cannot_be_less_than_shipped_units: får inte vara mindre än antalet levererade enheter.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock: "Överstiger tillgängligt lager. Var säker på att radartikeln har ett giltigt antal."
-      is_too_large: "är för stor – vi har inte så mycket i lager!"
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: Överstiger tillgängligt lager. Var säker på att radartikeln har ett giltigt antal.
+      is_too_large: är för stor – vi har inte så mycket i lager!
       must_be_int: måste vara ett heltal
       must_be_non_negative: måste vara ett positivt tal
       unpaid_amount_not_zero: 'Beloppet har inte ersatts till fullo. Kvarstår: %{amount}'
@@ -1316,7 +1319,7 @@ sv:
     what_is_a_cvv: Vad är en säkerthetskod (CVV)?
     what_is_this: Vad är det här?
     width: Bredd
-    year: "År"
+    year: År
     you_have_no_orders_yet: Du har inga order än.
     your_cart_is_empty: Varukorgen är tom
     your_order_is_empty_add_product: Din order är tom, sök och lägg till produkten ovan

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1,1286 +1,1289 @@
+---
 th:
   activerecord:
     attributes:
       spree/address:
-        address1: "ที่อยู่"
-        address2: "ที่อยู่ 2"
-        city: "ตำบล"
-        country: "ประเทศ"
-        firstname: "ชื่อ"
-        lastname: "นามสกุล"
-        phone: "เบอร์โทรศัพท์"
-        state: "จังหวัด"
-        zipcode: "รหัสไปรษณีย์"
+        address1: ที่อยู่
+        address2: ที่อยู่ 2
+        city: ตำบล
+        country: ประเทศ
+        firstname: ชื่อ
+        lastname: นามสกุล
+        phone: เบอร์โทรศัพท์
+        state: จังหวัด
+        zipcode: รหัสไปรษณีย์
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
         iso_name: ISO Name
-        name: "ชื่อประเทศ"
+        name: ชื่อประเทศ
         numcode: ISO Code
       spree/credit_card:
-        base:
-        cc_type: "ประเภท"
-        month: "เดือน"
-        name:
-        number: "เลขที่บัตร"
-        verification_value: "เลขยืนยัน"
-        year: "ปี"
+        base: 
+        cc_type: ประเภท
+        month: เดือน
+        name: 
+        number: เลขที่บัตร
+        verification_value: เลขยืนยัน
+        year: ปี
       spree/inventory_unit:
-        state: "จังหวัด"
+        state: จังหวัด
       spree/line_item:
-        price: "ราคา"
-        quantity: "จำนวน"
+        price: ราคา
+        quantity: จำนวน
       spree/option_type:
-        name: "ชื่อเรียก"
-        presentation: "การแสดงผล"
+        name: ชื่อเรียก
+        presentation: การแสดงผล
       spree/order:
-        checkout_complete: "เช็คเอ้าท์เรียบร้อย"
-        completed_at: "รายการสมบูรณ์เมื่อ"
-        considered_risky:
-        coupon_code: "เลขคูปอง"
-        created_at: "วันที่สั่งสินค้า"
-        email: "อีเมลของลูกค้า"
-        ip_address: "หลายเลขไอพี"
-        item_total: "รวม"
-        number: "หมายเลข"
-        payment_state: "จังหวัด"
-        shipment_state: "จังหวัด"
-        special_instructions: "ข้อแนะนำเพิ่มเติม"
-        state: "จังหวัด"
-        total: "รวม"
+        checkout_complete: เช็คเอ้าท์เรียบร้อย
+        completed_at: รายการสมบูรณ์เมื่อ
+        considered_risky: 
+        coupon_code: เลขคูปอง
+        created_at: วันที่สั่งสินค้า
+        email: อีเมลของลูกค้า
+        ip_address: หลายเลขไอพี
+        item_total: รวม
+        number: หมายเลข
+        payment_state: จังหวัด
+        shipment_state: จังหวัด
+        special_instructions: ข้อแนะนำเพิ่มเติม
+        state: จังหวัด
+        total: รวม
       spree/order/bill_address:
-        address1: "ชื่อถนนในใบเสร็จ"
-        city: "ชื่อตำบลในใบเสร็จ"
-        firstname: "ชื่อในใบเสร็จ"
-        lastname: "นามสกุลในใบเสร็จ"
-        phone: "เบอร์โทรศัพท์ในใบเสร็จ"
-        state: "ชื่อจังหวัดในใบเสร็จ"
-        zipcode: "รหัสไปรษณีย์ในใบเสร็จ"
+        address1: ชื่อถนนในใบเสร็จ
+        city: ชื่อตำบลในใบเสร็จ
+        firstname: ชื่อในใบเสร็จ
+        lastname: นามสกุลในใบเสร็จ
+        phone: เบอร์โทรศัพท์ในใบเสร็จ
+        state: ชื่อจังหวัดในใบเสร็จ
+        zipcode: รหัสไปรษณีย์ในใบเสร็จ
       spree/order/ship_address:
-        address1: "ถนนที่จัดส่ง"
-        city: "จังหวัดที่จัดส่ง"
-        firstname: "ชื่อผู้รับ"
-        lastname: "นามสกุลผู้รับ"
-        phone: "เบอร์โทรศัพท์ผู้รับ"
-        state: "จังหวัดที่จัดส่ง"
-        zipcode: "รหัสไปรษณีย์ผู้รับ"
+        address1: ถนนที่จัดส่ง
+        city: จังหวัดที่จัดส่ง
+        firstname: ชื่อผู้รับ
+        lastname: นามสกุลผู้รับ
+        phone: เบอร์โทรศัพท์ผู้รับ
+        state: จังหวัดที่จัดส่ง
+        zipcode: รหัสไปรษณีย์ผู้รับ
       spree/payment:
-        amount: "จำนวน"
+        amount: จำนวน
       spree/payment_method:
-        name: "ชื่อ"
+        name: ชื่อ
       spree/product:
-        available_on: "พร้อมเมื่อ"
-        cost_currency: "ราคาอัตราแลกเปลี่ยน"
-        cost_price: "ราคา"
-        description: "รายละเอียด"
-        master_price: "ราคาจริง"
-        name: "ชื่อ"
-        on_hand: "มีสินค้า"
-        shipping_category: "ประเภทการส่งสินค้า"
-        tax_category: "ประเภทภาษี"
+        available_on: พร้อมเมื่อ
+        cost_currency: ราคาอัตราแลกเปลี่ยน
+        cost_price: ราคา
+        description: รายละเอียด
+        master_price: ราคาจริง
+        name: ชื่อ
+        on_hand: มีสินค้า
+        shipping_category: ประเภทการส่งสินค้า
+        tax_category: ประเภทภาษี
       spree/promotion:
-        advertise: "โฆษณา"
-        code: "หมายเลข"
-        description: "รายละเอียด"
+        advertise: โฆษณา
+        code: หมายเลข
+        description: รายละเอียด
         event_name: Event Name
-        expires_at: "วันหมดอายุ"
-        name: "ชื่อ"
+        expires_at: วันหมดอายุ
+        name: ชื่อ
         path: Path
-        starts_at: "เริ่มเมื่อ"
-        usage_limit: "จำกัดจำนวน"
+        starts_at: เริ่มเมื่อ
+        usage_limit: จำกัดจำนวน
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
-        name: "ชื่อ"
-        presentation: "การแสดงผล"
+        name: ชื่อ
+        presentation: การแสดงผล
       spree/prototype:
-        name: "ชื่อ"
+        name: ชื่อ
       spree/return_authorization:
-        amount: "จำนวน"
+        amount: จำนวน
       spree/role:
-        name: "ชื่อ"
+        name: ชื่อ
       spree/state:
-        abbr: "ตัวย่อ"
-        name: "ชื่อ"
+        abbr: ตัวย่อ
+        name: ชื่อ
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
-        description: "รายละเอียด"
-        name: "ชื่อ"
+        description: รายละเอียด
+        name: ชื่อ
       spree/tax_rate:
-        amount: "อัตรา"
-        included_in_price: "รวมในราคา"
-        show_rate_in_label: "แสดงอัตรา"
+        amount: อัตรา
+        included_in_price: รวมในราคา
+        show_rate_in_label: แสดงอัตรา
       spree/taxon:
-        name: "ชื่อ"
+        name: ชื่อ
         permalink: Permalink
-        position: "ตำแหน่ง"
+        position: ตำแหน่ง
       spree/taxonomy:
-        name: "ชื่อ"
+        name: ชื่อ
       spree/user:
-        email: "อีเมล"
-        password: "รหัสผ่าน"
-        password_confirmation: "ยืนยันรหัสผ่าน"
+        email: อีเมล
+        password: รหัสผ่าน
+        password_confirmation: ยืนยันรหัสผ่าน
       spree/variant:
-        cost_currency: "อัตราแลกเปลี่ยน"
-        cost_price: "ราคา"
-        depth: "ความลึก"
-        height: "ความสูง"
-        price: "ราคา"
+        cost_currency: อัตราแลกเปลี่ยน
+        cost_price: ราคา
+        depth: ความลึก
+        height: ความสูง
+        price: ราคา
         sku: SKU
-        weight: "น้ำหนัก"
-        width: "ความกว้าง"
+        weight: น้ำหนัก
+        width: ความกว้าง
       spree/zone:
-        description: "รายละเอียด"
-        name: "ชื่อ"
+        description: รายละเอียด
+        name: ชื่อ
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
-        one: "ที่อยู่"
-        other: "ที่อยู่"
+        one: ที่อยู่
+        other: ที่อยู่
       spree/country:
-        one: "ประเทศ"
-        other: "ประเทศ"
+        one: ประเทศ
+        other: ประเทศ
       spree/credit_card:
-        one: "บัตรเครดิต"
-        other: "บัตรเครดิต"
-      spree/customer_return:
+        one: บัตรเครดิต
+        other: บัตรเครดิต
+      spree/customer_return: 
       spree/inventory_unit:
-        one: "จำนวนในคลัง"
-        other: "จำนวนในคลัง"
+        one: จำนวนในคลัง
+        other: จำนวนในคลัง
       spree/line_item:
         one: Line Item
         other: Line Items
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order:
-        one: "สั่งซื้อ"
-        other: "สั่งซื้อ"
+        one: สั่งซื้อ
+        other: สั่งซื้อ
       spree/payment:
-        one: "ชำระ"
-        other: "ชำระ"
-      spree/payment_method:
+        one: ชำระ
+        other: ชำระ
+      spree/payment_method: 
       spree/product:
-        one: "สินค้า"
-        other: "สินค้า"
-      spree/promotion:
-      spree/promotion_category:
+        one: สินค้า
+        other: สินค้า
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property:
-        one: "คุณสมบัติ"
-        other: "คุณสมบัติ"
+        one: คุณสมบัติ
+        other: คุณสมบัติ
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
-        one: "รายการคืน"
-        other: "รายการคืน"
-      spree/return_authorization_reason:
+        one: รายการคืน
+        other: รายการคืน
+      spree/return_authorization_reason: 
       spree/role:
-        one: "หน้าที่"
-        other: "หน้าที่"
+        one: หน้าที่
+        other: หน้าที่
       spree/shipment:
-        one: "การส่งสินค้า"
-        other: "การส่งสินค้า"
+        one: การส่งสินค้า
+        other: การส่งสินค้า
       spree/shipping_category:
-        one: "ประเภทการจัดส่ง"
-        other: "ประเภทการจัดส่ง"
-      spree/shipping_method:
+        one: ประเภทการจัดส่ง
+        other: ประเภทการจัดส่ง
+      spree/shipping_method: 
       spree/state:
-        one: "จังหวัด"
-        other: "จังหวัด"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+        one: จังหวัด
+        other: จังหวัด
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
-        one: "ประเภทภาษี"
-        other: "ประเภทภาษี"
+        one: ประเภทภาษี
+        other: ประเภทภาษี
       spree/tax_rate:
-        one: "อัตราภาษีTax Rate"
-        other: "อัตราภาษี"
-      spree/taxon:
-      spree/taxonomy:
-      spree/tracker:
+        one: อัตราภาษีTax Rate
+        other: อัตราภาษี
+      spree/taxon: 
+      spree/taxonomy: 
+      spree/tracker: 
       spree/user:
-        one: "ผู้ใช้งาน"
-        other: "ผู้ใช้งาน"
+        one: ผู้ใช้งาน
+        other: ผู้ใช้งาน
       spree/variant:
-        one: "ตัวแปร"
-        other: "ตัวแปร"
+        one: ตัวแปร
+        other: ตัวแปร
       spree/zone:
-        one: "เขต"
-        other: "เขต"
+        one: เขต
+        other: เขต
   spree:
-    abbreviation: "คำย่อ"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
-    account: "บัญชีผู้ใช้"
-    account_updated: "ปรับปรุงบัญชีผู้ใช้แล้ว"
-    action: "ทำการ"
+    abbreviation: คำย่อ
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
+    account: บัญชีผู้ใช้
+    account_updated: ปรับปรุงบัญชีผู้ใช้แล้ว
+    action: ทำการ
     actions:
-      cancel: "ยกเลิก"
-      continue: "ต่อไป"
-      create: "สร้าง"
-      destroy: "ทำลาย"
-      edit: "แก้ไข"
-      list: "แสดงรายการ"
-      listing: "รายการ"
-      new: "สร้าง"
-      refund:
-      save: "บันทึก"
-      update: "ปรับปรุง"
-    activate: "เริ่มใช้งาน"
-    active: "ใช้งาน"
-    add: "เพิ่ม"
-    add_action_of_type: "เพิ่มประเภท"
-    add_country: "เพิ่มประเทศ"
-    add_coupon_code:
-    add_new_header: "เพิ่ม Header"
-    add_new_style: "เพิ่ม Style"
-    add_one: "เพิ่ม"
-    add_option_value: "เพิ่มรายการตัวเลือก"
-    add_product: "เพิ่มสินค้า"
-    add_product_properties: "เพิ่มคุณสมบัติ"
-    add_rule_of_type: "เพิ่มกฏของประเภท"
-    add_state: "เพิ่มจังหวัด"
-    add_stock: "เพิ่มสต็อก"
-    add_stock_management: "เพิ่มการจัดการสต็อก"
-    add_to_cart: "เพิ่มลงตะกร้า"
-    add_variant: "เพิ่มตัวแปร"
-    additional_item: "ราคาเพิ่มเติม"
-    address1: "ที่อยู่"
-    address2: "ที่อยู่ (เพิ่มเติม)"
-    adjustable:
-    adjustment: "แก้ไขรายการ"
-    adjustment_amount: "จำนวน"
-    adjustment_successfully_closed: "รายการแก้ไขได้ทำการปิดเป็นที่เรียบร้อย"
-    adjustment_successfully_opened: "รายการแก้ไขได้ทำการเปิดเป็นที่เรียบร้อย"
-    adjustment_total: "ยอดรวมรายการที่แก้ไข"
-    adjustments: "แก้ไขรายการ"
+      cancel: ยกเลิก
+      continue: ต่อไป
+      create: สร้าง
+      destroy: ทำลาย
+      edit: แก้ไข
+      list: แสดงรายการ
+      listing: รายการ
+      new: สร้าง
+      refund: 
+      save: บันทึก
+      update: ปรับปรุง
+    activate: เริ่มใช้งาน
+    active: ใช้งาน
+    add: เพิ่ม
+    add_action_of_type: เพิ่มประเภท
+    add_country: เพิ่มประเทศ
+    add_coupon_code: 
+    add_new_header: เพิ่ม Header
+    add_new_style: เพิ่ม Style
+    add_one: เพิ่ม
+    add_option_value: เพิ่มรายการตัวเลือก
+    add_product: เพิ่มสินค้า
+    add_product_properties: เพิ่มคุณสมบัติ
+    add_rule_of_type: เพิ่มกฏของประเภท
+    add_state: เพิ่มจังหวัด
+    add_stock: เพิ่มสต็อก
+    add_stock_management: เพิ่มการจัดการสต็อก
+    add_to_cart: เพิ่มลงตะกร้า
+    add_variant: เพิ่มตัวแปร
+    additional_item: ราคาเพิ่มเติม
+    address1: ที่อยู่
+    address2: ที่อยู่ (เพิ่มเติม)
+    adjustable: 
+    adjustment: แก้ไขรายการ
+    adjustment_amount: จำนวน
+    adjustment_successfully_closed: รายการแก้ไขได้ทำการปิดเป็นที่เรียบร้อย
+    adjustment_successfully_opened: รายการแก้ไขได้ทำการเปิดเป็นที่เรียบร้อย
+    adjustment_total: ยอดรวมรายการที่แก้ไข
+    adjustments: แก้ไขรายการ
     admin:
       tab:
-        configuration: "ตั้งค่า"
-        option_types:
-        orders: "สั่งซื้อ"
-        overview: "ภาพรวม"
-        products: "สินค้า"
-        promotions: "โปรโมชั่น"
-        promotion_categories:
-        properties:
-        prototypes:
-        reports: "รายงาน"
-        taxonomies:
-        taxons:
-        users: "ผู้ใช้"
+        configuration: ตั้งค่า
+        option_types: 
+        orders: สั่งซื้อ
+        overview: ภาพรวม
+        products: สินค้า
+        promotion_categories: 
+        promotions: โปรโมชั่น
+        properties: 
+        prototypes: 
+        reports: รายงาน
+        taxonomies: 
+        taxons: 
+        users: ผู้ใช้
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
-    administration: "การจัดการ"
-    advertise:
-    agree_to_privacy_policy: "ตกลงในนโยบายความเป็นส่วนตัว"
-    agree_to_terms_of_service: "ตกลงในข้อตกลงบริการ"
-    all: "ทั้งหมด"
-    all_adjustments_closed: "ทุกรายการแก้ไขนั้นได้ปิดลงแล้ว!"
-    all_adjustments_opened: "ทุกรายการแก้ไขนั้้นได้เปิดแล้ว!"
-    all_departments: "ทุกแผนก"
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test: "อนุญาตให้ใช้ SSL เมื่ออยู่ในโหมดของการพัฒนาและทดสอบ"
-    allow_ssl_in_production: "อนุญาต SSL ให้ทำงานบน Production"
-    allow_ssl_in_staging: "อนุณาต SSL ให้ทำงานบน Stagging"
-    already_signed_up_for_analytics: "คุณได้สมัครใช้งาน Spree Analytics"
-    alt_text: "ข้อความอื่นๆ"
-    alternative_phone: "เบอร์โทรอื่นๆ"
-    amount: "รวม"
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
+    administration: การจัดการ
+    advertise: 
+    agree_to_privacy_policy: ตกลงในนโยบายความเป็นส่วนตัว
+    agree_to_terms_of_service: ตกลงในข้อตกลงบริการ
+    all: ทั้งหมด
+    all_adjustments_closed: ทุกรายการแก้ไขนั้นได้ปิดลงแล้ว!
+    all_adjustments_opened: ทุกรายการแก้ไขนั้้นได้เปิดแล้ว!
+    all_departments: ทุกแผนก
+    all_items_have_been_returned: 
+    allow_ssl_in_development_and_test: อนุญาตให้ใช้ SSL เมื่ออยู่ในโหมดของการพัฒนาและทดสอบ
+    allow_ssl_in_production: อนุญาต SSL ให้ทำงานบน Production
+    allow_ssl_in_staging: อนุณาต SSL ให้ทำงานบน Stagging
+    already_signed_up_for_analytics: คุณได้สมัครใช้งาน Spree Analytics
+    alt_text: ข้อความอื่นๆ
+    alternative_phone: เบอร์โทรอื่นๆ
+    amount: รวม
     analytics_desc_header_1: Spree Analytics
-    analytics_desc_header_2: "ข้อมูล analytics  ได้ผนวกไปยังหน้า Dashboard ของคุณ"
-    analytics_desc_list_1: "ได้ข้อมูลการสั่งซื้อในทันที"
-    analytics_desc_list_2: "ต้องการเฉพาะบัญชีฟรีของ Spree เพื่อใช้งาน"
-    analytics_desc_list_3: "ไม่ต้องติดตั้งโค๊ดใดๆ"
-    analytics_desc_list_4: "มันฟรีจริงๆนะ!"
+    analytics_desc_header_2: ข้อมูล analytics  ได้ผนวกไปยังหน้า Dashboard ของคุณ
+    analytics_desc_list_1: ได้ข้อมูลการสั่งซื้อในทันที
+    analytics_desc_list_2: ต้องการเฉพาะบัญชีฟรีของ Spree เพื่อใช้งาน
+    analytics_desc_list_3: ไม่ต้องติดตั้งโค๊ดใดๆ
+    analytics_desc_list_4: มันฟรีจริงๆนะ!
     analytics_trackers: Analytics Trackers
-    and: "และ"
-    approve:
-    approved_at:
-    approver:
-    are_you_sure: "แน่ใจหรือไม่"
-    are_you_sure_delete: "คุณแน่ใจที่จะลบข้อมูลนี้หรือไม่?"
-    associated_adjustment_closed: "รายการที่เกี่ยวข้อกับรายการปรับปรุงนั้นได้ปิดแล้ว และจะไม่นำมาคำนวนใหม่ คุณต้องการที่จะเปิดหรือไม่?"
-    at_symbol: '@'
-    authorization_failure: "การขออนุญาต ไม่สำเร็จ"
-    authorized:
-    auto_capture:
-    available_on: "พร้อมเมื่อ"
-    average_order_value:
-    avs_response:
-    back: "กลับ"
+    and: และ
+    approve: 
+    approved_at: 
+    approver: 
+    are_you_sure: แน่ใจหรือไม่
+    are_you_sure_delete: คุณแน่ใจที่จะลบข้อมูลนี้หรือไม่?
+    associated_adjustment_closed: รายการที่เกี่ยวข้อกับรายการปรับปรุงนั้นได้ปิดแล้ว และจะไม่นำมาคำนวนใหม่ คุณต้องการที่จะเปิดหรือไม่?
+    at_symbol: "@"
+    authorization_failure: การขออนุญาต ไม่สำเร็จ
+    authorized: 
+    auto_capture: 
+    available_on: พร้อมเมื่อ
+    average_order_value: 
+    avs_response: 
+    back: กลับ
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
-    back_to_store: "กลับไปหน้าร้าน"
-    back_to_users_list: "กลับไปยังรายการลูกค้า"
-    backorderable: "สามารถสั่งซื้อล่วงหน้าได้"
-    backorderable_default:
-    backordered:
-    backorders_allowed:
-    balance_due: "ยอดที่ต้องชำระ"
-    base_amount:
-    base_percent:
-    bill_address: "ที่อยู่บนใบเสร็จรับเงิน"
-    billing: "ใบเสร็จรับเงิน"
-    billing_address: "ที่อยู่บนใบเสร็จรับเงิน"
-    both: "ทั้งสอง"
-    calculated_reimbursements:
-    calculator: "เครื่องคิดเลข"
-    calculator_settings_warning: "หากคุณต้องการเปลี่ยนวิธีการคำนวน คุณต้องบันทึกก่อนถึงจะสามารถแก้ไขการคำนวนได้"
-    cancel: "ยกเลิก"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: "คุณไม่สามารถชำระรายการสั่งซื้อได้เนื่องจากไม่ได้กำหนดวิธีชำระสินค้า"
-    cannot_create_returns: "ไม่สามารถทำรายการคืนสินาได้เนื่องจากยังไม่ได้ส่งสินค้าดังกล่าว"
-    cannot_perform_operation: "ไม่สามารถทำรายการที่ต้องการได้"
-    cannot_set_shipping_method_without_address: "ไม่สามารถตั้งค่าประเภทการจัดส่งได้จนกว่าจะได้รับรายละเอียดของลูกค้า"
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
+    back_to_store: กลับไปหน้าร้าน
+    back_to_users_list: กลับไปยังรายการลูกค้า
+    backorderable: สามารถสั่งซื้อล่วงหน้าได้
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
+    balance_due: ยอดที่ต้องชำระ
+    base_amount: 
+    base_percent: 
+    bill_address: ที่อยู่บนใบเสร็จรับเงิน
+    billing: ใบเสร็จรับเงิน
+    billing_address: ที่อยู่บนใบเสร็จรับเงิน
+    both: ทั้งสอง
+    calculated_reimbursements: 
+    calculator: เครื่องคิดเลข
+    calculator_settings_warning: หากคุณต้องการเปลี่ยนวิธีการคำนวน คุณต้องบันทึกก่อนถึงจะสามารถแก้ไขการคำนวนได้
+    cancel: ยกเลิก
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: คุณไม่สามารถชำระรายการสั่งซื้อได้เนื่องจากไม่ได้กำหนดวิธีชำระสินค้า
+    cannot_create_returns: ไม่สามารถทำรายการคืนสินาได้เนื่องจากยังไม่ได้ส่งสินค้าดังกล่าว
+    cannot_perform_operation: ไม่สามารถทำรายการที่ต้องการได้
+    cannot_set_shipping_method_without_address: ไม่สามารถตั้งค่าประเภทการจัดส่งได้จนกว่าจะได้รับรายละเอียดของลูกค้า
     capture: capture
-    capture_events:
-    card_code: "รหัสบัตร"
-    card_number: "หมายเลขบัตร"
-    card_type:
-    card_type_is: "ชนิดของบัตร"
-    cart: "ตะกร้าสินค้า"
-    cart_subtotal:
-    categories: "หมวดหมู่"
-    category: "ชนิด"
-    charged:
-    check_for_spree_alerts: "ตรวจสอบการแจ้งเตือน Spree"
-    checkout: "สั่งซื้อ"
-    choose_a_customer: "เลือกลูกค้า"
-    choose_a_taxon_to_sort_products_for:
-    choose_currency: "เลือกสกุลเงิน"
-    choose_dashboard_locale: "เลือกภาษาของ Dashboard"
-    choose_location:
-    city: "เขต หรือ อำเภอ"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    capture_events: 
+    card_code: รหัสบัตร
+    card_number: หมายเลขบัตร
+    card_type: 
+    card_type_is: ชนิดของบัตร
+    cart: ตะกร้าสินค้า
+    cart_subtotal: 
+    categories: หมวดหมู่
+    category: ชนิด
+    charged: 
+    check_for_spree_alerts: ตรวจสอบการแจ้งเตือน Spree
+    checkout: สั่งซื้อ
+    choose_a_customer: เลือกลูกค้า
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: เลือกสกุลเงิน
+    choose_dashboard_locale: เลือกภาษาของ Dashboard
+    choose_location: 
+    city: เขต หรือ อำเภอ
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Clone
-    close: "ปิด"
-    close_all_adjustments: "ปิดรายการปรับปรุงทั้งหมด"
+    close: ปิด
+    close_all_adjustments: ปิดรายการปรับปรุงทั้งหมด
     code: Code
-    company: "บริษัท"
-    complete: "เสร็จสิ้น"
-    configuration: "จัดการระบบ"
-    configurations: "รายการจัดการ"
-    confirm: "ยืนยันรหัสผ่าน"
-    confirm_delete: "ยืนยันการลบ"
-    confirm_password: "ยืนยันรหัสผ่าน"
-    continue: "ดำเนินการต่อ"
-    continue_shopping: "เลือกซื้อสินค้าต่อ"
-    cost_currency: "ราคาสกุลเงิน"
+    company: บริษัท
+    complete: เสร็จสิ้น
+    configuration: จัดการระบบ
+    configurations: รายการจัดการ
+    confirm: ยืนยันรหัสผ่าน
+    confirm_delete: ยืนยันการลบ
+    confirm_password: ยืนยันรหัสผ่าน
+    continue: ดำเนินการต่อ
+    continue_shopping: เลือกซื้อสินค้าต่อ
+    cost_currency: ราคาสกุลเงิน
     cost_price: Cost Price
-    could_not_connect_to_jirafe: "ไม่สามารถเชื่อมต่อกับ Jirafe เพื่อรับข้อมูลได้ ระบบจะทดลองเชื่อมต่อใหม่อีกครั้ง"
-    could_not_create_customer_return:
-    could_not_create_stock_movement: "เกิดปัญหาขึ้นระหว่างทำการเคลื่อนย้ายสินค้า กรุณาลองใหม่อีกครั้ง"
-    count_on_hand: "จำนวนในมือ"
-    countries: "ประเทศ"
-    country: "ประเทศ"
-    country_based: "ยีดประเทศเป็นหลัก"
-    country_name: "ชื่อ"
+    could_not_connect_to_jirafe: ไม่สามารถเชื่อมต่อกับ Jirafe เพื่อรับข้อมูลได้ ระบบจะทดลองเชื่อมต่อใหม่อีกครั้ง
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: เกิดปัญหาขึ้นระหว่างทำการเคลื่อนย้ายสินค้า กรุณาลองใหม่อีกครั้ง
+    count_on_hand: จำนวนในมือ
+    countries: ประเทศ
+    country: ประเทศ
+    country_based: ยีดประเทศเป็นหลัก
+    country_name: ชื่อ
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon: "คูปอง"
-    coupon_code: "หมายเลขคูปอง"
-    coupon_code_already_applied: "คูปองใบนี้ได้ถูกใช้ในรายการสั่งซื้อนี้แล้ว"
-    coupon_code_applied: "คูปองใบนี้ได้ถูกใช้สิทธิร่วมกับรายการสั่งซื้อของคุณเป็นที่เรียบร้อย"
-    coupon_code_better_exists: "คูปองที่ได้ใช้นั้นทำให้ราคาถูกลง"
-    coupon_code_expired: "คูปองหมดอายุแล้ว"
-    coupon_code_max_usage: "คูปองได้ถูกใช้เกินกำหนดแล้ว"
-    coupon_code_not_eligible: "คูปองนี้ไม่สามารถใช้กับรายการสั่งซื้อดังกล่าวได้"
-    coupon_code_not_found: "ไม่พบหมายเลขคูปองนี้ กรุณาลองใหม่อีกครั้ง"
-    coupon_code_unknown_error:
-    create: "สร้าง"
-    create_a_new_account: "สร้างบัญชีผู้ใช้ใหม่"
-    create_new_order:
-    create_reimbursement:
-    created_at: "สร้างเมื่อ"
-    credit: "เครดิต"
-    credit_card: "บัตรเครดิต"
-    credit_cards: "บัตรเครดิต"
-    credit_owed: "ค้างเครดิตอยู่"
-    credits:
-    currency: "สกุลเงิน"
-    currency_decimal_mark: "จุดทศนิยมของสกุลเงิน"
-    currency_settings: "ตั้งค่าสกุลเงิน"
-    currency_symbol_position: "ใส่เครื่องหมายสกุลเงินก่อนหรือหลังจำนวน?"
-    currency_thousands_separator: "ตัวคั่นทุกหนึ่งพัน"
-    current: "ขณะนี้"
-    current_promotion_usage: "ใช้อยู่: %{count}"
-    customer: "ลูกค้า"
-    customer_details: "รายละเอียดลูกค้า"
-    customer_details_updated: "ได้ทำการปรับปรุงรายละเอียดของลูกค้าแล้ว"
-    customer_return:
-    customer_returns:
-    customer_search: "ค้นหาลูกค้า"
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
+    coupon: คูปอง
+    coupon_code: หมายเลขคูปอง
+    coupon_code_already_applied: คูปองใบนี้ได้ถูกใช้ในรายการสั่งซื้อนี้แล้ว
+    coupon_code_applied: คูปองใบนี้ได้ถูกใช้สิทธิร่วมกับรายการสั่งซื้อของคุณเป็นที่เรียบร้อย
+    coupon_code_better_exists: คูปองที่ได้ใช้นั้นทำให้ราคาถูกลง
+    coupon_code_expired: คูปองหมดอายุแล้ว
+    coupon_code_max_usage: คูปองได้ถูกใช้เกินกำหนดแล้ว
+    coupon_code_not_eligible: คูปองนี้ไม่สามารถใช้กับรายการสั่งซื้อดังกล่าวได้
+    coupon_code_not_found: ไม่พบหมายเลขคูปองนี้ กรุณาลองใหม่อีกครั้ง
+    coupon_code_unknown_error: 
+    create: สร้าง
+    create_a_new_account: สร้างบัญชีผู้ใช้ใหม่
+    create_new_order: 
+    create_reimbursement: 
+    created_at: สร้างเมื่อ
+    credit: เครดิต
+    credit_card: บัตรเครดิต
+    credit_cards: บัตรเครดิต
+    credit_owed: ค้างเครดิตอยู่
+    credits: 
+    currency: สกุลเงิน
+    currency_decimal_mark: จุดทศนิยมของสกุลเงิน
+    currency_settings: ตั้งค่าสกุลเงิน
+    currency_symbol_position: ใส่เครื่องหมายสกุลเงินก่อนหรือหลังจำนวน?
+    currency_thousands_separator: ตัวคั่นทุกหนึ่งพัน
+    current: ขณะนี้
+    current_promotion_usage: 'ใช้อยู่: %{count}'
+    customer: ลูกค้า
+    customer_details: รายละเอียดลูกค้า
+    customer_details_updated: ได้ทำการปรับปรุงรายละเอียดของลูกค้าแล้ว
+    customer_return: 
+    customer_returns: 
+    customer_search: ค้นหาลูกค้า
     cut: Cut
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: App ID
         app_token: App Token
-        currently_unavailable: "ไม่สามารถใช้ Jirafe ได้ในขณะนี้ Spree จะลองเชื่อมต่อใหม่ภายหลัง"
+        currently_unavailable: ไม่สามารถใช้ Jirafe ได้ในขณะนี้ Spree จะลองเชื่อมต่อใหม่ภายหลัง
         explanation: Field ด้านล่างอาจสร้างขึ้นมาหากคุณเลือกที่จะลงทะเบียน Jirafe จากหน้า Dashboard ของ admin
-        header: "ตั้งค่า Jarafe Analytics"
+        header: ตั้งค่า Jarafe Analytics
         site_id: Site ID
         token: Token
-      jirafe_settings_updated: "ค่าของ Jirafe ได้ถูกปรับปรุงแล้ว"
-    date: "วันที่"
-    date_completed: "วันที่เสร็จสิ้น"
+      jirafe_settings_updated: ค่าของ Jirafe ได้ถูกปรับปรุงแล้ว
+    date: วันที่
+    date_completed: วันที่เสร็จสิ้น
     date_picker:
-      first_day:
+      first_day: 
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
-    date_range: "ช่วงวันที่"
-    default: "ค่าเริ่มต้น"
-    default_refund_amount:
-    default_tax: "ค่าภาษีเริ่มต้น"
-    default_tax_zone: "ค่าโซนภาษีเริ่มต้น"
-    delete: "ลบ"
-    deleted_variants_present:
-    delivery: "จัดส่ง"
-    depth: "ลึก"
-    description: "รายละเอียด"
-    destination: "จุดหมาย"
-    destroy: "ทำลาย"
-    details:
-    discount_amount: "จำนวนส่วนลด"
-    dismiss_banner: "ไม่ ขอบคุณ! ฉันไม่สนใจ และไม่ต้องแสดงข้อความดังกล่าวอีก"
-    display: "แสดง"
-    display_currency: "แสดงสกุลเงิน"
-    doesnt_track_inventory:
-    edit: "แก้ไข"
-    editing_resource:
-    editing_rma_reason:
-    editing_user: "แก้ไขข้อมูลผู้ใช้"
+    date_range: ช่วงวันที่
+    default: ค่าเริ่มต้น
+    default_refund_amount: 
+    default_tax: ค่าภาษีเริ่มต้น
+    default_tax_zone: ค่าโซนภาษีเริ่มต้น
+    delete: ลบ
+    deleted_variants_present: 
+    delivery: จัดส่ง
+    depth: ลึก
+    description: รายละเอียด
+    destination: จุดหมาย
+    destroy: ทำลาย
+    details: 
+    discount_amount: จำนวนส่วนลด
+    dismiss_banner: ไม่ ขอบคุณ! ฉันไม่สนใจ และไม่ต้องแสดงข้อความดังกล่าวอีก
+    display: แสดง
+    display_currency: แสดงสกุลเงิน
+    doesnt_track_inventory: 
+    edit: แก้ไข
+    editing_resource: 
+    editing_rma_reason: 
+    editing_user: แก้ไขข้อมูลผู้ใช้
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email: "อีเมล"
-    empty: "ว่างเปล่า"
-    empty_cart: "ล้างตะกร้า"
-    enable_mail_delivery: "เปิดระบบส่งเมล"
-    end: "จบ"
-    ending_in: "จบภายใน"
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
+    email: อีเมล
+    empty: ว่างเปล่า
+    empty_cart: ล้างตะกร้า
+    enable_mail_delivery: เปิดระบบส่งเมล
+    end: จบ
+    ending_in: จบภายใน
     environment: Environment
-    error: "ข้อผิดพลาด"
+    error: ข้อผิดพลาด
     errors:
       messages:
-        could_not_create_taxon: "ไม่สามารถสร้าง Taxon"
-        no_payment_methods_available: "ไม่พบวิธีการชำระเงินใน environment นี้"
-        no_shipping_methods_available: "ไม่พบวิธีจัดส่งสินค้าในสถานที่ดังกล่าว กรุณาเปลี่ยนที่อยู่ใหม่"
+        could_not_create_taxon: ไม่สามารถสร้าง Taxon
+        no_payment_methods_available: ไม่พบวิธีการชำระเงินใน environment นี้
+        no_shipping_methods_available: ไม่พบวิธีจัดส่งสินค้าในสถานที่ดังกล่าว กรุณาเปลี่ยนที่อยู่ใหม่
     errors_prohibited_this_record_from_being_saved:
       one: 1 ข้อผิดพลาดที่ไม่สามารถจัดเก็บข้อมูลได้
       other: "%{count} ข้อผิดพลาดที่ไม่สามารถจัดเก็บข้อมูลได้"
-    event: "กรณี"
+    event: กรณี
     events:
       spree:
         cart:
-          add: "เพิ่มลงตะกร้า"
+          add: เพิ่มลงตะกร้า
         checkout:
-          coupon_code_added: "ได้เพิ่มหมายเลขคูปองแล้ว"
+          coupon_code_added: ได้เพิ่มหมายเลขคูปองแล้ว
         content:
-          visited: "ไปยังหน้า Static content"
+          visited: ไปยังหน้า Static content
         order:
-          contents_changed: "รายการสั่งซื้อได้ทำการเปลี่ยนแปลง"
-        page_view: "ได้ดูหน้า Static page"
+          contents_changed: รายการสั่งซื้อได้ทำการเปลี่ยนแปลง
+        page_view: ได้ดูหน้า Static page
         user:
-          signup: "สมัครสมาชิก"
+          signup: สมัครสมาชิก
     exceptions:
-      count_on_hand_setter: "ไม่สามารถตั้งค่า count_on_hand ได้ด้วยตัวเอง เนื่องจากระบบได้ตั้งค่า recalculate_count_on_hand โดยอัตโนมัติ กรุณาใช้ `update_column(:count_on_hand, value)` แทน"
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
-    expiration: "หมดอายุ"
-    extension: "ส่วนขยาย"
-    failed_payment_attempts:
-    filename: "ชื่อไฟล์"
-    fill_in_customer_info: "กรุณากรอกข้อมูลลูกค้า"
-    filter_results: "กรอกผลลัพท์"
+      count_on_hand_setter: >-
+        ไม่สามารถตั้งค่า count_on_hand ได้ด้วยตัวเอง เนื่องจากระบบได้ตั้งค่า recalculate_count_on_hand โดยอัตโนมัติ กรุณาใช้ `update_column(:count_on_hand,
+        value)` แทน
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
+    expiration: หมดอายุ
+    extension: ส่วนขยาย
+    failed_payment_attempts: 
+    filename: ชื่อไฟล์
+    fill_in_customer_info: กรุณากรอกข้อมูลลูกค้า
+    filter_results: กรอกผลลัพท์
     finalize: Finalize
-    finalized:
-    find_a_taxon:
-    first_item: "ราคาสินค้าชิ้นแรก"
-    first_name: "ชื่อจริง"
-    first_name_begins_with: "ชื่อจริงเริ่มต้นด้วย"
+    finalized: 
+    find_a_taxon: 
+    first_item: ราคาสินค้าชิ้นแรก
+    first_name: ชื่อจริง
+    first_name_begins_with: ชื่อจริงเริ่มต้นด้วย
     flat_percent: Flat Percent
     flat_rate_per_order: Flat Rate (ต่อรายการสั่งซื้อ)
     flexible_rate: Flexible Rate
-    forgot_password: "ลืมรหัสผ่าน"
+    forgot_password: ลืมรหัสผ่าน
     free_shipping: Free Shipping
-    free_shipping_amount:
-    front_end: "หน้าขายสินค้า"
-    gateway: "ช่องทางการชำระเงิน"
+    free_shipping_amount: 
+    front_end: หน้าขายสินค้า
+    gateway: ช่องทางการชำระเงิน
     gateway_config_unavailable: Gateway unavailable for environment
-    gateway_error: "เกิดข้อผิดพลาดที่ช่องทางการชำระเงิน"
-    general: "เบื้องต้น"
-    general_settings: "ข้อมูลเบื้องต้น"
+    gateway_error: เกิดข้อผิดพลาดที่ช่องทางการชำระเงิน
+    general: เบื้องต้น
+    general_settings: ข้อมูลเบื้องต้น
     google_analytics: Google Analytics
     google_analytics_id: Analytics ID
     guest_checkout: Guest Checkout
     guest_user_account: Checkout as a Guest
     has_no_shipped_units: has no shipped units
-    height: "สูง"
-    hide_cents: "ซ่อนเซ็น"
-    home: "หน้าแรก"
+    height: สูง
+    hide_cents: ซ่อนเซ็น
+    home: หน้าแรก
     i18n:
-      available_locales: "ภาษาที่รองรับ"
-      language: "ภาษา"
-      localization_settings: "ตั้งค่าภาษา"
-      this_file_language: "ภาษาไทย (TH)"
-    icon: "ไอค่อน"
-    identifier:
-    image: "รูปภาพ"
-    images: "รูปภาพ"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price: "รวมในราคา"
-    included_price_validation: "ไม่สามารถเลือกได้หากคุณยังไม่ได้ตั้งค่าเริ่มต้นของโซนภาษี"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password: "กรุณากรอกอีเมลของคุณในฟอร์มด้านล่าง"
-    insufficient_stock: "สินค้าในคลังไม่เพียงพอ เรามีแค่ %{on_hand} อยู่ในขณะนี้"
-    insufficient_stock_lines_present:
-    intercept_email_address: "ยับยั้งอีเมล"
-    intercept_email_instructions: "แก้ไขอีเมลผู้รับและแทนที่ด้วยอีเมลนี้"
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider: "ผู้ให้บริการชำระเงินไม่ถูกต้อง"
-    invalid_promotion_action: "การตั้งค่าโปรโมชั่นไม่ถูกต้อง"
-    invalid_promotion_rule: "กฏของโปรโมชั่นไม่ถูกต้อง"
-    inventory: "คลัง"
-    inventory_adjustment: "ปรับแต่งคลังสินค้า"
-    inventory_error_flash_for_insufficient_quantity: "สินค้าในตะกร้าของคุณนั้นหมดเสียแล้ว"
-    inventory_state:
-    is_not_available_to_shipment_address: "นั้นไม่พร้อมที่ส่งไปยังที่อยู่ดังกล่าว"
-    iso_name: "ชื่อ ISO"
-    item: "สินค้า"
-    item_description: "รายละเอียดสินค้า"
-    item_total: "จำนวนทั้งหมด"
+      available_locales: ภาษาที่รองรับ
+      language: ภาษา
+      localization_settings: ตั้งค่าภาษา
+      this_file_language: ภาษาไทย (TH)
+    icon: ไอค่อน
+    identifier: 
+    image: รูปภาพ
+    images: รูปภาพ
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: รวมในราคา
+    included_price_validation: ไม่สามารถเลือกได้หากคุณยังไม่ได้ตั้งค่าเริ่มต้นของโซนภาษี
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
+    instructions_to_reset_password: กรุณากรอกอีเมลของคุณในฟอร์มด้านล่าง
+    insufficient_stock: สินค้าในคลังไม่เพียงพอ เรามีแค่ %{on_hand} อยู่ในขณะนี้
+    insufficient_stock_lines_present: 
+    intercept_email_address: ยับยั้งอีเมล
+    intercept_email_instructions: แก้ไขอีเมลผู้รับและแทนที่ด้วยอีเมลนี้
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: ผู้ให้บริการชำระเงินไม่ถูกต้อง
+    invalid_promotion_action: การตั้งค่าโปรโมชั่นไม่ถูกต้อง
+    invalid_promotion_rule: กฏของโปรโมชั่นไม่ถูกต้อง
+    inventory: คลัง
+    inventory_adjustment: ปรับแต่งคลังสินค้า
+    inventory_error_flash_for_insufficient_quantity: สินค้าในตะกร้าของคุณนั้นหมดเสียแล้ว
+    inventory_state: 
+    is_not_available_to_shipment_address: นั้นไม่พร้อมที่ส่งไปยังที่อยู่ดังกล่าว
+    iso_name: ชื่อ ISO
+    item: สินค้า
+    item_description: รายละเอียดสินค้า
+    item_total: จำนวนทั้งหมด
     item_total_rule:
       operators:
-        gt: "มากกว่า"
-        gte: "มากกว่าหรือเท่ากับ"
-        lt:
-        lte:
-    items_cannot_be_shipped: "เราไม่สามารถส่งสินค้าดังกล่าวไปยังสถานที่ของคุณได้ กรุณาเลือกสถานที่จัดส่งอื่น"
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        gt: มากกว่า
+        gte: มากกว่าหรือเท่ากับ
+        lt: 
+        lte: 
+    items_cannot_be_shipped: เราไม่สามารถส่งสินค้าดังกล่าวไปยังสถานที่ของคุณได้ กรุณาเลือกสถานที่จัดส่งอื่น
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Path
-    last_name: "นามสกุล"
-    last_name_begins_with: "นามสกุลเริ่มต้นด้วย"
-    learn_more: "เพิ่มเติม"
-    lifetime_stats:
-    line_item_adjustments:
-    list: "รายการ"
-    loading: "กำลังโหลด"
-    locale_changed: "เปลี่ยนภาษา"
-    location: "สถานที่"
-    lock: "ล๊อก"
-    log_entries:
-    logged_in_as: "เข้าสู่ระบบเป็น"
-    logged_in_succesfully: "เข้าสู่ระบบสำเร็จ"
-    logged_out: "คุณได้ออกจากระบบแล้ว"
-    login: "เข้าสู่ระบบ"
-    login_as_existing: "เข้าสู่ระบบจากบัญขีที่มีอยู่แล้ว"
-    login_failed: "ไม่สามารถเข้าสู่ระบบได้"
-    login_name: "เข้าสู่ระบบ"
-    logout: "ออกจากระบบ"
-    logs:
-    look_for_similar_items: "มองหาสินค้าที่คล้ายกัน"
-    make_refund: "ทำเรื่องขอคืนสินค้า"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
-    master_price: "ราคาหลัก"
+    last_name: นามสกุล
+    last_name_begins_with: นามสกุลเริ่มต้นด้วย
+    learn_more: เพิ่มเติม
+    lifetime_stats: 
+    line_item_adjustments: 
+    list: รายการ
+    loading: กำลังโหลด
+    locale_changed: เปลี่ยนภาษา
+    location: สถานที่
+    lock: ล๊อก
+    log_entries: 
+    logged_in_as: เข้าสู่ระบบเป็น
+    logged_in_succesfully: เข้าสู่ระบบสำเร็จ
+    logged_out: คุณได้ออกจากระบบแล้ว
+    login: เข้าสู่ระบบ
+    login_as_existing: เข้าสู่ระบบจากบัญขีที่มีอยู่แล้ว
+    login_failed: ไม่สามารถเข้าสู่ระบบได้
+    login_name: เข้าสู่ระบบ
+    logout: ออกจากระบบ
+    logs: 
+    look_for_similar_items: มองหาสินค้าที่คล้ายกัน
+    make_refund: ทำเรื่องขอคืนสินค้า
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
+    master_price: ราคาหลัก
     match_choices:
-      all: "ทั้งหมด"
-      none: "ไม่มี"
-    max_items: "มากสุด"
-    member_since:
-    memo:
+      all: ทั้งหมด
+      none: ไม่มี
+    max_items: มากสุด
+    member_since: 
+    memo: 
     meta_description: Meta Description
     meta_keywords: Meta Keywords
-    meta_title:
+    meta_title: 
     metadata: Metadata
-    minimal_amount: "จำนวนต่ำสุด"
-    month: "เดือน"
-    more: "เพิ่มเติม"
-    move_stock_between_locations: "ย้ายสินค้าข้ามสถานที่"
-    my_account: "บัญชีของท่าน"
-    my_orders: "รายการสั่งซื้อ"
-    name: "ชื่อ"
-    name_on_card:
-    name_or_sku: "ชื่อหรือ SKU (กรุณาใส่ตัวอักษรอย่างน้อย 4 ตัวขึ้นไปของชื่อสินค้า)"
-    new: "ใหม่"
+    minimal_amount: จำนวนต่ำสุด
+    month: เดือน
+    more: เพิ่มเติม
+    move_stock_between_locations: ย้ายสินค้าข้ามสถานที่
+    my_account: บัญชีของท่าน
+    my_orders: รายการสั่งซื้อ
+    name: ชื่อ
+    name_on_card: 
+    name_or_sku: ชื่อหรือ SKU (กรุณาใส่ตัวอักษรอย่างน้อย 4 ตัวขึ้นไปของชื่อสินค้า)
+    new: ใหม่
     new_adjustment: New Adjustment
-    new_country:
-    new_customer: "สมัครสมาชิก"
-    new_customer_return:
-    new_image: "เพิ่มภาพ"
-    new_option_type: "เพิ่มรายการให้เลือก"
-    new_order: "สั่งซื้อสินค้า"
-    new_order_completed: "รายการสั่งซื้อเสร็จสิ้น"
-    new_payment: "ชำระใหม่"
-    new_payment_method: "เลือกวิธีการชำระใหม่"
-    new_product: "เพิ่มสินค้า"
-    new_promotion: "โปรโมชั่นใหม่"
-    new_promotion_category:
-    new_property: "เพิ่มคุณลักษณะ"
-    new_prototype: "เพิ่มต้นแบบ"
-    new_refund:
-    new_refund_reason:
-    new_return_authorization: "รายการคืนสินค้าใหม่"
-    new_rma_reason:
-    new_shipment_at_location:
-    new_shipping_category: "เพิ่มกลุ่มวิธีการจัดส่ง"
-    new_shipping_method: "เพิ่มวิธีจัดส่ง"
-    new_state: "เพิ่มรัฐหรือจังหวัด"
-    new_stock_location: "สร้างคลังสินค้าใหม่"
-    new_stock_movement: "เพิ่มรายการเคลื่อนไหวสินค้าใหม่"
-    new_stock_transfer: "เพิ่มรายการย้ายสินค้าใหม่"
-    new_tax_category: "เพิ่มรูปแบบการคิดภาษี"
-    new_tax_rate: "เพิ่มอัตราภาษี"
+    new_country: 
+    new_customer: สมัครสมาชิก
+    new_customer_return: 
+    new_image: เพิ่มภาพ
+    new_option_type: เพิ่มรายการให้เลือก
+    new_order: สั่งซื้อสินค้า
+    new_order_completed: รายการสั่งซื้อเสร็จสิ้น
+    new_payment: ชำระใหม่
+    new_payment_method: เลือกวิธีการชำระใหม่
+    new_product: เพิ่มสินค้า
+    new_promotion: โปรโมชั่นใหม่
+    new_promotion_category: 
+    new_property: เพิ่มคุณลักษณะ
+    new_prototype: เพิ่มต้นแบบ
+    new_refund: 
+    new_refund_reason: 
+    new_return_authorization: รายการคืนสินค้าใหม่
+    new_rma_reason: 
+    new_shipment_at_location: 
+    new_shipping_category: เพิ่มกลุ่มวิธีการจัดส่ง
+    new_shipping_method: เพิ่มวิธีจัดส่ง
+    new_state: เพิ่มรัฐหรือจังหวัด
+    new_stock_location: สร้างคลังสินค้าใหม่
+    new_stock_movement: เพิ่มรายการเคลื่อนไหวสินค้าใหม่
+    new_stock_transfer: เพิ่มรายการย้ายสินค้าใหม่
+    new_tax_category: เพิ่มรูปแบบการคิดภาษี
+    new_tax_rate: เพิ่มอัตราภาษี
     new_taxon: New Taxon
-    new_taxonomy: "เพิ่ม Taxonomy"
+    new_taxonomy: เพิ่ม Taxonomy
     new_tracker: New Tracker
-    new_user: "สร้างผู้ใช้ใหม่"
-    new_variant: "เพิ่มตัวแปรใหม่"
-    new_zone: "เพิ่มเขตใหม่"
-    next: "ถัดไป"
-    no_actions_added: "ไม่พบการสั่งการ"
-    no_payment_found:
-    no_pending_payments: "ไม่พบรายการรอชำระ"
-    no_products_found: "ไม่พบสินค้า"
-    no_resource_found:
-    no_results: "ไม่พบผลลัพท์"
-    no_returns_found:
-    no_rules_added: "ไม่พบ rules"
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present: "ไม่พบรายละเอียดของ Tracker"
-    none: "ว่าง"
-    none_selected:
-    normal_amount: "ราคาปรกติ"
-    not: "ไม่"
-    not_available: "ไม่มี"
-    not_enough_stock: "จำนวนรายการสินค้าไม่พอในคลังสินค้าดังกล่าว"
+    new_user: สร้างผู้ใช้ใหม่
+    new_variant: เพิ่มตัวแปรใหม่
+    new_zone: เพิ่มเขตใหม่
+    next: ถัดไป
+    no_actions_added: ไม่พบการสั่งการ
+    no_payment_found: 
+    no_pending_payments: ไม่พบรายการรอชำระ
+    no_products_found: ไม่พบสินค้า
+    no_resource_found: 
+    no_results: ไม่พบผลลัพท์
+    no_returns_found: 
+    no_rules_added: ไม่พบ rules
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: ไม่พบรายละเอียดของ Tracker
+    none: ว่าง
+    none_selected: 
+    normal_amount: ราคาปรกติ
+    not: ไม่
+    not_available: ไม่มี
+    not_enough_stock: จำนวนรายการสินค้าไม่พอในคลังสินค้าดังกล่าว
     not_found: "%{resource} นั้นไม่พบ"
-    note:
+    note: 
     notice_messages:
-      product_cloned: "สินค้าได้ถูกทำสำเนา"
-      product_deleted: "สินค้าได้ถูกลบแล้ว"
-      product_not_cloned: "สินค้าไม่สามารถทำสำเนาได้"
-      product_not_deleted: "สินค้าไม่สามารถถูกลบได้"
+      product_cloned: สินค้าได้ถูกทำสำเนา
+      product_deleted: สินค้าได้ถูกลบแล้ว
+      product_not_cloned: สินค้าไม่สามารถทำสำเนาได้
+      product_not_deleted: สินค้าไม่สามารถถูกลบได้
       variant_deleted: Variant has been deleted
-      variant_not_deleted: "ตัวแปรไม่สามารถถูกลบได้"
-    num_orders:
-    on_hand: "สินค้าในคลัง"
-    open: "เปิด"
-    open_all_adjustments: "เปิดรายการปรับปรุงทั้งหมด"
-    option_type: "ประเภทตัวเลือก"
-    option_type_placeholder: "เลือกประเภทตัวเลือก"
-    option_types: "ประเภทตัวเลือก"
-    option_value: "ค่าของตัวเลือก"
-    option_values: "ค่าของตัวเลือก"
-    optional: "ตัวเลือก"
-    options: "ตัวเลือก"
-    or: "หรือ"
+      variant_not_deleted: ตัวแปรไม่สามารถถูกลบได้
+    num_orders: 
+    on_hand: สินค้าในคลัง
+    open: เปิด
+    open_all_adjustments: เปิดรายการปรับปรุงทั้งหมด
+    option_type: ประเภทตัวเลือก
+    option_type_placeholder: เลือกประเภทตัวเลือก
+    option_types: ประเภทตัวเลือก
+    option_value: ค่าของตัวเลือก
+    option_values: ค่าของตัวเลือก
+    optional: ตัวเลือก
+    options: ตัวเลือก
+    or: หรือ
     or_over_price: "%{price} หรือมากกว่า"
-    order: "รายการ"
+    order: รายการ
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
-    order_details: "รายละเอียดการสั่งซื้อ"
-    order_email_resent: "ส่งอีเมลการสั่งซื้อใหม่"
-    order_information: "ข้อมูลการสั่งซื้อ"
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
+    order_details: รายละเอียดการสั่งซื้อ
+    order_email_resent: ส่งอีเมลการสั่งซื้อใหม่
+    order_information: ข้อมูลการสั่งซื้อ
     order_mailer:
       cancel_email:
-        dear_customer: "ถึงคุณลูกค้า,\\n"
-        instructions: "สินค้าของคุณได้ถูกยกเลิกแล้ว กรุณาเก็บหลักฐานอีเมลฉบับนี้เอาไว้ เพื่อใช้ในการอ้างอิงในอนาคต"
-        order_summary_canceled: "รายการที่สั่งซื้อ [ยกเลิก]"
-        subject: "การยกเลิกการสั่งซื้อ"
-        subtotal:
-        total:
+        dear_customer: ถึงคุณลูกค้า,\n
+        instructions: สินค้าของคุณได้ถูกยกเลิกแล้ว กรุณาเก็บหลักฐานอีเมลฉบับนี้เอาไว้ เพื่อใช้ในการอ้างอิงในอนาคต
+        order_summary_canceled: รายการที่สั่งซื้อ [ยกเลิก]
+        subject: การยกเลิกการสั่งซื้อ
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer: "ถึงคุณลูกค้า,\\n"
-        instructions: "กรุณาตรวจสอบและเก็บรายละเอียดการสั่งซื้อนี้เอาไว้"
-        order_summary: "รายการที่สั่งซื้อ"
-        subject: "ยืนยันการสั่งซื้อ"
-        subtotal:
-        thanks: "ขอขอบคุณที่ได้รับใช้คุณ"
-        total:
-    order_not_found: "เราไม่พบรายการสั่งซื้อของคุณ กรุณาลองใหม่อีกครั้ง"
-    order_number: "รหัสสั่งซื้อ %{number}"
-    order_processed_successfully: "รายการสั่งซื้อของคุณถูกดำเนินการเรียบร้อยแล้ว"
-    order_resumed:
+        dear_customer: ถึงคุณลูกค้า,\n
+        instructions: กรุณาตรวจสอบและเก็บรายละเอียดการสั่งซื้อนี้เอาไว้
+        order_summary: รายการที่สั่งซื้อ
+        subject: ยืนยันการสั่งซื้อ
+        subtotal: 
+        thanks: ขอขอบคุณที่ได้รับใช้คุณ
+        total: 
+    order_not_found: เราไม่พบรายการสั่งซื้อของคุณ กรุณาลองใหม่อีกครั้ง
+    order_number: รหัสสั่งซื้อ %{number}
+    order_processed_successfully: รายการสั่งซื้อของคุณถูกดำเนินการเรียบร้อยแล้ว
+    order_resumed: 
     order_state:
-      address: "ที่อยู่"
-      awaiting_return: "อยู่ในระหว่างการคืน"
-      canceled: "ยกเลิก"
-      cart: "ตะกร้า"
-      complete: "เสร็จสิ้น"
-      confirm: "ยืนยัน"
-      considered_risky:
-      delivery: "ส่งสินค้า"
-      payment: "ชำระเงิน"
-      resumed: "ต่อไป"
-      returned: "คืน"
-    order_summary: "รายการที่สั่งซื้อ"
-    order_sure_want_to: "คุณยืนยันว่าต้องการ %{event} กับรายการสั่งซื้อนี้?"
-    order_total: "ราคารวม"
-    order_updated: "รายการสั่งซื้อได้ถูกปรับปรุงแล้ว"
-    orders: "รายการสั่งซื้อ"
-    other_items_in_other:
-    out_of_stock: "สินค้าหมด"
-    overview: "ภาพรวม"
-    package_from: "สินค้าจาก"
+      address: ที่อยู่
+      awaiting_return: อยู่ในระหว่างการคืน
+      canceled: ยกเลิก
+      cart: ตะกร้า
+      complete: เสร็จสิ้น
+      confirm: ยืนยัน
+      considered_risky: 
+      delivery: ส่งสินค้า
+      payment: ชำระเงิน
+      resumed: ต่อไป
+      returned: คืน
+    order_summary: รายการที่สั่งซื้อ
+    order_sure_want_to: คุณยืนยันว่าต้องการ %{event} กับรายการสั่งซื้อนี้?
+    order_total: ราคารวม
+    order_updated: รายการสั่งซื้อได้ถูกปรับปรุงแล้ว
+    orders: รายการสั่งซื้อ
+    other_items_in_other: 
+    out_of_stock: สินค้าหมด
+    overview: ภาพรวม
+    package_from: สินค้าจาก
     pagination:
-      next_page: "หน้าต่อไป »"
+      next_page: หน้าต่อไป »
       previous_page: "« ก่อนก่อนนี้"
       truncate: "…"
-    password: "รหัสผ่าน"
-    paste: "แปะ"
+    password: รหัสผ่าน
+    paste: แปะ
     path: Path
-    pay: "ชำระ"
-    payment: "ชำระ"
-    payment_could_not_be_created:
-    payment_identifier:
-    payment_information: "ข้อมูลการชำระเงิน"
-    payment_method: "วิธีชำระเงิน"
-    payment_method_not_supported:
-    payment_methods: "วิธีชำระเงิน"
-    payment_processing_failed: "ไม่สามารถชำระเงินได้ กรุณาตรวจสอบข้อมูลที่คุณได้กรอกใหม่"
-    payment_processor_choose_banner_text: "หากคุณต้องการความช่วยเหลือในการตัดเงิน กรุณาไปยัง"
-    payment_processor_choose_link: "หน้าชำระเงิน"
-    payment_state: "สถานะการชำระเงิน"
+    pay: ชำระ
+    payment: ชำระ
+    payment_could_not_be_created: 
+    payment_identifier: 
+    payment_information: ข้อมูลการชำระเงิน
+    payment_method: วิธีชำระเงิน
+    payment_method_not_supported: 
+    payment_methods: วิธีชำระเงิน
+    payment_processing_failed: ไม่สามารถชำระเงินได้ กรุณาตรวจสอบข้อมูลที่คุณได้กรอกใหม่
+    payment_processor_choose_banner_text: หากคุณต้องการความช่วยเหลือในการตัดเงิน กรุณาไปยัง
+    payment_processor_choose_link: หน้าชำระเงิน
+    payment_state: สถานะการชำระเงิน
     payment_states:
-      balance_due: "จำนวนที่ค้าง"
+      balance_due: จำนวนที่ค้าง
       checkout: checkout
-      completed: "เสร็จสิ้น"
+      completed: เสร็จสิ้น
       credit_owed: credit owed
-      failed: "ผิดพลาด"
-      paid: "ชำระแล้ว"
-      pending: "รอ"
-      processing: "กำลังดำเนินการ"
+      failed: ผิดพลาด
+      paid: ชำระแล้ว
+      pending: รอ
+      processing: กำลังดำเนินการ
       void: void
-    payment_updated: "ได้ปรับปรุงการชำระเงินแล้ว"
-    payments: "รายการชำระเงิน"
-    pending:
-    percent: "เปอร์เซ็น"
-    percent_per_item: "เปอร์เซ็นต่อชิ้น"
+    payment_updated: ได้ปรับปรุงการชำระเงินแล้ว
+    payments: รายการชำระเงิน
+    pending: 
+    percent: เปอร์เซ็น
+    percent_per_item: เปอร์เซ็นต่อชิ้น
     permalink: Permalink
-    phone: "เบอร์โทรศัพท์"
-    place_order: "สั่งซื้อ"
-    please_define_payment_methods: "กรุณาเลือกวิธีการชำระก่อน"
-    populate_get_error: "เกิดข้อผิดพลาด กรุณาเพิ่มสินค้าใหม่อีกครั้ง"
-    powered_by: "สนับสนุนโดย"
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
-    presentation: "แสดง"
-    previous: "ก่อนหน้า"
-    previous_state_missing:
-    price: "ราคา"
-    price_range: "ราคาระหว่าง"
+    phone: เบอร์โทรศัพท์
+    place_order: สั่งซื้อ
+    please_define_payment_methods: กรุณาเลือกวิธีการชำระก่อน
+    populate_get_error: เกิดข้อผิดพลาด กรุณาเพิ่มสินค้าใหม่อีกครั้ง
+    powered_by: สนับสนุนโดย
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
+    presentation: แสดง
+    previous: ก่อนหน้า
+    previous_state_missing: 
+    price: ราคา
+    price_range: ราคาระหว่าง
     price_sack: Price Sack
     process: Process
-    product: "สินค้า"
-    product_details: "รายละเอียดสินค้า"
-    product_has_no_description: "สินค้าไม่มีรายละเอียด"
-    product_not_available_in_this_currency: "สินค้านี้ไม่รองรับสกุลเงินนี้"
-    product_properties: "สรรพคุณของสินค้า"
+    product: สินค้า
+    product_details: รายละเอียดสินค้า
+    product_has_no_description: สินค้าไม่มีรายละเอียด
+    product_not_available_in_this_currency: สินค้านี้ไม่รองรับสกุลเงินนี้
+    product_properties: สรรพคุณของสินค้า
     product_rule:
-      choose_products: "เลือกสินค้า"
-      label:
-      match_all: "ทั้งหมด"
-      match_any: "อย่างน้อยหนึ่ง"
-      match_none:
+      choose_products: เลือกสินค้า
+      label: 
+      match_all: ทั้งหมด
+      match_any: อย่างน้อยหนึ่ง
+      match_none: 
       product_source:
-        group: "จากกลุ่มของสินค้า"
-        manual: "เลือกเอง"
-    products: "สินค้า"
-    promotion: "โปรโมชั่น"
-    promotion_action: "ดำเนินการโปรโมชั่น"
+        group: จากกลุ่มของสินค้า
+        manual: เลือกเอง
+    products: สินค้า
+    promotion: โปรโมชั่น
+    promotion_action: ดำเนินการโปรโมชั่น
     promotion_action_types:
       create_adjustment:
         description: Creates a promotion credit adjustment on the order
-        name: "สร้างการปรับเปลี่ยน"
+        name: สร้างการปรับเปลี่ยน
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description: "สร้างตะกร้าสินค้าด้วยจำนวนที่กำหนดจากตัวแปร"
-        name: "สร้าง line items"
+        description: สร้างตะกร้าสินค้าด้วยจำนวนที่กำหนดจากตัวแปร
+        name: สร้าง line items
       free_shipping:
-        description:
-        name:
-    promotion_actions: "ดำเนินการ"
+        description: 
+        name: 
+    promotion_actions: ดำเนินการ
     promotion_form:
       match_policies:
-        all: "จับคู่ทั้งหมด"
-        any: "จับคู่อย่างใดอย่างหนึ่ง"
-    promotion_rule: "กฏของโปรโมชั่น"
+        all: จับคู่ทั้งหมด
+        any: จับคู่อย่างใดอย่างหนึ่ง
+    promotion_rule: กฏของโปรโมชั่น
     promotion_rule_types:
       first_order:
-        description: "ต้องเป็นรายการสั่งซื้อแรกเท่านั้น"
-        name: "รายการแรก"
+        description: ต้องเป็นรายการสั่งซื้อแรกเท่านั้น
+        name: รายการแรก
       item_total:
-        description: "จำนวนสั่งซื้อนั้นอยู่ในเกณฑ์ดังกล่าว"
-        name: "จำนวนทั้งหมด"
+        description: จำนวนสั่งซื้อนั้นอยู่ในเกณฑ์ดังกล่าว
+        name: จำนวนทั้งหมด
       landing_page:
-        description: "ลูกค้าต้องไปยังหน้าที่กำหนด"
+        description: ลูกค้าต้องไปยังหน้าที่กำหนด
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description: "รายการนั้นรวมสินค้าที่กำหนด"
-        name: "สินค้า"
+        description: รายการนั้นรวมสินค้าที่กำหนด
+        name: สินค้า
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
-        description: "เฉพาะลูกค้าที่กำหนด"
-        name: "ผู้ใช้"
+        description: เฉพาะลูกค้าที่กำหนด
+        name: ผู้ใช้
       user_logged_in:
-        description: "เฉพาะลูกค้าที่เข้าระบบ"
-        name: "ผู้ใช้ในระบบ"
-    promotion_uses:
-    promotionable:
-    promotions: "โปรโมชั่น"
-    propagate_all_variants:
-    properties: "คุณสมบัติ"
-    property: "คุณสมบัติ"
+        description: เฉพาะลูกค้าที่เข้าระบบ
+        name: ผู้ใช้ในระบบ
+    promotion_uses: 
+    promotionable: 
+    promotions: โปรโมชั่น
+    propagate_all_variants: 
+    properties: คุณสมบัติ
+    property: คุณสมบัติ
     prototype: Prototype
     prototypes: Prototypes
-    provider: "ผู้ให้บริการ"
-    provider_settings_warning: "หากคุณต้องการเปลี่ยนประเภทผู้ให้บริการ คุณจำเป็นต้องบันทึกรายการก่อนจึงจะสามารถแก้ไขค่าของผู้ให้บริการได้"
-    qty: "จำนวน"
-    quantity: "จำนวน"
-    quantity_returned: "จำนวนที่คืน"
-    quantity_shipped: "จำนวนที่ส่ง"
-    quick_search:
-    rate: "อัตรา"
-    reason: "เหตุผล"
-    receive: "ได้รับ"
-    receive_stock: "ได้รับสินค้า"
-    received: "ได้รับแล้ว"
-    reception_status:
-    reference: "อ้างอิง"
-    refund: "คืนเงิน"
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
-    register: "ลงทะเบียน"
-    registration: "ลงทะเบียน"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    provider: ผู้ให้บริการ
+    provider_settings_warning: หากคุณต้องการเปลี่ยนประเภทผู้ให้บริการ คุณจำเป็นต้องบันทึกรายการก่อนจึงจะสามารถแก้ไขค่าของผู้ให้บริการได้
+    qty: จำนวน
+    quantity: จำนวน
+    quantity_returned: จำนวนที่คืน
+    quantity_shipped: จำนวนที่ส่ง
+    quick_search: 
+    rate: อัตรา
+    reason: เหตุผล
+    receive: ได้รับ
+    receive_stock: ได้รับสินค้า
+    received: ได้รับแล้ว
+    reception_status: 
+    reference: อ้างอิง
+    refund: คืนเงิน
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
+    register: ลงทะเบียน
+    registration: ลงทะเบียน
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
-    remember_me: "จำฉัน"
-    remove: "ลบ"
-    rename: "เปลี่ยนชื่อ"
-    report:
-    reports: "รายงาน"
-    resend: "ส่งใหม่"
-    reset_password: "ตั้งรหัสผ่านใหม่"
-    response_code: "รหัสที่ได้รับ"
-    resume: "ทำต่อ"
-    resumed: "ทำต่อ"
-    return: "กลับ"
-    return_authorization: "รายการคืนสินค้า"
-    return_authorization_reasons:
-    return_authorization_updated: "รายการคืนสินค้าได้ปรับปรุงแล้ว"
-    return_authorizations: "รายการคืนสินค้า"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity: "จำนวนที่คืน"
-    returned: "คืน"
-    returns:
-    review: "ตรวจสอบ"
-    risk:
-    risk_analysis:
-    risky:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
+    remember_me: จำฉัน
+    remove: ลบ
+    rename: เปลี่ยนชื่อ
+    report: 
+    reports: รายงาน
+    resend: ส่งใหม่
+    reset_password: ตั้งรหัสผ่านใหม่
+    response_code: รหัสที่ได้รับ
+    resume: ทำต่อ
+    resumed: ทำต่อ
+    return: กลับ
+    return_authorization: รายการคืนสินค้า
+    return_authorization_reasons: 
+    return_authorization_updated: รายการคืนสินค้าได้ปรับปรุงแล้ว
+    return_authorizations: รายการคืนสินค้า
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
+    return_quantity: จำนวนที่คืน
+    returned: คืน
+    returns: 
+    review: ตรวจสอบ
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
-    roles: "หน้าที่"
-    rules: "กฏ"
-    safe:
-    sales_total: "ยอดขายรวม"
-    sales_total_description: "ยอดขายรวมสำหรับรายการที่สั่งซื้อทั้งหมด"
-    sales_totals: "ยอดขายรวม"
-    save_and_continue: "บันทึกและดำเนินการต่อ"
-    save_my_address:
-    say_no: "ไม่"
-    say_yes: "ถูกต้อง"
+    roles: หน้าที่
+    rules: กฏ
+    safe: 
+    sales_total: ยอดขายรวม
+    sales_total_description: ยอดขายรวมสำหรับรายการที่สั่งซื้อทั้งหมด
+    sales_totals: ยอดขายรวม
+    save_and_continue: บันทึกและดำเนินการต่อ
+    save_my_address: 
+    say_no: ไม่
+    say_yes: ถูกต้อง
     scope: Scope
-    search: "ค้นหา"
-    search_results: "ผลลัพท์การค้นหาของ '%{keywords}'"
-    searching: "กำลังค้นหา"
+    search: ค้นหา
+    search_results: ผลลัพท์การค้นหาของ '%{keywords}'
+    searching: กำลังค้นหา
     secure_connection_type: Secure Connection Type
-    security_settings: "ตั้งค่าความปลอดภัย"
-    select: "เลือก"
-    select_a_return_authorization_reason:
-    select_a_stock_location:
-    select_from_prototype: "เลือกจาก Prototype"
-    select_stock: "เลือกจากคลัง"
-    send_copy_of_all_mails_to: "ส่งสำเนาไปยัง"
-    send_mails_as: "ส่งเมลด้วย"
-    server: "เซิร์ฟเวอร์"
-    server_error: "เซิร์ฟเวอร์ส่งข้อผิดพลาด"
-    settings: "ตั้งค่า"
-    ship: "ส่ง"
-    ship_address: "ที่อยู่���่งของ"
-    ship_total: "ค่าจัดส่ง"
-    shipment: "การส่ง"
-    shipment_adjustments:
-    shipment_details:
+    security_settings: ตั้งค่าความปลอดภัย
+    select: เลือก
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
+    select_from_prototype: เลือกจาก Prototype
+    select_stock: เลือกจากคลัง
+    send_copy_of_all_mails_to: ส่งสำเนาไปยัง
+    send_mails_as: ส่งเมลด้วย
+    server: เซิร์ฟเวอร์
+    server_error: เซิร์ฟเวอร์ส่งข้อผิดพลาด
+    settings: ตั้งค่า
+    ship: ส่ง
+    ship_address: ที่อยู่���่งของ
+    ship_total: ค่าจัดส่ง
+    shipment: การส่ง
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer: "ถึงคุณลูกค้า,\\n"
-        instructions: "รายการสั่งซื้อของคุณได้ทำการจัดส่งแล้ว"
-        shipment_summary: "สรุปรายการส่งสินค้า"
-        subject: "การแจ้งเตือนการส่งสินค้า"
-        thanks: "ขอขอบพระคุณสำหรับการสั่งซื้อกับเรา"
-        track_information: "หมายเลขการติดตามสถานะการส่งสินค้า: %{tracking}"
-        track_link: "ลิ้งไปยังหน้าสถานะ: %{url}"
-    shipment_state: "สถานะการจัดส่ง"
+        dear_customer: ถึงคุณลูกค้า,\n
+        instructions: รายการสั่งซื้อของคุณได้ทำการจัดส่งแล้ว
+        shipment_summary: สรุปรายการส่งสินค้า
+        subject: การแจ้งเตือนการส่งสินค้า
+        thanks: ขอขอบพระคุณสำหรับการสั่งซื้อกับเรา
+        track_information: 'หมายเลขการติดตามสถานะการส่งสินค้า: %{tracking}'
+        track_link: 'ลิ้งไปยังหน้าสถานะ: %{url}'
+    shipment_state: สถานะการจัดส่ง
     shipment_states:
-      backorder: "พร้อมจัดส่ง"
-      canceled:
-      partial: "บางส่วน"
-      pending: "รอ"
-      ready: "พร้อม"
-      shipped: "ส่งแล้ว"
-    shipment_transfer_error:
-    shipment_transfer_success:
-    shipments: "การจัดส่ง"
-    shipped: "ส่งแล้ว"
-    shipping: "ส่ง"
-    shipping_address: "ที่อยู่การจัดส่ง"
-    shipping_categories: "ประเภทการจัดส่ง"
-    shipping_category: "ประเภทการจัดส่ง"
-    shipping_flat_rate_per_item: "อัตราสุทธิต่อชิ้น"
-    shipping_flat_rate_per_order: "อัตราสุทธิ"
-    shipping_flexible_rate: "อัตราแปรผั่นต่อชิ้น"
-    shipping_instructions: "ขั้นตอนการจัดส่ง"
-    shipping_method: "วิธีการจัดส่ง"
-    shipping_methods: "วิธีการจัดส่ง"
+      backorder: พร้อมจัดส่ง
+      canceled: 
+      partial: บางส่วน
+      pending: รอ
+      ready: พร้อม
+      shipped: ส่งแล้ว
+    shipment_transfer_error: 
+    shipment_transfer_success: 
+    shipments: การจัดส่ง
+    shipped: ส่งแล้ว
+    shipping: ส่ง
+    shipping_address: ที่อยู่การจัดส่ง
+    shipping_categories: ประเภทการจัดส่ง
+    shipping_category: ประเภทการจัดส่ง
+    shipping_flat_rate_per_item: อัตราสุทธิต่อชิ้น
+    shipping_flat_rate_per_order: อัตราสุทธิ
+    shipping_flexible_rate: อัตราแปรผั่นต่อชิ้น
+    shipping_instructions: ขั้นตอนการจัดส่ง
+    shipping_method: วิธีการจัดส่ง
+    shipping_methods: วิธีการจัดส่ง
     shipping_price_sack: Price sack
-    shipping_total:
-    shop_by_taxonomy: "ซื้อโดย %{taxonomy}"
-    shopping_cart: "ตะกร้าสินค้า"
-    show: "แสดง"
-    show_active: "แสดงที่ใช้งานอยู่"
-    show_deleted: "แสดงที่ลบ"
-    show_only_complete_orders: "แสดงรายการสั่งซื้อที่สมบูรณ์"
-    show_only_considered_risky:
-    show_rate_in_label: "แสดงอัตรา"
-    sku:
-    skus:
-    slug:
-    source: "จาก"
-    special_instructions: "วิธี"
-    split: "แยก"
-    spree_gateway_error_flash_for_checkout: "เกิดปัญหาขึ้นกับข้อมูลการชำระเงินของคุณ กรุณาตรวจสอบข้อมูลการชำระเงินของคุณแล้วลองใหม่"
+    shipping_total: 
+    shop_by_taxonomy: ซื้อโดย %{taxonomy}
+    shopping_cart: ตะกร้าสินค้า
+    show: แสดง
+    show_active: แสดงที่ใช้งานอยู่
+    show_deleted: แสดงที่ลบ
+    show_only_complete_orders: แสดงรายการสั่งซื้อที่สมบูรณ์
+    show_only_considered_risky: 
+    show_rate_in_label: แสดงอัตรา
+    sku: 
+    skus: 
+    slug: 
+    source: จาก
+    special_instructions: วิธี
+    split: แยก
+    spree_gateway_error_flash_for_checkout: เกิดปัญหาขึ้นกับข้อมูลการชำระเงินของคุณ กรุณาตรวจสอบข้อมูลการชำระเงินของคุณแล้วลองใหม่
     ssl:
-      change_protocol:
-    start: "เริ่ม"
-    state: "จังหวัด"
-    state_based: "จังหวัดที่ตั้ง"
+      change_protocol: 
+    start: เริ่ม
+    state: จังหวัด
+    state_based: จังหวัดที่ตั้ง
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states: "จังหวัด"
-    states_required: "จังหวัดที่ต้องการ"
-    status: "สถานะ"
-    stock:
-    stock_location: "สถานที่ของคลังสินค้า"
-    stock_location_info: "ข้อมูลของคลังสินค้า"
-    stock_locations: "สถานที่ของคลังสินค้า"
-    stock_locations_need_a_default_country:
-    stock_management: "การจัดการคลังสินค้า"
-    stock_management_requires_a_stock_location: "กรุณาสร้างคลังสินค้าเพื่อที่จะสามารถบริหารคลังได้"
-    stock_movements: "สินค้าเคลื่อนไหว"
-    stock_movements_for_stock_location: "สินค้าเคลื่อนไหวของ %{stock_location_name}"
-    stock_successfully_transferred: "สินค้าได้ย้ายไปยังคลังที่ต้องการแล้ว"
-    stock_transfer: "ย้ายสินค้า"
-    stock_transfers: "ย้ายสินค้า"
-    stop: "หยุด"
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
+    states: จังหวัด
+    states_required: จังหวัดที่ต้องการ
+    status: สถานะ
+    stock: 
+    stock_location: สถานที่ของคลังสินค้า
+    stock_location_info: ข้อมูลของคลังสินค้า
+    stock_locations: สถานที่ของคลังสินค้า
+    stock_locations_need_a_default_country: 
+    stock_management: การจัดการคลังสินค้า
+    stock_management_requires_a_stock_location: กรุณาสร้างคลังสินค้าเพื่อที่จะสามารถบริหารคลังได้
+    stock_movements: สินค้าเคลื่อนไหว
+    stock_movements_for_stock_location: สินค้าเคลื่อนไหวของ %{stock_location_name}
+    stock_successfully_transferred: สินค้าได้ย้ายไปยังคลังที่ต้องการแล้ว
+    stock_transfer: ย้ายสินค้า
+    stock_transfers: ย้ายสินค้า
+    stop: หยุด
     store: Store
-    street_address: "ที่อยู่"
-    street_address_2: "ที่อยู่ (ต่อ)"
-    subtotal: "ยอด"
-    subtract: "หักออก"
-    success:
+    street_address: ที่อยู่
+    street_address_2: ที่อยู่ (ต่อ)
+    subtotal: ยอด
+    subtract: หักออก
+    success: 
     successfully_created: "%{resource} นั้นได้สร้างเรียบร้อยแล้ว"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} นั้นได้ถูกลบเรียบร้อยแล้ว"
-    successfully_signed_up_for_analytics: "ได้สมัคร Spree Analytics เป็นที่เรียบร้อย"
+    successfully_signed_up_for_analytics: ได้สมัคร Spree Analytics เป็นที่เรียบร้อย
     successfully_updated: "%{resource} นั้นได้ปรับปรุงเรียบร้อยแล้ว"
-    summary:
-    tax: "ภาษี"
-    tax_categories: "ประเภทภาษี"
-    tax_category: "ประเภทภาษี"
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation: "อัตราภาษีนั้นเป็นทศนิยมเพื่อง่ายในการคำนวน (ตัวอย่าง, หากภาษีคือ 7% ให้ใส่ 0.07)"
-    tax_rates: "อัตราภาษี"
+    summary: 
+    tax: ภาษี
+    tax_categories: ประเภทภาษี
+    tax_category: ประเภทภาษี
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: อัตราภาษีนั้นเป็นทศนิยมเพื่อง่ายในการคำนวน (ตัวอย่าง, หากภาษีคือ 7% ให้ใส่ 0.07)
+    tax_rates: อัตราภาษี
     taxon: Taxon
-    taxon_edit: "แก้ไข Taxon"
-    taxon_placeholder: "เพิ่ม Taxon"
+    taxon_edit: แก้ไข Taxon
+    taxon_placeholder: เพิ่ม Taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Taxonomies
     taxonomy: Taxonomy
-    taxonomy_edit: "แก้ไข taxonomy"
-    taxonomy_tree_error: "รายการที่ขอเปลี่ยนแปลงไม่สามารถทำได้ และได้ทำการแก้ไขคืนดังเดิม โปรดลองอีกครั้ง"
+    taxonomy_edit: แก้ไข taxonomy
+    taxonomy_tree_error: รายการที่ขอเปลี่ยนแปลงไม่สามารถทำได้ และได้ทำการแก้ไขคืนดังเดิม โปรดลองอีกครั้ง
     taxonomy_tree_instruction: "* คลิกขวาที่ Child ใน Tree เพื่อเข้าเมนูในการเพิ่ม, ลบ หรือจัดรายการ Child"
     taxons: Taxons
-    test: "ทดสอบ"
+    test: ทดสอบ
     test_mailer:
       test_email:
-        greeting: "ยินดีด้วย!"
-        message: "หากคุณได้รับอีเมลฉบับนี้ แสดงว่าการตั้งค่าอีเมลของคุณนั้นถูกต้อง"
-        subject: "ทดสอบอีเมล"
-    test_mode: "โหมดทดสอบ"
-    thank_you_for_your_order: "ขอบคุณสำหรับการสั่งซื้อของคุณ กรุณาเก็บหน้านี้เอาไว้"
-    there_are_no_items_for_this_order: "ไม่พบรายการสินค้าในการสั่งซื้อนี้ กรุณาเพิ่มรายการสินค้าเพื่อทำการต่อ"
-    there_were_problems_with_the_following_fields: "เกิดปัญหากับ Field ดังกล่าว"
-    this_order_has_already_received_a_refund:
-    thumbnail: "รูป Thumnail"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time: "เวลา"
-    to_add_variants_you_must_first_define: "หากเพิ่มตัวแปร คุณต้องกำหนด"
-    total: "จำนวน"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+        greeting: ยินดีด้วย!
+        message: หากคุณได้รับอีเมลฉบับนี้ แสดงว่าการตั้งค่าอีเมลของคุณนั้นถูกต้อง
+        subject: ทดสอบอีเมล
+    test_mode: โหมดทดสอบ
+    thank_you_for_your_order: ขอบคุณสำหรับการสั่งซื้อของคุณ กรุณาเก็บหน้านี้เอาไว้
+    there_are_no_items_for_this_order: ไม่พบรายการสินค้าในการสั่งซื้อนี้ กรุณาเพิ่มรายการสินค้าเพื่อทำการต่อ
+    there_were_problems_with_the_following_fields: เกิดปัญหากับ Field ดังกล่าว
+    this_order_has_already_received_a_refund: 
+    thumbnail: รูป Thumnail
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: เวลา
+    to_add_variants_you_must_first_define: หากเพิ่มตัวแปร คุณต้องกำหนด
+    total: จำนวน
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Tracking
     tracking_number: Tracking Number
     tracking_url: Tracking URL
-    tracking_url_placeholder: "ตัวอย่าง http://quickship.com/package?num=:tracking"
-    transaction_id:
-    transfer_from_location: "ย้ายจาก"
-    transfer_stock: "ย้ายสินค้า"
-    transfer_to_location: "ย้ายไป"
+    tracking_url_placeholder: ตัวอย่าง http://quickship.com/package?num=:tracking
+    transaction_id: 
+    transfer_from_location: ย้ายจาก
+    transfer_stock: ย้ายสินค้า
+    transfer_to_location: ย้ายไป
     tree: Tree
-    type: "ประเภท"
-    type_to_search: "พิมพ์เพื่อค้นหา"
-    unable_to_connect_to_gateway: "ไม่สามารถติดต่อกับ Gateway"
-    unable_to_create_reimbursements:
-    under_price: "ไม่เกิน %{price}"
-    unlock: "ปลดล๊อก"
-    unrecognized_card_type: "ไม่รู้จักบัตรประเภทนี้"
-    unshippable_items: "สินค้าที่ไม่สามารถส่งได้"
-    update: "แก้ไข"
-    updating: "กำลังแก้ไข"
-    usage_limit: "ลิมิตการใช้"
-    use_app_default:
-    use_billing_address: "ใช้ที่อยู่ที่ออกใบเสร็จ"
-    use_new_cc: "ใช้บัตรใบใหม่"
-    use_s3: "ใช้ Amazon S3 สำหรับรูปภาพ"
-    user: "ผู้ใช้"
+    type: ประเภท
+    type_to_search: พิมพ์เพื่อค้นหา
+    unable_to_connect_to_gateway: ไม่สามารถติดต่อกับ Gateway
+    unable_to_create_reimbursements: 
+    under_price: ไม่เกิน %{price}
+    unlock: ปลดล๊อก
+    unrecognized_card_type: ไม่รู้จักบัตรประเภทนี้
+    unshippable_items: สินค้าที่ไม่สามารถส่งได้
+    update: แก้ไข
+    updating: กำลังแก้ไข
+    usage_limit: ลิมิตการใช้
+    use_app_default: 
+    use_billing_address: ใช้ที่อยู่ที่ออกใบเสร็จ
+    use_new_cc: ใช้บัตรใบใหม่
+    use_s3: ใช้ Amazon S3 สำหรับรูปภาพ
+    user: ผู้ใช้
     user_rule:
-      choose_users: "เลือกผู้ใช้"
-    users: "ผู้ใช้"
+      choose_users: เลือกผู้ใช้
+    users: ผู้ใช้
     validation:
-      cannot_be_less_than_shipped_units: "ไม่สามารถน้อยกว่าจำนวนในการจัดส่ง"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_be_less_than_shipped_units: ไม่สามารถน้อยกว่าจำนวนในการจัดส่ง
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: exceeds available stock. Please ensure line items have a valid quantity.
-      is_too_large: "นั้นใหญ่เกินไป -- สินค้าในมือไม่สามารถรองรับจำนวนที่ต้องการได้"
-      must_be_int: "ต้องเป็นเลขจำนวนเต็ม"
-      must_be_non_negative: "ต้องเป็นค่าที่ไม่ติดลบ"
-      unpaid_amount_not_zero:
-    value: "ค่า"
-    variant: "ตัวแปร"
-    variant_placeholder: "เลือกตัวแปร"
-    variants: "ตัวแปร"
-    version: "เวอร์ชั่น"
+      is_too_large: นั้นใหญ่เกินไป -- สินค้าในมือไม่สามารถรองรับจำนวนที่ต้องการได้
+      must_be_int: ต้องเป็นเลขจำนวนเต็ม
+      must_be_non_negative: ต้องเป็นค่าที่ไม่ติดลบ
+      unpaid_amount_not_zero: 
+    value: ค่า
+    variant: ตัวแปร
+    variant_placeholder: เลือกตัวแปร
+    variants: ตัวแปร
+    version: เวอร์ชั่น
     void: Void
-    weight: "น้ำหนัก"
-    what_is_a_cvv: "อะไรคือ (CVV) บนบัตรเครดิต?"
-    what_is_this: "นี่คืออะไร"
-    width: "กว้าง"
-    year: "ปี"
-    you_have_no_orders_yet: "คุณยังไม่มีรายการสั่งซื้อ"
-    your_cart_is_empty: "ตะกร้าคุณว่างเปล่า"
-    your_order_is_empty_add_product: "คุณไม่มีรายการสั่งซื้อ กรุณาค้นหาและเพิ่มสินค้าด้านบน"
-    zip: "รหัสไปรษณีย์"
-    zipcode: "รหัสไปรษณีย์"
-    zone: "โซน"
-    zones: "โซน"
+    weight: น้ำหนัก
+    what_is_a_cvv: อะไรคือ (CVV) บนบัตรเครดิต?
+    what_is_this: นี่คืออะไร
+    width: กว้าง
+    year: ปี
+    you_have_no_orders_yet: คุณยังไม่มีรายการสั่งซื้อ
+    your_cart_is_empty: ตะกร้าคุณว่างเปล่า
+    your_order_is_empty_add_product: คุณไม่มีรายการสั่งซื้อ กรุณาค้นหาและเพิ่มสินค้าด้านบน
+    zip: รหัสไปรษณีย์
+    zipcode: รหัสไปรษณีย์
+    zone: โซน
+    zones: โซน

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,22 +1,23 @@
+---
 tr:
   activerecord:
     attributes:
       spree/address:
         address1: Adres
         address2: Adres (Devamı)
-        city: "Şehir"
-        country: "Ülke"
+        city: Şehir
+        country: Ülke
         firstname: Ad
         lastname: Soyad
         phone: Telefon
         state: Eyalet
         zipcode: Posta Kodu
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,7 +25,7 @@ tr:
         name: Ad
         numcode: ISO Kodu
       spree/credit_card:
-        base:
+        base: 
         cc_type: Tür
         month: Ay
         name: İsim Soyisim
@@ -40,7 +41,7 @@ tr:
         name: Ad
         presentation: Tanıtım
       spree/order:
-        checkout_complete: "Ödeme Tamamlandı"
+        checkout_complete: Ödeme Tamamlandı
         completed_at: Tamamlanma zamanı
         considered_risky: Riskli Olarak Belirtildi
         coupon_code: Kupon Kodu
@@ -49,9 +50,9 @@ tr:
         ip_address: IP Adresi
         item_total: Toplam Miktar
         number: Numara
-        payment_state: "Ödeme Bölgesi"
+        payment_state: Ödeme Bölgesi
         shipment_state: Kargo Bölgesi
-        special_instructions: "Özel Tanımlar"
+        special_instructions: Özel Tanımlar
         state: Bölge
         total: Toplam
       spree/order/bill_address:
@@ -95,7 +96,7 @@ tr:
         starts_at: Başlama Tarihi
         usage_limit: Kullanım Limiti
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Ad
         presentation: Tanıtım
@@ -109,20 +110,20 @@ tr:
         abbr: Kısaltma
         name: Ad
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Açıklama
         name: Ad
@@ -138,8 +139,8 @@ tr:
         name: Ad
       spree/user:
         email: E-posta
-        password: "Şifre"
-        password_confirmation: "Şifre Tekrarı"
+        password: Şifre
+        password_confirmation: Şifre Tekrarı
       spree/variant:
         cost_currency: Maliyet Kuru
         cost_price: Maliyet Fiyatı
@@ -157,97 +158,97 @@ tr:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
               card_expired: Kart süresi doldu
-              expiry_invalid:
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address: Adresler
-      spree/country: "Ülkeler"
+      spree/country: Ülkeler
       spree/credit_card: Kredi Kartları
-      spree/customer_return:
+      spree/customer_return: 
       spree/inventory_unit: Stok Birimi
       spree/line_item: Kalem
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: 
+      spree/option_value: 
       spree/order: Siparişler
-      spree/payment: "Ödemeler"
-      spree/payment_method:
-      spree/product: "Ürünler"
-      spree/promotion:
-      spree/promotion_category:
-      spree/property: "Özellikler"
+      spree/payment: Ödemeler
+      spree/payment_method: 
+      spree/product: Ürünler
+      spree/promotion: 
+      spree/promotion_category: 
+      spree/property: Özellikler
       spree/prototype: Prototipler
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization: Geri İade Yetkileri
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: 
       spree/role: Roller
       spree/shipment: Kargolar
       spree/shipping_category: Kargo Kategorileri
-      spree/shipping_method:
+      spree/shipping_method: 
       spree/state: Bölgeler
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category: Vergi Sınıfları
       spree/tax_rate: Vergi Oranları
       spree/taxon: Gruplar
       spree/taxonomy: Gruplandırmalar
-      spree/tracker:
+      spree/tracker: 
       spree/user: Kullanıcılar
-      spree/variant: "Çeşitler"
+      spree/variant: Çeşitler
       spree/zone: Bölgeler
   spree:
     abbreviation: Kısaltma
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Hesap
     account_updated: Hesap güncellendi
     action: Hareket
     actions:
-      cancel: "İptal"
+      cancel: İptal
       continue: Devam Et
       create: Oluştur
       destroy: Sil
@@ -255,21 +256,21 @@ tr:
       list: Liste
       listing: Listeleme
       new: Yeni
-      refund:
+      refund: 
       save: Kaydet
       update: Güncelle
     activate: Etkinleştirme
     active: Etkin
     add: Ekle
     add_action_of_type: Hareket tipi ekle
-    add_country: "Ülke ekle"
-    add_coupon_code:
+    add_country: Ülke ekle
+    add_coupon_code: 
     add_new_header: Yeni başlık ekle
     add_new_style: Yeni biçim ekle
     add_one: Yeni ekle
     add_option_value: Seçenek Değeri Ekle
-    add_product: "Ürün Ekle"
-    add_product_properties: "Ürün Özellikleri Ekle"
+    add_product: Ürün Ekle
+    add_product_properties: Ürün Özellikleri Ekle
     add_rule_of_type: Yeni kural tipi ekle
     add_state: Bölge ekle
     add_stock: Stok Ekle
@@ -279,7 +280,7 @@ tr:
     additional_item: Ek parça maliyeti
     address1: Adres
     address2: Adres(Devamı)
-    adjustable:
+    adjustable: 
     adjustment: Kredi
     adjustment_amount: Miktar
     adjustment_successfully_closed: Kredi başarıyla kapatıldı!
@@ -291,34 +292,34 @@ tr:
         configuration: Ayarlar
         option_types: Seçenek Tipleri
         orders: Siparişler
-        overview: "Ön izleme"
-        products: "Ürünler"
+        overview: Ön izleme
+        products: Ürünler
+        promotion_categories: 
         promotions: Promosyonlar
-        promotion_categories:
-        properties: "Özellikler"
+        properties: Özellikler
         prototypes: Prototipler
         reports: Raporlar
-        taxonomies:
-        taxons:
+        taxonomies: 
+        taxons: 
         users: Kullanıcılar
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Yönetim
-    advertise:
+    advertise: 
     agree_to_privacy_policy: Gizlilik Politikasını kabul ediyorum
     agree_to_terms_of_service: Hizmet Sözleşmesini kabul ediyorum
     all: Tümü
     all_adjustments_closed: Tüm krediler başarıyla kapatıldı!
     all_adjustments_opened: Tüm Krediler başarıyla açıldı!
     all_departments: Tüm Birimler
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Geliştirme ve deneme aşamalarında SSL kullanımına izin ver
     allow_ssl_in_production: Gerçek satış aşamasında SSL kullanımına izin ver
     allow_ssl_in_staging: Devreye alma aşamasında SSL kullanımına izin ver
@@ -334,99 +335,100 @@ tr:
     analytics_desc_list_4: Tamamen ücretsiz!
     analytics_trackers: Analiz İzleyicileri
     and: ve
-    approve:
-    approved_at:
-    approver:
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Emin misiniz?
     are_you_sure_delete: Bu kaydı silmek istediğnizden emin misiniz?
     associated_adjustment_closed: Bağlı kredi kapatıldı ve tekrar hesaplanmayacak. Tekrar açmak ister misiniz?
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Yetkilendirme Hatası
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Geliş Tarihi
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Geri
     back_end: Arkaplan
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Mağazaya Geri Dön
     back_to_users_list: Kullanıcı Listesine Geri Dön
-    backorderable: "İade Edilebilir"
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable: İade Edilebilir
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Kalan Bakiye
-    base_amount:
-    base_percent:
+    base_amount: 
+    base_percent: 
     bill_address: Fatura Adresi
     billing: Fatura
     billing_address: Fatura Adresi
     both: Her ikisi
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Hesap Makinesi
-    calculator_settings_warning: Hesaplayıcı tipini değiştirirseniz, Hesap makinesi ayarlarını düzenleyebilmek için önce yaptığınız değişiklikleri kaydetmelisiniz.
+    calculator_settings_warning: Hesaplayıcı tipini değiştirirseniz, Hesap makinesi ayarlarını düzenleyebilmek için önce yaptığınız değişiklikleri
+      kaydetmelisiniz.
     cancel: iptal
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: "Ödeme yöntemi tanımlanmadan bir ödeme oluşturamazsınız."
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: Ödeme yöntemi tanımlanmadan bir ödeme oluşturamazsınız.
     cannot_create_returns: 'Bu sipariş kargolanmış bir ürün içermediğinden geri dönderilemez. '
     cannot_perform_operation: Bu işlem gerçekleştirilemez.
     cannot_set_shipping_method_without_address: Müşteri detayları belirtilmedikçe kargo yöntemi seçilemez.
     capture: Yakala
-    capture_events:
+    capture_events: 
     card_code: Kart Kodu
     card_number: Kart Numarası
-    card_type:
+    card_type: 
     card_type_is: Kart Tipi
     cart: Sepet
     cart_subtotal: Ara Toplam
     categories: Kategoriler
     category: Kategori
-    charged:
+    charged: 
     check_for_spree_alerts: Spree uyarılarını denetle
-    checkout: "Ödeme"
+    checkout: Ödeme
     choose_a_customer: Bir müşteri seç
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Kur Seç
     choose_dashboard_locale: Kontrol Paneli Dili Seç
     choose_location: Yer Seç
-    city: "Şehir"
+    city: Şehir
     clear_cache: Önbelleği Temizle
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
-    clone: "Çoğalt"
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
+    clone: Çoğalt
     close: Kapat
     close_all_adjustments: Tüm kredileri kapat
     code: Kod
-    company: "Şirket"
+    company: Şirket
     complete: tamamı
     configuration: Ayarlama
     configurations: Ayarlamalar
     confirm: Onay
     confirm_delete: Silme İşlemini Onayla
-    confirm_password: "Şifre Onayı"
+    confirm_password: Şifre Onayı
     continue: Devam Et
     continue_shopping: Alışverişe Devam et
     cost_currency: Maliyet Kuru
     cost_price: Maliyet Fiyatı
     could_not_connect_to_jirafe: Jirafe eşleme verilerine ulaşılamıyor. Daha sonra otomatik olarak tekrar denenecek.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: Stok hareketi kaydedilirken bir sorun oluştu. Lütfen daha sonra tekrar deneyiniz.
     count_on_hand: Elde olan miktar
-    countries: "Ülkeler"
-    country: "Ülke"
-    country_based: "Ülke Tabanlı"
+    countries: Ülkeler
+    country: Ülke
+    country_based: Ülke Tabanlı
     country_name: Ad
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
     coupon: Kupon
     coupon_code: Kupon kodu
     coupon_code_already_applied: Girdiğiniz kupon kodu bu siparişe önceden uygulandı
@@ -436,7 +438,7 @@ tr:
     coupon_code_max_usage: Kupon kodu kullanma limitine ulaşıldı
     coupon_code_not_eligible: Kupon kodu bu siparişe uygulanabilir değil
     coupon_code_not_found: Girdiğiniz kupon kodu bulunamadı. Lütfen tekrar deneyiniz.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Oluştur
     create_a_new_account: Yeni hesap oluştur
     create_new_order: Yeni sipariş oluştur
@@ -446,7 +448,7 @@ tr:
     credit_card: Kredi Kartı
     credit_cards: Kredi Kartları
     credit_owed: Kredi Borcu
-    credits:
+    credits: 
     currency: Kur
     currency_decimal_mark: Ondalık ayırıcı işareti
     currency_settings: Kur Ayarları
@@ -457,16 +459,16 @@ tr:
     customer: Müşteri
     customer_details: Müşteri Ayrıntıları
     customer_details_updated: Müşteri Ayrıntıları Güncellendi
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Müşteri Arama
     cut: Kes
-    cvv_response:
+    cvv_response: 
     dash:
       jirafe:
         app_id: Uygulama ID
         app_token: Uygulama Belirteci
-        currently_unavailable:
+        currently_unavailable: 
         explanation: Eğer yönetim panelinden Jirafe ile kayıt ol seçeneğini seçtiyseniz, aşağıdaki alanlar otomatik doldurulmuş olabilir.
         header: Jirafe Analizleri Ayarları
         site_id: Site ID
@@ -475,45 +477,45 @@ tr:
     date: Tarih
     date_completed: Tarih Tamamlandı
     date_picker:
-      first_day:
+      first_day: 
       format: "%d.%m%Y"
       js_format: dd.mm.yyyy
     date_range: Tarih Aralığı
     default: Varsayılan
-    default_refund_amount:
+    default_refund_amount: 
     default_tax: Varsayılan Vergi
     default_tax_zone: Varsayılan Vergi Bölgesi
     delete: Sil
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Teslimat
     depth: Derinlik
     description: Açıklama
     destination: Gideceği Yer
     destroy: Sil
     details: Ayrıntılar
-    discount_amount: "İndirim Miktarı"
+    discount_amount: İndirim Miktarı
     dismiss_banner: Hayır. Teşekkürler! İlgilenmiyorum, bu mesajı tekrar gösterme.
     display: Göster
     display_currency: Kurları göster
     doesnt_track_inventory: Stok takip edilemiyor
     edit: Düzenle
     editing_resource: Kaynak düzenleniyor
-    editing_rma_reason:
+    editing_rma_reason: 
     editing_user: Kullanıcı Düzenleme
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
         missing_product: Ürün bulunamadı
         missing_taxon: Sınıflandırma bulunamadı
-        no_applicable_products:
+        no_applicable_products: 
         no_matching_taxons: Eşleşen ürün yok
-        no_user_or_email_specified:
-        no_user_specified:
+        no_user_or_email_specified: 
+        no_user_specified: 
         not_first_order: İlk sipariş değil
     email: E-posta
     empty: Boş
@@ -544,30 +546,32 @@ tr:
         user:
           signup: Kullanıcı girişi
     exceptions:
-      count_on_hand_setter: recalculate_count_on_hand geri çağrım işlevi tarafından otomatik olarak ayarlandığından, count_on_hand değeri elle değiştirilemez. Bunun yerine update_column(:count_on_hand, value) işlevini kullanın.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: >-
+        recalculate_count_on_hand geri çağrım işlevi tarafından otomatik olarak ayarlandığından, count_on_hand değeri elle değiştirilemez. Bunun
+        yerine update_column(:count_on_hand, value) işlevini kullanın.
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Geçerlilik
     extension: Eklenti
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Dosya adı
     fill_in_customer_info: Lütfen müşteri bilgilerini giriniz.
     filter_results: Süzgeç Sonuçları
     finalize: Sonlandır
     finalized: Sonlandırldı
     find_a_taxon: Bir sınıflandırma bul
-    first_item: "İlk Parça Maliyeti"
-    first_name: "İsim"
-    first_name_begins_with: "İsmi Şununla Başlayan"
+    first_item: İlk Parça Maliyeti
+    first_name: İsim
+    first_name_begins_with: İsmi Şununla Başlayan
     flat_percent: Sabit Yüzde
     flat_rate_per_order: Sabit Oran (sipariş bazlı)
     flexible_rate: Esnek Oran
-    forgot_password: "Şifrenizi mi Unuttunuz?"
-    free_shipping: "Ücretsiz Kargo"
-    free_shipping_amount:
-    front_end: "Ön Yüz"
+    forgot_password: Şifrenizi mi Unuttunuz?
+    free_shipping: Ücretsiz Kargo
+    free_shipping_amount: 
+    front_end: Ön Yüz
     gateway: Yöntem
     gateway_config_unavailable: Bu ortam için yöntem geçerli değil
     gateway_error: Yöntem Hatası
@@ -590,34 +594,34 @@ tr:
     identifier: Belirteç
     image: Resim
     images: Resimler
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
     inactive: Pasif
     incl: dahil
     included_in_price: Fiyata eklenmiş
     included_price_validation: Varsayılan Vergi Bölgesi ayarlanmadan seçilemez
     incomplete: Tamamlanmamış
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
     instructions_to_reset_password: Lütfen aşağıdaki forma e-posta adresinizi giriniz.
     insufficient_stock: Bu üründen istenilen miktarda bulunmuyor, sadece %{on_hand} adet elde bulunmaktadır.
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: E-posta Adresini Engelle
     intercept_email_instructions: E-posta adresini yoksay ve bu adresle değiştir.
     internal_name: dahili isim
     invalid_credit_card: Geçersiz kredi kartı
-    invalid_exchange_variant:
+    invalid_exchange_variant: 
     invalid_payment_provider: Geçersiz ödeme sağlayıcı.
     invalid_promotion_action: Geçersiz promosyon hareketi.
     invalid_promotion_rule: Geçersiz promosyon kuralı.
     inventory: Stok
     inventory_adjustment: Stok Kredisi
     inventory_error_flash_for_insufficient_quantity: Sepetinizde bulunan bir ürün artık temin edilemiyor.
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: belirtilen adrese gönderilememektedir
     iso_name: Iso Adı
-    item: "Ürün"
-    item_description: "Ürün Açıklaması"
+    item: Ürün
+    item_description: Ürün Açıklaması
     item_total: Toplam Ürün
     item_total_rule:
       operators:
@@ -626,9 +630,9 @@ tr:
         lt: küçüktür
         lte: küçük eşittir
     items_cannot_be_shipped: Seçtiğiniz ülkeye gönderim yapılamamaktadır
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Yol
@@ -636,7 +640,7 @@ tr:
     last_name_begins_with: Soyismi Şununla Başlayan
     learn_more: Daha Fazla
     lifetime_stats: tüm zaman istatistikleri
-    line_item_adjustments:
+    line_item_adjustments: 
     list: Liste
     loading: Yükleniyor
     locale_changed: Dil Değiştirildi
@@ -645,26 +649,26 @@ tr:
     log_entries: Log kayıtları
     logged_in_as: 'Açılan Oturum: '
     logged_in_succesfully: Giriş Başarılı
-    logged_out: "Çıkış Yaptınız."
+    logged_out: Çıkış Yaptınız.
     login: Giriş
     login_as_existing: Varolan bir müşteri hesabıyla giriş yap
     login_failed: Giriş başarısız.
     login_name: Giriş
-    logout: "Çıkış"
+    logout: Çıkış
     logs: Loglar
     look_for_similar_items: Benzer ürünlere bak
     make_refund: Geri ödeme Yap
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Ana Fiyat
     match_choices:
       all: Tümü
       none: Hiçbiri
     max_items: En fazla Ürün
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Meta Açıklaması
     meta_keywords: Meta Kelimeleri
     meta_title: Meta Başlığı
@@ -675,14 +679,14 @@ tr:
     move_stock_between_locations: Stoğu Konumlar Arası Taşı
     my_account: Hesabım
     my_orders: Siparişlerim
-    name: "İsim"
+    name: İsim
     name_on_card: Kart Üzerindeki İsim
-    name_or_sku: "İsim ya da SKU (en az 4 karakter giriniz)"
+    name_or_sku: İsim ya da SKU (en az 4 karakter giriniz)
     new: Yeni
     new_adjustment: Yeni Kredi
     new_country: Yeni Ülke
     new_customer: Yeni Müşteri
-    new_customer_return:
+    new_customer_return: 
     new_image: Yeni Resim
     new_option_type: Yeni Seçenek Tipi
     new_order: Yeni Sipariş
@@ -698,7 +702,7 @@ tr:
     new_refund_reason: Yeni Geri Ödeme Sebebi
     new_return_authorization: Yeni İade İzni
     new_rma_reason: Yeni İade Sebebi
-    new_shipment_at_location:
+    new_shipment_at_location: 
     new_shipping_category: Yeni Kargo Kategorisi
     new_shipping_method: Yeni Kargo Yöntemi
     new_state: Yeni Bölge
@@ -720,10 +724,10 @@ tr:
     no_products_found: Hiçbir Ürün Bulunamadı
     no_resource_found: Kayıt bulunamadı
     no_results: Sonuç yok
-    no_returns_found:
+    no_returns_found: 
     no_rules_added: Hiçbir kural eklenmedi
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: Hiçbir izleyici ayrıntısı belirtilmedi.
     none: Hiçbiri
     none_selected: Hiçbiri Seçili Değil
@@ -734,10 +738,10 @@ tr:
     not_found: "%{resource} bulunamadı"
     note: Not
     notice_messages:
-      product_cloned: "Ürün çoğaltıldı"
-      product_deleted: "Ürün silindi"
-      product_not_cloned: "Ürün çoğaltılamadı"
-      product_not_deleted: "Ürün silinemedi"
+      product_cloned: Ürün çoğaltıldı
+      product_deleted: Ürün silindi
+      product_not_cloned: Ürün çoğaltılamadı
+      product_not_deleted: Ürün silinemedi
       variant_deleted: Değişken silindi
       variant_not_deleted: Değişken silinemedi
     num_orders: Sipariş Sayısı
@@ -749,30 +753,28 @@ tr:
     option_types: Seçenek Tipleri
     option_value: Seçenek Değeri
     option_values: Seçenek Değerleri
-    optional: "İsteğe Bağlı"
+    optional: İsteğe Bağlı
     options: Seçenekler
     or: veya
     or_over_price: "%{price} veya daha fazlası"
     order: Sipariş
     order_adjustments: Sipariş kredileri
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Sipariş Ayrıntıları
     order_email_resent: Sipariş E-postasını Tekrar Gönder
     order_information: Sipariş Bilgisi
     order_mailer:
       cancel_email:
-        dear_customer: |
-          Sayın Müşterimiz,
+        dear_customer: Sayın Müşterimiz,
         instructions: Siparişiniz iptal edilmiştir. Kayıtlarınız için lütfen iptal etme işleminin bilgilerini saklayınız.
         order_summary_canceled: Sipariş Özeti[İPTAL]
         subject: Sipariş İptal Etme
-        subtotal:
-        total:
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer: |
-          Değerli Müşterimiz,
+        dear_customer: Değerli Müşterimiz,
         instructions: Lütfen aşağıdaki sipariş bilgilerini gözden geçiriniz ve kayıtlarınız için saklayınız.
         order_summary: Sipariş Özeti
         subject: Sipariş Onayı
@@ -782,7 +784,7 @@ tr:
     order_not_found: Siparişinizi bulamadık. Lütfen tekrar deneyiniz.
     order_number: Sipariş Numarası
     order_processed_successfully: Siparişiniz başarıyla işlenmiştir.
-    order_resumed:
+    order_resumed: 
     order_state:
       address: adres bilgileri
       awaiting_return: dönüş bekleniyor
@@ -800,7 +802,7 @@ tr:
     order_total: Sipariş Toplamı
     order_updated: Sipariş Güncellendi
     orders: Siparişler
-    other_items_in_other:
+    other_items_in_other: 
     out_of_stock: Stokta Yok
     overview: Gözden Geçirme
     package_from: kimden
@@ -808,68 +810,68 @@ tr:
       next_page: sonraki sayfa »
       previous_page: "« önceki sayfa"
       truncate: "…"
-    password: "Şifre"
+    password: Şifre
     paste: Yapıştır
     path: Yol
-    pay: "öde"
-    payment: "Ödeme"
+    pay: öde
+    payment: Ödeme
     payment_could_not_be_created: Ödeme oluşturulamadı
     payment_identifier: Ödeme Kodu
-    payment_information: "Ödeme Bilgisi"
-    payment_method: "Ödeme Yöntemi"
+    payment_information: Ödeme Bilgisi
+    payment_method: Ödeme Yöntemi
     payment_method_not_supported: Ödeme yöntemi desteklenmiyor
-    payment_methods: "Ödeme Yöntemleri"
-    payment_processing_failed: "Ödeme gerçekleştirilemedi, lütfen girmiş olduğunuz bilgileri kontrol ediniz"
-    payment_processor_choose_banner_text: "Ödeme işlemi seçmekte zorlanıyorsanız, lütfen takip eden bağlantıya tıklayınız"
-    payment_processor_choose_link: "ödeme sayfamız"
-    payment_state: "Ödeme Durumu"
+    payment_methods: Ödeme Yöntemleri
+    payment_processing_failed: Ödeme gerçekleştirilemedi, lütfen girmiş olduğunuz bilgileri kontrol ediniz
+    payment_processor_choose_banner_text: Ödeme işlemi seçmekte zorlanıyorsanız, lütfen takip eden bağlantıya tıklayınız
+    payment_processor_choose_link: ödeme sayfamız
+    payment_state: Ödeme Durumu
     payment_states:
       balance_due: kalan borç
-      checkout: "ödeme"
+      checkout: ödeme
       completed: tamamlandı
       credit_owed: kredi borcu
       failed: başarısız
-      paid: "ödendi"
+      paid: ödendi
       pending: bekliyor
       processing: işleniyor
       void: geçersiz
-    payment_updated: "Ödeme Güncellendi"
-    payments: "Ödemeler"
-    pending:
+    payment_updated: Ödeme Güncellendi
+    payments: Ödemeler
+    pending: 
     percent: Yüzde
-    percent_per_item: "Ürün Başına Yüzde"
+    percent_per_item: Ürün Başına Yüzde
     permalink: Kalıcı Bağlantı
     phone: Telefon
     place_order: Sipariş Ver
     please_define_payment_methods: Lütfen önce bir ödeme yöntemi tanımlayın.
     populate_get_error: Bir hata oluştu. Lütfen ürün ekleme işlemini tekrar deneyin.
     powered_by: Geliştiren
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Tanıtım
-    previous: "Önceki"
+    previous: Önceki
     previous_state_missing: Önceki durum bulunamadı
     price: Fiyat
     price_range: Fiyat Aralığı
     price_sack: Fiyat Torbası
-    process: "İşlem"
-    product: "Ürün"
-    product_details: "Ürün Ayrıntıları"
+    process: İşlem
+    product: Ürün
+    product_details: Ürün Ayrıntıları
     product_has_no_description: Bu ürün hakkında bir açıklama yok
     product_not_available_in_this_currency: Bu ürün seçilen para birimi için geçerli değildir.
-    product_properties: "Ürün Özellikleri"
+    product_properties: Ürün Özellikleri
     product_rule:
-      choose_products: "Ürün seçin"
+      choose_products: Ürün seçin
       label: Etiket
       match_all: tümü
       match_any: en az bir
       match_none: hiçbiri
       product_source:
-        group: "Ürün grubundan"
+        group: Ürün grubundan
         manual: Elle seçim
-    products: "Ürünler"
+    products: Ürünler
     promotion: Promosyon
     promotion_action: Promosyon Hareketi
     promotion_action_types:
@@ -877,14 +879,14 @@ tr:
         description: Sipariş için bir promosyon kredisi oluşturur
         name: Kredi oluştur
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
         description: Sepeti tanımlanmış değişkenlerle doldurur
         name: Sıralı ürünler oluştur
       free_shipping:
-        description:
-        name:
+        description: 
+        name: 
     promotion_actions: Hareketler
     promotion_form:
       match_policies:
@@ -894,41 +896,42 @@ tr:
     promotion_rule_types:
       first_order:
         description: Müşterinin ilk siparişi olmak zorundadır
-        name: "İlk sipariş"
+        name: İlk sipariş
       item_total:
         description: Sipariş toplamı bu şartları sağlamalıdır
-        name: "Ürün toplamı"
+        name: Ürün toplamı
       landing_page:
         description: Müşteri tanımlanmış olan bir sayfayı ziyaret etmelidir
         name: Açılış Sayfası
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
         description: Sipariş sadece tanımlanmış ürünleri içerir
-        name: "Ürün(ler)"
+        name: Ürün(ler)
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
         description: Sadece belirli kullanıcılar için kullanılabilir
         name: Kullanıcı
       user_logged_in:
         description: Sadece giriş yapmış kullanıcılar için kullanılabilir
         name: Kullanıcı Giriş yaptı
-    promotion_uses:
-    promotionable:
+    promotion_uses: 
+    promotionable: 
     promotions: Promosyonlar
-    propagate_all_variants:
-    properties: "Özellikler"
-    property: "Özellik"
+    propagate_all_variants: 
+    properties: Özellikler
+    property: Özellik
     prototype: Prototip
     prototypes: Prototipler
     provider: Sağlayıcı
-    provider_settings_warning: Sağlayıcı tipini değiştirirseniz, sağlayıcı ayarlarını değiştirebilmek için öncelikle değişiklikleri kaydetmeniz gerekmektedir
+    provider_settings_warning: Sağlayıcı tipini değiştirirseniz, sağlayıcı ayarlarını değiştirebilmek için öncelikle değişiklikleri kaydetmeniz
+      gerekmektedir
     qty: Miktar
     quantity: Miktar
     quantity_returned: Dönen Miktar
@@ -939,68 +942,68 @@ tr:
     receive: alınan
     receive_stock: Gelen Stok
     received: Gelen
-    reception_status:
+    reception_status: 
     reference: Referans
     refund: Geri Ödeme
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
     register: Kayıt ol
     registration: Kayıt
     reimburse: Ödemeyi iade et
     reimbursed: Ödeme iade edildi
-    reimbursement:
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Beni hatırla
     remove: Kaldır
     rename: Yeniden adlandır
     report: Rapor
     reports: Raporlar
     resend: Tekrar Gönder
-    reset_password: "Şifremi Sıfırla"
+    reset_password: Şifremi Sıfırla
     response_code: Yanıt Kodu
     resume: devam
     resumed: Devam Eden
     return: iade
-    return_authorization: "İade Yönetimi"
-    return_authorization_reasons:
-    return_authorization_updated: "İade yönetimi güncellendi"
-    return_authorizations: "İade Yönetimleri"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity: "İade Miktarı"
-    returned: "İade Edilmiş"
-    returns:
+    return_authorization: İade Yönetimi
+    return_authorization_reasons: 
+    return_authorization_updated: İade yönetimi güncellendi
+    return_authorizations: İade Yönetimleri
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
+    return_quantity: İade Miktarı
+    returned: İade Edilmiş
+    returns: 
     review: Gözden Geçir
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit: "İade(RMA) Kredisi"
-    rma_number: "İade(RMA) Numarası"
-    rma_value: "İade(RMA) Değeri"
+    risk: 
+    risk_analysis: 
+    risky: 
+    rma_credit: İade(RMA) Kredisi
+    rma_number: İade(RMA) Numarası
+    rma_value: İade(RMA) Değeri
     roles: Roller
     rules: Kurallar
     safe: Güvenli
@@ -1018,8 +1021,8 @@ tr:
     secure_connection_type: Güvenli Bağlantı Tipi
     security_settings: Güvenlik Ayarları
     select: Seç
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Prototipten Seç
     select_stock: Stok Seç
     send_copy_of_all_mails_to: Tüm e-postaların bir kopyasını şuraya gönder
@@ -1031,12 +1034,11 @@ tr:
     ship_address: Kargo Adresi
     ship_total: Kargo Toplamı
     shipment: Kargo
-    shipment_adjustments:
+    shipment_adjustments: 
     shipment_details: Kargo Detayları
     shipment_mailer:
       shipped_email:
-        dear_customer: |
-          Değerli Müşterimiz,
+        dear_customer: Değerli Müşterimiz,
         instructions: Siparişiniz kargoya verildi
         shipment_summary: Kargo Özeti
         subject: Kargo Bildirimi
@@ -1073,17 +1075,17 @@ tr:
     show_active: Aktifleri Göster
     show_deleted: Silinmişleri Göster
     show_only_complete_orders: Sadece tamamlanmış siparişleri göster
-    show_only_considered_risky:
+    show_only_considered_risky: 
     show_rate_in_label: Etikette oranı göster
     sku: Stok Kodu
     skus: Stok Kodları
     slug: slug
     source: Kaynak
-    special_instructions: "Özel Açıklamalar"
+    special_instructions: Özel Açıklamalar
     split: Ayır
-    spree_gateway_error_flash_for_checkout: "Ödeme bilgilerinizle alakalı bir sorun oluştu. Lütfen bilgilerinizi kontrol ederek tekrar deneyiniz."
+    spree_gateway_error_flash_for_checkout: Ödeme bilgilerinizle alakalı bir sorun oluştu. Lütfen bilgilerinizi kontrol ederek tekrar deneyiniz.
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Başlangıç
     state: Bölge
     state_based: Bölge Tabanlı
@@ -1091,34 +1093,34 @@ tr:
       accepted: kabul edildi
       address: adres
       authorized: yetkilendirildi
-      awaiting:
-      awaiting_return:
+      awaiting: 
+      awaiting_return: 
       backordered: önsipariş verildi
       canceled: iptal edildi
       cart: sepet
-      checkout:
+      checkout: 
       closed: kapandı
-      complete:
+      complete: 
       completed: tamamlandı
       confirm: onayla
       delivery: teslimat
       errored: hatalı
       failed: hatalı
-      given_to_customer:
+      given_to_customer: 
       invalid: geçersiz
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Bölgeler
     states_required: Zorunlu Bölgeler
     status: Durum
@@ -1126,9 +1128,9 @@ tr:
     stock_location: Stok Bölgesi
     stock_location_info: Stok bölge bilgisi
     stock_locations: Stok Bölgeleri
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: 
     stock_management: Stok Yönetimi
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: 
     stock_movements: Stok Hareketleri
     stock_movements_for_stock_location: "%{stock_location_name} bölgesi için stok hareketleri"
     stock_successfully_transferred: Stok bölgeler arasında başarıyla aktarıldı.
@@ -1139,33 +1141,33 @@ tr:
     street_address: Adres Satırı
     street_address_2: Adres Satırı (Devamı)
     subtotal: Alt toplam
-    subtract: "Çıkart"
-    success:
+    subtract: Çıkart
+    success: 
     successfully_created: "%{resource} başarıyla oluşturuldu!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} başarıyla kaldırıldı!"
     successfully_signed_up_for_analytics: Spree Analizleri için kayıt başarıyla tamamlandı
     successfully_updated: "%{resource} başarıyla güncellendi!"
-    summary:
+    summary: 
     tax: Vergi
     tax_categories: Vergi Sınıfları
     tax_category: Vergi Sınıfı
-    tax_code:
-    tax_included:
+    tax_code: 
+    tax_included: 
     tax_rate_amount_explanation: Vergi oranları hesaplamalarda ondalık olarak kullanılır.(örneğin vergi oranı %18 ise 0.18 girin)
     tax_rates: Vergi Oranları
     taxon: Grup
     taxon_edit: Grup Düzenle
     taxon_placeholder: Grup Ekle
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Gruplandırmalar
     taxonomy: Gruplandırma
     taxonomy_edit: Gruplandırma düzenle
-    taxonomy_tree_error: "İstenilen değişiklikler kabul edilmedi ve ağaç bir önceki durumuna geri döndürüldü, lütfen tekrar deneyin."
+    taxonomy_tree_error: İstenilen değişiklikler kabul edilmedi ve ağaç bir önceki durumuna geri döndürüldü, lütfen tekrar deneyin.
     taxonomy_tree_instruction: "* Ağaç üzerindeki bir girdinin sırasını değiştirmek yada silmek için girdiye sağ tıklayın."
     taxons: Gruplar
     test: Deneme
@@ -1176,34 +1178,34 @@ tr:
         subject: Deneme Postası
     test_mode: Deneme Modu
     thank_you_for_your_order: Alışverişiniz için teşekkürler. Lütfen kayıtlarınızda tutmak için bu bilgi sayfasının bir kopyasını saklayınız.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: 
     there_were_problems_with_the_following_fields: Aşağıdaki alanlarla ilgili sorunlar var
-    this_order_has_already_received_a_refund:
-    thumbnail: "Önizleme"
-    tiered_flat_rate:
-    tiered_percent:
+    this_order_has_already_received_a_refund: 
+    thumbnail: Önizleme
+    tiered_flat_rate: 
+    tiered_percent: 
     tiers: Katmanlar
     time: Zaman
     to_add_variants_you_must_first_define: Değişken eklemeden önce değişkeni tanımlamanız gerekmektedir
     total: Toplam
-    total_per_item:
-    total_pre_tax_refund:
+    total_per_item: 
+    total_pre_tax_refund: 
     total_price: Toplam Fiyat
-    total_sales:
+    total_sales: 
     track_inventory: Stoğu takip et
     tracking: Takip
     tracking_number: Takip Numarası
     tracking_url: Takip URL'si
-    tracking_url_placeholder: "örnek: http://kargocum.com/paket_takip?takip_no=:takipno"
-    transaction_id:
+    tracking_url_placeholder: 'örnek: http://kargocum.com/paket_takip?takip_no=:takipno'
+    transaction_id: 
     transfer_from_location: Buradan Aktar
     transfer_stock: Stok Aktar
     transfer_to_location: Buraya Aktar
     tree: Agaç
     type: Tip
     type_to_search: Aranacak tip
-    unable_to_connect_to_gateway: "Ödeme sağlayıcıya bağlanılamıyor."
-    unable_to_create_reimbursements:
+    unable_to_connect_to_gateway: Ödeme sağlayıcıya bağlanılamıyor.
+    unable_to_create_reimbursements: 
     under_price: "%{price} Altı"
     unlock: Kilit Çöz
     unrecognized_card_type: Tanımlanamayan kart tipi
@@ -1211,7 +1213,7 @@ tr:
     update: Güncelle
     updating: Güncelleme
     usage_limit: Kullanım Limiti
-    use_app_default:
+    use_app_default: 
     use_billing_address: Fatura Adresini Kullan
     use_new_cc: Yeni bir kart kullan
     use_s3: Resimler için Amazon S3 kullan
@@ -1221,12 +1223,12 @@ tr:
     users: Kullanıcılar
     validation:
       cannot_be_less_than_shipped_units: kargolanmış ürün sayısından daha az olamaz.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: elde olan stok aşıldı. İstenilen ürün miktarının geçerli miktarda olduğundan emin olun.
-      is_too_large: "çok fazla -- eldeki stok istenilen miktarı karşılayacak kadar yeterli değil!"
+      is_too_large: çok fazla -- eldeki stok istenilen miktarı karşılayacak kadar yeterli değil!
       must_be_int: bir sayı olmak zorundadır
       must_be_non_negative: negatif olmayan bir değer olmalıdır
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Değer
     variant: Değişken
     variant_placeholder: Bir varyant seçin

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,1436 +1,1445 @@
+---
 uk:
   activerecord:
     attributes:
       spree/address:
-        address1: "Адреса"
-        address2: "Адреса (2-й рядок)"
-        city: "Місто"
-        country: "Країна"
-        firstname: "Ім’я"
-        lastname: "Прізвище"
-        phone: "Телефон"
-        state: "Регіон/Область"
-        zipcode: "Індекс"
+        address1: Адреса
+        address2: Адреса (2-й рядок)
+        city: Місто
+        country: Країна
+        firstname: Ім’я
+        lastname: Прізвище
+        phone: Телефон
+        state: Регіон/Область
+        zipcode: Індекс
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount: "Базова сума"
-        preferred_tiers: "Рівні"
+        preferred_base_amount: Базова сума
+        preferred_tiers: Рівні
       spree/calculator/tiered_percent:
-        preferred_base_percent: "Базовий відсоток"
-        preferred_tiers: "Рівні"
+        preferred_base_percent: Базовий відсоток
+        preferred_tiers: Рівні
       spree/country:
         iso: ISO
         iso3: ISO3
-        iso_name: "Назва згідно ISO"
-        name: "Назва"
-        numcode: "Код ISO"
+        iso_name: Назва згідно ISO
+        name: Назва
+        numcode: Код ISO
       spree/credit_card:
-        base:
-        cc_type: "Тип"
-        month: "Місяць"
-        name: "Назва"
-        number: "Номер"
-        verification_value: "Код перевірки (CVV/CVC)"
-        year: "Рік"
+        base: 
+        cc_type: Тип
+        month: Місяць
+        name: Назва
+        number: Номер
+        verification_value: Код перевірки (CVV/CVC)
+        year: Рік
       spree/inventory_unit:
-        state: "Стан"
+        state: Стан
       spree/line_item:
-        price: "Ціна"
-        quantity: "Кількість"
+        price: Ціна
+        quantity: Кількість
       spree/option_type:
-        name: "Назва"
-        presentation: "Відобразити як"
+        name: Назва
+        presentation: Відобразити як
       spree/order:
-        checkout_complete: "Оформлення замовлення завершено"
-        completed_at: "Завершено в"
-        considered_risky: "Вважається ризикованим"
-        coupon_code: "Код купона"
-        created_at: "Дата замовлення"
+        checkout_complete: Оформлення замовлення завершено
+        completed_at: Завершено в
+        considered_risky: Вважається ризикованим
+        coupon_code: Код купона
+        created_at: Дата замовлення
         email: E-Mail клієнта
         ip_address: IP адреса
-        item_total: "Разом без знижки"
-        number: "Номер"
-        payment_state: "Стан оплати"
-        shipment_state: "Стан відправлення"
-        special_instructions: "Додаткові інструкції"
-        state: "Стан"
-        total: "Разом"
+        item_total: Разом без знижки
+        number: Номер
+        payment_state: Стан оплати
+        shipment_state: Стан відправлення
+        special_instructions: Додаткові інструкції
+        state: Стан
+        total: Разом
       spree/order/bill_address:
-        address1: "Платіжна адреса. Вулиця"
-        city: "Платіжна адреса. Місто"
-        firstname: "Платіжна адреса. Ім’я"
-        lastname: "Платіжна адреса. Прізвище"
-        phone: "Платіжна адреса. Телефон"
-        state: "Платіжна адреса. Регіон/Область"
-        zipcode: "Платіжна адреса. Індекс"
+        address1: Платіжна адреса. Вулиця
+        city: Платіжна адреса. Місто
+        firstname: Платіжна адреса. Ім’я
+        lastname: Платіжна адреса. Прізвище
+        phone: Платіжна адреса. Телефон
+        state: Платіжна адреса. Регіон/Область
+        zipcode: Платіжна адреса. Індекс
       spree/order/ship_address:
-        address1: "Адреса доставки. Вулиця"
-        city: "Адреса доставки. Місто"
-        firstname: "Адреса доставки. Ім’я"
-        lastname: "Адреса доставки. Прізвище"
-        phone: "Адреса доставки. Телефон"
-        state: "Адреса доставки. Регіон/Область"
-        zipcode: "Адреса доставки. Індекс"
+        address1: Адреса доставки. Вулиця
+        city: Адреса доставки. Місто
+        firstname: Адреса доставки. Ім’я
+        lastname: Адреса доставки. Прізвище
+        phone: Адреса доставки. Телефон
+        state: Адреса доставки. Регіон/Область
+        zipcode: Адреса доставки. Індекс
       spree/payment:
-        amount: "Сума"
+        amount: Сума
       spree/payment_method:
-        name: "Назва"
+        name: Назва
       spree/product:
-        available_on: "Доступний на"
-        cost_currency: "Валюта"
-        cost_price: "Собівартість"
-        description: "Опис"
-        master_price: "Ціна за замовчуванням"
-        name: "Назва"
-        on_hand: "Вільний залишок"
-        shipping_category: "Категорія доставки"
-        tax_category: "Податкова категорія"
+        available_on: Доступний на
+        cost_currency: Валюта
+        cost_price: Собівартість
+        description: Опис
+        master_price: Ціна за замовчуванням
+        name: Назва
+        on_hand: Вільний залишок
+        shipping_category: Категорія доставки
+        tax_category: Податкова категорія
       spree/promotion:
-        advertise: "Рекламувати"
-        code: "Код купона"
-        description: "Опис"
-        event_name: "Назва події"
-        expires_at: "Дата завершення"
-        name: "Назва"
-        path: "Шлях"
-        starts_at: "Дата початку"
-        usage_limit: "Ліміт використань"
+        advertise: Рекламувати
+        code: Код купона
+        description: Опис
+        event_name: Назва події
+        expires_at: Дата завершення
+        name: Назва
+        path: Шлях
+        starts_at: Дата початку
+        usage_limit: Ліміт використань
       spree/promotion_category:
-        name: "Назва"
+        name: Назва
       spree/property:
-        name: "Назва"
-        presentation: "Відображати як"
+        name: Назва
+        presentation: Відображати як
       spree/prototype:
-        name: "Назва"
+        name: Назва
       spree/return_authorization:
-        amount: "Сума"
+        amount: Сума
       spree/role:
-        name: "Назва"
+        name: Назва
       spree/state:
-        abbr: "Абревіатура"
-        name: "Назва"
+        abbr: Абревіатура
+        name: Назва
       spree/store:
-        mail_from_address: "E-mail адреса в полі 'Від кого'"
+        mail_from_address: E-mail адреса в полі 'Від кого'
         meta_description: Meta Description
         meta_keywords: Meta Keywords
-        name: "Назва сайту"
+        name: Назва сайту
         seo_title: SEO-заголовок
         url: URL сайту
       spree/tax_category:
-        description: "Опис"
-        name: "Назва"
+        description: Опис
+        name: Назва
       spree/tax_rate:
-        amount: "Податкова ставка"
-        included_in_price: "Включено в ціну"
-        show_rate_in_label: "Показувати ставку в мітці"
+        amount: Податкова ставка
+        included_in_price: Включено в ціну
+        show_rate_in_label: Показувати ставку в мітці
       spree/taxon:
-        name: "Назва"
-        permalink: "Постійне посилання"
-        position: "Позиція"
+        name: Назва
+        permalink: Постійне посилання
+        position: Позиція
       spree/taxonomy:
-        name: "Назва"
+        name: Назва
       spree/user:
-        email: "Електронна пошта"
-        password: "Пароль"
-        password_confirmation: "Підтвердження пароля"
+        email: Електронна пошта
+        password: Пароль
+        password_confirmation: Підтвердження пароля
       spree/variant:
-        cost_currency: "Валюта"
-        cost_price: "Собівартість"
-        depth: "Глибина"
-        height: "Висота"
-        price: "Ціна"
-        sku: "Артикул"
-        weight: "Вага"
-        width: "Ширина"
+        cost_currency: Валюта
+        cost_price: Собівартість
+        depth: Глибина
+        height: Висота
+        price: Ціна
+        sku: Артикул
+        weight: Вага
+        width: Ширина
       spree/zone:
-        description: "Опис"
-        name: "Назва"
+        description: Опис
+        name: Назва
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: "Ключі рівнів повинні бути числами, більшими за 0"
+              keys_should_be_positive_number: Ключі рівнів повинні бути числами, більшими за 0
             preferred_tiers:
-              should_be_hash: "повинно бути хешем"
+              should_be_hash: повинно бути хешем
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: "Ключі рівнів повинні бути числами, більшими за 0"
-              values_should_be_percent: "Значення рівнів починні бути процентами між 0% та 100%"
+              keys_should_be_positive_number: Ключі рівнів повинні бути числами, більшими за 0
+              values_should_be_percent: Значення рівнів починні бути процентами між 0% та 100%
             preferred_tiers:
-              should_be_hash: "повинно бути хешем"
+              should_be_hash: повинно бути хешем
         spree/classification:
           attributes:
             taxon_id:
-              already_linked: "уже прив’язаний до цього товару"
+              already_linked: уже прив’язаний до цього товару
         spree/credit_card:
           attributes:
             base:
-              card_expired: "Термін дії карти завершився"
-              expiry_invalid: "Термін дії невірний"
+              card_expired: Термін дії карти завершився
+              expiry_invalid: Термін дії невірний
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency: "Повинна відповідати валюті замовлення"
+              must_match_order_currency: Повинна відповідати валюті замовлення
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed: "більше дозволеної суми."
+              greater_than_allowed: більше дозволеної суми.
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match: "Одна або більше позицій повернення не належить до того ж замовлення, що відшкодування."
+              return_items_order_id_does_not_match: Одна або більше позицій повернення не належить до того ж замовлення, що відшкодування.
         spree/return_item:
           attributes:
             inventory_unit:
               other_completed_return_item_exists: "%{inventory_unit_id} уже має повернення %{return_item_id}"
             reimbursement:
-              cannot_be_associated_unless_accepted: "не можна прив’язати до позиції, яка не була прийнята."
+              cannot_be_associated_unless_accepted: не можна прив’язати до позиції, яка не була прийнята.
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store: "неможливо видалити магазин за замовчуванням"
+              cannot_destroy_default_store: неможливо видалити магазин за замовчуванням
     models:
       spree/address:
-        few: "Адреси"
-        many: "Адрес"
-        one: "Адреса"
-        other: "Адрес"
+        few: Адреси
+        many: Адрес
+        one: Адреса
+        other: Адрес
       spree/country:
-        few: "Країни"
-        many: "Країн"
-        one: "Країна"
-        other: "Країн"
+        few: Країни
+        many: Країн
+        one: Країна
+        other: Країн
       spree/credit_card:
-        few: "Кредитні картки"
-        many: "Кредитних карток"
-        one: "Кредитна картка"
-        other: "Кредитних карток"
+        few: Кредитні картки
+        many: Кредитних карток
+        one: Кредитна картка
+        other: Кредитних карток
       spree/customer_return:
-        few: "Повернення від покупця"
-        many: "Повернень від покупця"
-        one: "Повернення від покупця"
-        other: "Повернень від покупця"
+        few: Повернення від покупця
+        many: Повернень від покупця
+        one: Повернення від покупця
+        other: Повернень від покупця
       spree/inventory_unit:
-        few: "Розміщення позиції замовлення"
-        many: "Розміщень позиції замовлення"
-        one: "Розміщення позиції замовлення"
-        other: "Розміщень позиції замовлення"
+        few: Розміщення позиції замовлення
+        many: Розміщень позиції замовлення
+        one: Розміщення позиції замовлення
+        other: Розміщень позиції замовлення
       spree/line_item:
-        few: "Позиції замовлення"
-        many: "Позицій замовлення"
-        one: "Позиція замовлення"
-        other: "Позицій замовлення"
+        few: Позиції замовлення
+        many: Позицій замовлення
+        one: Позиція замовлення
+        other: Позицій замовлення
       spree/option_type:
-        few: "Характеристики"
-        many: "Характеристик"
-        one: "Характеристика"
-        other: "Характеристик"
+        few: Характеристики
+        many: Характеристик
+        one: Характеристика
+        other: Характеристик
       spree/option_value:
-        few: "Значення характеристики"
-        many: "Значень характеристики"
-        one: "Значення характеристики"
-        other: "Значень характеристики"
+        few: Значення характеристики
+        many: Значень характеристики
+        one: Значення характеристики
+        other: Значень характеристики
       spree/order:
-        few: "Замовлення"
-        many: "Замовлень"
-        one: "Замовлення"
-        other: "Замовлень"
+        few: Замовлення
+        many: Замовлень
+        one: Замовлення
+        other: Замовлень
       spree/payment:
-        few: "Платежа"
-        many: "Платежів"
-        one: "Платіж"
-        other: "Платежів"
+        few: Платежа
+        many: Платежів
+        one: Платіж
+        other: Платежів
       spree/payment_method:
-        few: "Способи оплати"
-        many: "Способів оплати"
-        one: "Спосіб оплати"
-        other: "Способів оплати"
+        few: Способи оплати
+        many: Способів оплати
+        one: Спосіб оплати
+        other: Способів оплати
       spree/product:
-        few: "Товари"
-        many: "Товарів"
-        one: "Товар"
-        other: "Товарів"
+        few: Товари
+        many: Товарів
+        one: Товар
+        other: Товарів
       spree/promotion:
-        few: "Промоакції"
-        many: "Промоакцій"
-        one: "Промоакція"
-        other: "Промоакцій"
+        few: Промоакції
+        many: Промоакцій
+        one: Промоакція
+        other: Промоакцій
       spree/promotion_category:
-        few: "Категорії промоакцій"
-        many: "Категорій промоакцій"
-        one: "Категорія промоакцій"
-        other: "Категорій промоакцій"
+        few: Категорії промоакцій
+        many: Категорій промоакцій
+        one: Категорія промоакцій
+        other: Категорій промоакцій
       spree/property:
-        few: "Властивості"
-        many: "Властивостей"
-        one: "Властивість"
-        other: "Властивостей"
+        few: Властивості
+        many: Властивостей
+        one: Властивість
+        other: Властивостей
       spree/prototype:
-        few: "Прототипи"
-        many: "Прототипів"
-        one: "Прототип"
-        other: "Прототипів"
+        few: Прототипи
+        many: Прототипів
+        one: Прототип
+        other: Прототипів
       spree/refund_reason:
-        few: "Підстави повернення грошей"
-        many: "Підстав повернення грошей"
-        one: "Підстава повернення грошей"
-        other: "Підстав повернення грошей"
+        few: Підстави повернення грошей
+        many: Підстав повернення грошей
+        one: Підстава повернення грошей
+        other: Підстав повернення грошей
       spree/reimbursement:
-        few: "Відшкодування"
-        many: "Відшкодувань"
-        one: "Відшкодування"
-        other: "Відшкодувань"
+        few: Відшкодування
+        many: Відшкодувань
+        one: Відшкодування
+        other: Відшкодувань
       spree/reimbursement_type:
-        few: "Типи відшкодування"
-        many: "Типів відшкодування"
-        one: "Тип відшкодування"
-        other: "Типів відшкодування"
+        few: Типи відшкодування
+        many: Типів відшкодування
+        one: Тип відшкодування
+        other: Типів відшкодування
       spree/return_authorization:
-        few: "Дозволи на повернення товару"
-        many: "Дозволів на повернення товару"
-        one: "Дозвіл на повернення товару"
-        other: "Дозволів на повернення товару"
+        few: Дозволи на повернення товару
+        many: Дозволів на повернення товару
+        one: Дозвіл на повернення товару
+        other: Дозволів на повернення товару
       spree/return_authorization_reason:
-        few: "Підстави дозволу на повернення товару"
-        many: "Підстав дозволу на повернення товару"
-        one: "Підстава дозволу на повернення товару"
-        other: "Підстав дозволу на повернення товару"
+        few: Підстави дозволу на повернення товару
+        many: Підстав дозволу на повернення товару
+        one: Підстава дозволу на повернення товару
+        other: Підстав дозволу на повернення товару
       spree/role:
-        few: "Ролі"
-        many: "Ролей"
-        one: "Роль"
-        other: "Ролей"
+        few: Ролі
+        many: Ролей
+        one: Роль
+        other: Ролей
       spree/shipment:
-        few: "Відправлення"
-        many: "Відправлень"
-        one: "Відправлення"
-        other: "Відправлень"
+        few: Відправлення
+        many: Відправлень
+        one: Відправлення
+        other: Відправлень
       spree/shipping_category:
-        few: "Категорії доставки"
-        many: "Категорій доставки"
-        one: "Категорія доставки"
-        other: "Категорій доставки"
+        few: Категорії доставки
+        many: Категорій доставки
+        one: Категорія доставки
+        other: Категорій доставки
       spree/shipping_method:
-        few: "Способи доставки"
-        many: "Способів доставки"
-        one: "Спосіб доставки"
-        other: "Способів доставки"
+        few: Способи доставки
+        many: Способів доставки
+        one: Спосіб доставки
+        other: Способів доставки
       spree/state:
-        few: "Регіони/Області"
-        many: "Регіонів/Областей"
-        one: "Регіон/Область"
-        other: "Регіонів/Областей"
+        few: Регіони/Області
+        many: Регіонів/Областей
+        one: Регіон/Область
+        other: Регіонів/Областей
       spree/stock: Залишок
       spree/stock_location:
-        few: "Склади"
-        many: "Складів"
-        one: "Склад"
-        other: "Складів"
+        few: Склади
+        many: Складів
+        one: Склад
+        other: Складів
       spree/stock_movement:
-        few: "Рухи залишків"
-        many: "Рухів залишків"
-        one: "Рух залишків"
-        other: "Рухів залишків"
+        few: Рухи залишків
+        many: Рухів залишків
+        one: Рух залишків
+        other: Рухів залишків
       spree/stock_transfer:
-        few: "Переміщеня залишків"
-        many: "Переміщень залишків"
-        one: "Переміщення залишків"
-        other: "Переміщення залишків"
+        few: Переміщеня залишків
+        many: Переміщень залишків
+        one: Переміщення залишків
+        other: Переміщення залишків
       spree/tax_category:
-        few: "Податкові категорії"
-        many: "Податкових категорій"
-        one: "Податкова категорія"
-        other: "Податкових категорій"
+        few: Податкові категорії
+        many: Податкових категорій
+        one: Податкова категорія
+        other: Податкових категорій
       spree/tax_rate:
-        few: "Податкові ставки"
-        many: "Податкових ставок"
-        one: "Податкова ставка"
-        other: "Податкових ставок"
+        few: Податкові ставки
+        many: Податкових ставок
+        one: Податкова ставка
+        other: Податкових ставок
       spree/taxon:
-        few: "Таксона"
-        many: "Таксонів"
-        one: "Таксон"
-        other: "Таксонів"
+        few: Таксона
+        many: Таксонів
+        one: Таксон
+        other: Таксонів
       spree/taxonomy:
-        few: "Таксономії"
-        many: "Таксономій"
-        one: "Таксономія"
-        other: "Таксономій"
+        few: Таксономії
+        many: Таксономій
+        one: Таксономія
+        other: Таксономій
       spree/tracker:
-        few: "Трекера веб-аналітики"
-        many: "Трекерів веб-аналітики"
-        one: "Трекер веб-аналітики"
-        other: "Трекерів веб-аналітики"
+        few: Трекера веб-аналітики
+        many: Трекерів веб-аналітики
+        one: Трекер веб-аналітики
+        other: Трекерів веб-аналітики
       spree/user:
-        few: "Користувача"
-        many: "Користувачів"
-        one: "Користувач"
-        other: "Користувачів"
+        few: Користувача
+        many: Користувачів
+        one: Користувач
+        other: Користувачів
       spree/variant:
-        few: "Варіанта"
-        many: "Варіантів"
-        one: "Варіант"
-        other: "Варіантів"
+        few: Варіанта
+        many: Варіантів
+        one: Варіант
+        other: Варіантів
       spree/zone:
-        few: "Зони"
-        many: "Зон"
-        one: "Зона"
-        other: "Зон"
+        few: Зони
+        many: Зон
+        one: Зона
+        other: Зон
   spree:
-    abbreviation: "Абревіатура"
-    accept: "Прийняти"
-    acceptance_errors: "Помилки прийому"
-    acceptance_status: "Стан прийому"
-    accepted: "Прийнято"
-    account: "Обліковий запис"
-    account_updated: "Обліковий запис оновлено!"
-    action: "Дія"
+    abbreviation: Абревіатура
+    accept: Прийняти
+    acceptance_errors: Помилки прийому
+    acceptance_status: Стан прийому
+    accepted: Прийнято
+    account: Обліковий запис
+    account_updated: Обліковий запис оновлено!
+    action: Дія
     actions:
-      cancel: "Скасувати"
-      continue: "Продовжити"
-      create: "Створити"
-      destroy: "Видалити"
-      edit: "Змінити"
-      list: "Показати"
-      listing: "Список"
-      new: "Новий"
-      refund: "Повернути гроші"
-      save: "Зберегти"
-      update: "Змінити"
-    activate: "Активувати"
-    active: "Активний"
-    add: "Додати"
-    add_action_of_type: "Додати дію для типа"
-    add_country: "Додати країну"
-    add_coupon_code: "Додати код купона"
-    add_new_header: "Додати новий заголовок"
-    add_new_style: "Додати новий стиль"
-    add_one: "Додати"
-    add_option_value: "Додати значення характеристики"
-    add_product: "Додати товар"
-    add_product_properties: "Додати властивості товару"
-    add_rule_of_type: "Додати правило типу"
-    add_state: "Додати регіон/область"
-    add_stock: "Додати залишок"
-    add_stock_management: "Додати управління запасами"
-    add_to_cart: "Додати в кошик"
-    add_variant: "Додати варіант"
-    additional_item: "Ставка для додаткових найменувань"
-    address1: "Адреса"
-    address2: "Адреса (продовження)"
-    adjustable: "Коригований елемент"
-    adjustment: "Коригування"
-    adjustment_amount: "Загалом"
-    adjustment_successfully_closed: "Коригування було успішно закрите!"
-    adjustment_successfully_opened: "Коригування було успішно відкрите!"
-    adjustment_total: "Разом коригувань"
-    adjustments: "Коригування"
+      cancel: Скасувати
+      continue: Продовжити
+      create: Створити
+      destroy: Видалити
+      edit: Змінити
+      list: Показати
+      listing: Список
+      new: Новий
+      refund: Повернути гроші
+      save: Зберегти
+      update: Змінити
+    activate: Активувати
+    active: Активний
+    add: Додати
+    add_action_of_type: Додати дію для типа
+    add_country: Додати країну
+    add_coupon_code: Додати код купона
+    add_new_header: Додати новий заголовок
+    add_new_style: Додати новий стиль
+    add_one: Додати
+    add_option_value: Додати значення характеристики
+    add_product: Додати товар
+    add_product_properties: Додати властивості товару
+    add_rule_of_type: Додати правило типу
+    add_state: Додати регіон/область
+    add_stock: Додати залишок
+    add_stock_management: Додати управління запасами
+    add_to_cart: Додати в кошик
+    add_variant: Додати варіант
+    additional_item: Ставка для додаткових найменувань
+    address1: Адреса
+    address2: Адреса (продовження)
+    adjustable: Коригований елемент
+    adjustment: Коригування
+    adjustment_amount: Загалом
+    adjustment_successfully_closed: Коригування було успішно закрите!
+    adjustment_successfully_opened: Коригування було успішно відкрите!
+    adjustment_total: Разом коригувань
+    adjustments: Коригування
     admin:
       tab:
-        configuration: "Налаштування"
-        option_types: "Характеристики"
-        orders: "Замовлення"
-        overview: "Перегляд"
-        products: "Товари"
-        promotions: "Промоакції"
-        promotion_categories: "Категорії промоакцій"
-        properties: "Властивості"
-        prototypes: "Прототипи"
-        reports: "Звіти"
-        taxonomies: "Таксономії"
-        taxons: "Таксони"
-        users: "Користувачі"
+        configuration: Налаштування
+        option_types: Характеристики
+        orders: Замовлення
+        overview: Перегляд
+        products: Товари
+        promotion_categories: Категорії промоакцій
+        promotions: Промоакції
+        properties: Властивості
+        prototypes: Прототипи
+        reports: Звіти
+        taxonomies: Таксономії
+        taxons: Таксони
+        users: Користувачі
       user:
-        account: "Обліковий запис"
-        addresses: "Адреси"
-        items: "Позиції"
-        items_purchased: "Придбані позиції"
-        order_history: "Історія замовлень"
-        order_num: "Замолення №"
-        orders: "Замовлення"
-        user_information: "Інформація користувача"
-    administration: "Адміністрування"
-    advertise:
-    agree_to_privacy_policy: "Погоджуюсь з політикою конфіденційності"
-    agree_to_terms_of_service: "Погоджуюсь з умовами обслуговування"
-    all: "всі"
-    all_adjustments_closed: "Всі коригування успішно закриті!"
-    all_adjustments_opened: "Всі коригування успішно відкриті!"
-    all_departments: "Всі розділи"
-    all_items_have_been_returned: "Усі позиції повернено"
-    allow_ssl_in_development_and_test: "Використовувати SSL в development та test режимах"
-    allow_ssl_in_production: "Використовувати SSL в production"
-    allow_ssl_in_staging: "Використовувати SSL в staging"
-    already_signed_up_for_analytics: "Ви вже підписані на Spree Analytics"
-    alt_text: "Альтернативний текст"
-    alternative_phone: "Додатковий телефон"
-    amount: "Сума"
-    analytics_desc_header_1: "Аналітика Spree"
-    analytics_desc_header_2: "Аналітика в прямому ефірі додана на Spree dashboard"
-    analytics_desc_list_1: "Отримати інформацію про продажі в режимі реального часу"
-    analytics_desc_list_2: "Безкоштовний аккаунт Spree необхідний для активації"
-    analytics_desc_list_3: "Відсутній код для встановлення"
-    analytics_desc_list_4: "Повністю безкоштовний!"
-    analytics_trackers: "Трекери веб-аналітики"
-    and: "і"
-    approve: "підтвердити"
-    approved_at: "Дата підтвердження"
-    approver: "Підтверджено"
-    are_you_sure: "Ви впевнені"
-    are_you_sure_delete: "Ви впевнені, що хочете видалити цей запис?"
-    associated_adjustment_closed: "Пов’язане коригування закрито, і не буде перераховано. Чи бажаєте відкрити її?"
-    at_symbol: '@'
-    authorization_failure: "Помилка авторизації"
-    authorized: "Авторизовано"
-    auto_capture: "Автоматично проводити оплату"
-    available_on: "Доступно з"
-    average_order_value: "Середнє значення замовлень"
-    avs_response: "Відповідь AVS"
-    back: "Назад"
-    back_end: "в адміністративному інтерфейсі"
-    back_to_payment: "Назад до оплати"
-    back_to_resource_list: "Назад до списку ресурсів"
-    back_to_rma_reason_list: "Назад до списку підстав дозволів на повернення товару"
-    back_to_store: "Повернутися до магазину"
-    back_to_users_list: "Назад до списку користувачів"
-    backorderable: "Можливий продаж під замовлення"
-    backorderable_default: "Можливий продаж під замовлення за замовчуванням"
-    backordered: "Під замовлення"
-    backorders_allowed: "Продаж під замовлення дозволено"
-    balance_due: "Дебетове сальдо"
-    base_amount: "Базова сума"
-    base_percent: "Базовий відсоток"
-    bill_address: "Платіжна адреса"
-    billing: "Біллінг"
-    billing_address: "Платіжна адреса"
-    both: "скрізь"
-    calculated_reimbursements: "Обчислені відшкодування"
-    calculator: "Калькулятор"
-    calculator_settings_warning: "При зміні типу калькулятора, ви повинні зберегти зміни, перш ніж ви зможете змінювати його налаштування."
-    cancel: "Скасувати"
-    canceled_at: "Скасовано в"
-    canceler: "Скасував(ла)"
-    cannot_create_customer_returns: "Неможливо створити повернення покупця, оскільки це замовлення не має відправлених одиниць."
-    cannot_create_payment_without_payment_methods: "Неможливо створити оплату без визначення методів оплати."
-    cannot_create_returns: "Неможливо оформити повернення, тому що це замовлення ще не відправлено."
-    cannot_perform_operation: "Неможливо виконати необхідну операцію"
-    cannot_set_shipping_method_without_address: "Неможливо обрати спосіб доставки, доки дані користувача не вказані."
-    capture: "Провести оплати"
-    capture_events: "Проводки по оплаті"
-    card_code: "Код карти"
-    card_number: "Номер карти"
-    card_type: "Тип карти"
-    card_type_is: "Тип карти"
-    cart: "Кошик"
+        account: Обліковий запис
+        addresses: Адреси
+        items: Позиції
+        items_purchased: Придбані позиції
+        order_history: Історія замовлень
+        order_num: Замолення №
+        orders: Замовлення
+        user_information: Інформація користувача
+    administration: Адміністрування
+    advertise: 
+    agree_to_privacy_policy: Погоджуюсь з політикою конфіденційності
+    agree_to_terms_of_service: Погоджуюсь з умовами обслуговування
+    all: всі
+    all_adjustments_closed: Всі коригування успішно закриті!
+    all_adjustments_opened: Всі коригування успішно відкриті!
+    all_departments: Всі розділи
+    all_items_have_been_returned: Усі позиції повернено
+    allow_ssl_in_development_and_test: Використовувати SSL в development та test режимах
+    allow_ssl_in_production: Використовувати SSL в production
+    allow_ssl_in_staging: Використовувати SSL в staging
+    already_signed_up_for_analytics: Ви вже підписані на Spree Analytics
+    alt_text: Альтернативний текст
+    alternative_phone: Додатковий телефон
+    amount: Сума
+    analytics_desc_header_1: Аналітика Spree
+    analytics_desc_header_2: Аналітика в прямому ефірі додана на Spree dashboard
+    analytics_desc_list_1: Отримати інформацію про продажі в режимі реального часу
+    analytics_desc_list_2: Безкоштовний аккаунт Spree необхідний для активації
+    analytics_desc_list_3: Відсутній код для встановлення
+    analytics_desc_list_4: Повністю безкоштовний!
+    analytics_trackers: Трекери веб-аналітики
+    and: і
+    approve: підтвердити
+    approved_at: Дата підтвердження
+    approver: Підтверджено
+    are_you_sure: Ви впевнені
+    are_you_sure_delete: Ви впевнені, що хочете видалити цей запис?
+    associated_adjustment_closed: Пов’язане коригування закрито, і не буде перераховано. Чи бажаєте відкрити її?
+    at_symbol: "@"
+    authorization_failure: Помилка авторизації
+    authorized: Авторизовано
+    auto_capture: Автоматично проводити оплату
+    available_on: Доступно з
+    average_order_value: Середнє значення замовлень
+    avs_response: Відповідь AVS
+    back: Назад
+    back_end: в адміністративному інтерфейсі
+    back_to_payment: Назад до оплати
+    back_to_resource_list: Назад до списку ресурсів
+    back_to_rma_reason_list: Назад до списку підстав дозволів на повернення товару
+    back_to_store: Повернутися до магазину
+    back_to_users_list: Назад до списку користувачів
+    backorderable: Можливий продаж під замовлення
+    backorderable_default: Можливий продаж під замовлення за замовчуванням
+    backordered: Під замовлення
+    backorders_allowed: Продаж під замовлення дозволено
+    balance_due: Дебетове сальдо
+    base_amount: Базова сума
+    base_percent: Базовий відсоток
+    bill_address: Платіжна адреса
+    billing: Біллінг
+    billing_address: Платіжна адреса
+    both: скрізь
+    calculated_reimbursements: Обчислені відшкодування
+    calculator: Калькулятор
+    calculator_settings_warning: При зміні типу калькулятора, ви повинні зберегти зміни, перш ніж ви зможете змінювати його налаштування.
+    cancel: Скасувати
+    canceled_at: Скасовано в
+    canceler: Скасував(ла)
+    cannot_create_customer_returns: Неможливо створити повернення покупця, оскільки це замовлення не має відправлених одиниць.
+    cannot_create_payment_without_payment_methods: Неможливо створити оплату без визначення методів оплати.
+    cannot_create_returns: Неможливо оформити повернення, тому що це замовлення ще не відправлено.
+    cannot_perform_operation: Неможливо виконати необхідну операцію
+    cannot_set_shipping_method_without_address: Неможливо обрати спосіб доставки, доки дані користувача не вказані.
+    capture: Провести оплати
+    capture_events: Проводки по оплаті
+    card_code: Код карти
+    card_number: Номер карти
+    card_type: Тип карти
+    card_type_is: Тип карти
+    cart: Кошик
     cart_subtotal:
-      one: "Проміжний підсумок (1 позиція)"
-      other: "Проміжник підсумок (позицій: %{count})"
-    categories: "Категорії"
-    category: "Категорія"
-    charged: "Стягнено"
-    check_for_spree_alerts: "Перевіряти сповіщення Spree"
-    checkout: "Оформлення замовлення"
-    choose_a_customer: "Виберіть клієнта"
-    choose_a_taxon_to_sort_products_for: "Виберіть таксон для сортування товарів"
-    choose_currency: "Виберіть валюту"
-    choose_dashboard_locale: "Вибрати мову панелі управління"
-    choose_location: "Виберіть склад"
-    city: "Місто"
+      one: Проміжний підсумок (1 позиція)
+      other: 'Проміжник підсумок (позицій: %{count})'
+    categories: Категорії
+    category: Категорія
+    charged: Стягнено
+    check_for_spree_alerts: Перевіряти сповіщення Spree
+    checkout: Оформлення замовлення
+    choose_a_customer: Виберіть клієнта
+    choose_a_taxon_to_sort_products_for: Виберіть таксон для сортування товарів
+    choose_currency: Виберіть валюту
+    choose_dashboard_locale: Вибрати мову панелі управління
+    choose_location: Виберіть склад
+    city: Місто
     clear_cache: Очистити кеш
     clear_cache_ok: Кеш очищено
     clear_cache_warning: Очищення кешу тимчасово знизить швидкодію вашого магазину
-    click_and_drag_on_the_products_to_sort_them: "Перетягуйте товари, щоб відсортувати."
-    clone: "Клонувати"
-    close: "Закрити"
-    close_all_adjustments: "Закрити всі коригування"
-    code: "Кодове слово"
-    company: "Компанія"
-    complete: "Завершено"
-    configuration: "Конфігурація"
-    configurations: "Конфігурації"
-    confirm: "Підтвердити"
-    confirm_delete: "Підтвердження видалення"
-    confirm_password: "Підтвердження пароля"
-    continue: "Продовжити"
-    continue_shopping: "Продовжити покупки"
-    cost_currency: "Валюта"
-    cost_price: "Собівартість"
-    could_not_connect_to_jirafe: "Неможливо синхонізуватись з Jirafe. Повторна спроба відбудеться пізніше."
-    could_not_create_customer_return: "Не вдалось створити повернення від покупця"
-    could_not_create_stock_movement: "Не вдалось створити рух залишків. Будь ласка, спробуйте ще раз."
-    count_on_hand: "Вільний залишок"
-    countries: "Країни"
-    country: "Країна"
-    country_based: "Країна"
-    country_name: "Ім’я"
+    click_and_drag_on_the_products_to_sort_them: Перетягуйте товари, щоб відсортувати.
+    clone: Клонувати
+    close: Закрити
+    close_all_adjustments: Закрити всі коригування
+    code: Кодове слово
+    company: Компанія
+    complete: Завершено
+    configuration: Конфігурація
+    configurations: Конфігурації
+    confirm: Підтвердити
+    confirm_delete: Підтвердження видалення
+    confirm_password: Підтвердження пароля
+    continue: Продовжити
+    continue_shopping: Продовжити покупки
+    cost_currency: Валюта
+    cost_price: Собівартість
+    could_not_connect_to_jirafe: Неможливо синхонізуватись з Jirafe. Повторна спроба відбудеться пізніше.
+    could_not_create_customer_return: Не вдалось створити повернення від покупця
+    could_not_create_stock_movement: Не вдалось створити рух залишків. Будь ласка, спробуйте ще раз.
+    count_on_hand: Вільний залишок
+    countries: Країни
+    country: Країна
+    country_based: Країна
+    country_name: Ім’я
     country_names:
-      CA: "Канада"
-      FRA: "Франція"
-      ITA: "Італія"
-      US: "Сполучені Штати Америки"
-    coupon: "Купон"
-    coupon_code: "Код купона"
-    coupon_code_already_applied: "Цей код купона вже було використано у цьому замовленні"
-    coupon_code_applied: "Купон успішно застосований до вашого замовлення."
-    coupon_code_better_exists: "Попередньо застосований купон є вигіднішим"
-    coupon_code_expired: "Термін дії купону минув"
-    coupon_code_max_usage: "Ліміт використання купону вичерпано"
-    coupon_code_not_eligible: "Цей купон не може бути застосований до вашого замовлення"
-    coupon_code_not_found: "Введений код купона не існує. Будь ласка, спробуйте ще раз."
-    coupon_code_unknown_error: "Введений купон не можна застосувати цього разу."
-    create: "Створити"
-    create_a_new_account: "Створити новий обліковий запис"
-    create_new_order: "Створити нове замовлення"
-    create_reimbursement: "Створити відшкодування"
-    created_at: "Створено в"
-    credit: "Кредит"
-    credit_card: "Кредитна картка"
-    credit_cards: "Кредитні картки"
-    credit_owed: "Кредитна заборгованість"
-    credits: "Кредити"
-    currency: "Валюта"
-    currency_decimal_mark: "Десятковий роздільник валюти"
-    currency_settings: "Налаштування валюти"
-    currency_symbol_position: "Розташування символу валюти відносно суми"
-    currency_thousands_separator: "Роздільник тисяч валюти"
-    current: "Поточний"
-    current_promotion_usage: "Використано: %{count}"
-    customer: "Клієнт"
-    customer_details: "Докладно про клієнта"
-    customer_details_updated: "Реквізити покупця успішно оновлено"
-    customer_return: "Повернення від покупця"
-    customer_returns: "Повернення від покупця"
-    customer_search: "Пошук клієнта"
-    cut: "Вирізати"
-    cvv_response: "Відповідь CVV"
+      CA: Канада
+      FRA: Франція
+      ITA: Італія
+      US: Сполучені Штати Америки
+    coupon: Купон
+    coupon_code: Код купона
+    coupon_code_already_applied: Цей код купона вже було використано у цьому замовленні
+    coupon_code_applied: Купон успішно застосований до вашого замовлення.
+    coupon_code_better_exists: Попередньо застосований купон є вигіднішим
+    coupon_code_expired: Термін дії купону минув
+    coupon_code_max_usage: Ліміт використання купону вичерпано
+    coupon_code_not_eligible: Цей купон не може бути застосований до вашого замовлення
+    coupon_code_not_found: Введений код купона не існує. Будь ласка, спробуйте ще раз.
+    coupon_code_unknown_error: Введений купон не можна застосувати цього разу.
+    create: Створити
+    create_a_new_account: Створити новий обліковий запис
+    create_new_order: Створити нове замовлення
+    create_reimbursement: Створити відшкодування
+    created_at: Створено в
+    credit: Кредит
+    credit_card: Кредитна картка
+    credit_cards: Кредитні картки
+    credit_owed: Кредитна заборгованість
+    credits: Кредити
+    currency: Валюта
+    currency_decimal_mark: Десятковий роздільник валюти
+    currency_settings: Налаштування валюти
+    currency_symbol_position: Розташування символу валюти відносно суми
+    currency_thousands_separator: Роздільник тисяч валюти
+    current: Поточний
+    current_promotion_usage: 'Використано: %{count}'
+    customer: Клієнт
+    customer_details: Докладно про клієнта
+    customer_details_updated: Реквізити покупця успішно оновлено
+    customer_return: Повернення від покупця
+    customer_returns: Повернення від покупця
+    customer_search: Пошук клієнта
+    cut: Вирізати
+    cvv_response: Відповідь CVV
     dash:
       jirafe:
         app_id: ID додатку
-        app_token: "Токен додатку"
+        app_token: Токен додатку
         currently_unavailable: Jirafe недоступний. Spree автоматично підключиться до Jirafe знову, коли він стане доступним.
-        explanation: "Ці поля можуть бути заповнені, якщо ви зареєструєтесь в Jirafe з панелі адміністрування."
-        header: "Налаштування аналітики Jirafe"
+        explanation: Ці поля можуть бути заповнені, якщо ви зареєструєтесь в Jirafe з панелі адміністрування.
+        header: Налаштування аналітики Jirafe
         site_id: ID сайту
-        token: "Токен"
-      jirafe_settings_updated: "Налаштування Jirafe оновлено."
-    date: "Дата"
-    date_completed: "Дата завершення"
+        token: Токен
+      jirafe_settings_updated: Налаштування Jirafe оновлено.
+    date: Дата
+    date_completed: Дата завершення
     date_picker:
       first_day: 1
       format: "%d.%m.%Y"
       js_format: dd/mm/yy
-    date_range: "Період часу"
-    default: "За замовчуванням"
-    default_refund_amount: "Сума повернення грошей за замовчуванням"
-    default_tax: "Податок за замовчуванням"
-    default_tax_zone: "Податковий регіон за замовчуванням"
-    delete: "Видалити"
-    deleted_variants_present:
-    delivery: "Доставка"
-    depth: "Глибина"
-    description: "Опис"
-    destination_location: "Склад-отримувач"
-    destroy: "Видалити"
-    details: "Докладно"
-    discount_amount: "Сума знижки"
-    dismiss_banner: "Ні, дякую! Більше не показувати це повідомлення"
-    display: "Показати"
-    display_currency: "Показувати валюту"
-    edit: "Редагувати"
-    editing_resource: "Редагування ресурсу"
-    editing_rma_reason: "Редагування підстав дозволів на повернення товару"
-    editing_user: "Редагування користувача"
+    date_range: Період часу
+    default: За замовчуванням
+    default_refund_amount: Сума повернення грошей за замовчуванням
+    default_tax: Податок за замовчуванням
+    default_tax_zone: Податковий регіон за замовчуванням
+    delete: Видалити
+    deleted_variants_present: 
+    delivery: Доставка
+    depth: Глибина
+    description: Опис
+    destination_location: Склад-отримувач
+    destroy: Видалити
+    details: Докладно
+    discount_amount: Сума знижки
+    dismiss_banner: Ні, дякую! Більше не показувати це повідомлення
+    display: Показати
+    display_currency: Показувати валюту
+    edit: Редагувати
+    editing_resource: Редагування ресурсу
+    editing_rma_reason: Редагування підстав дозволів на повернення товару
+    editing_user: Редагування користувача
     eligibility_errors:
       messages:
-        has_excluded_product: "В кошику є товар, який не дозволяє застосувати код купона."
-        item_total_less_than: "Цей код купона не можна застосувати до замовлень на суму до %{amount}."
-        item_total_less_than_or_equal: "Цей купон не можна застосувати до замовлень на суму включно до %{amount}."
-        item_total_more_than: "Цей код купона не можна застосувати до замовлень на суму понад %{amount}."
-        item_total_more_than_or_equal: "Цей код купона не можна застосувати до замовлень на суму включно від %{amount}."
-        limit_once_per_user: "Цей код купона можна використати лише один раз."
-        missing_product: "Цей код купона не можна застосувати, бо у кошику немає всіх необхідних товарів."
-        missing_taxon: "Необхідно додати товар усіх акційних категорій, щоб застосувати цей код купона."
-        no_applicable_products: "Потрібно додати акційний товар, щоб застосувати код купона."
-        no_matching_taxons: "Додайте товар із акційної категорії, щоб застосувати цей код купона."
-        no_user_or_email_specified: "Увійдіть або введіть e-mail, щоб застосувати цей код купона."
-        no_user_specified: "Увійдіть, щоб застосувати цей купон."
-        not_first_order: "Цей код купона можна застосувати тільки до вашого першого замовлення."
-    email: "Електронна пошта"
-    empty: "Порожньо"
-    empty_cart: "Очистити кошик"
-    enable_mail_delivery: "Включити доставку пошти"
-    end: "Кінець"
-    ending_in: "Закінчується"
-    environment: "Середовище"
-    error: "помилка"
+        has_excluded_product: В кошику є товар, який не дозволяє застосувати код купона.
+        item_total_less_than: Цей код купона не можна застосувати до замовлень на суму до %{amount}.
+        item_total_less_than_or_equal: Цей купон не можна застосувати до замовлень на суму включно до %{amount}.
+        item_total_more_than: Цей код купона не можна застосувати до замовлень на суму понад %{amount}.
+        item_total_more_than_or_equal: Цей код купона не можна застосувати до замовлень на суму включно від %{amount}.
+        limit_once_per_user: Цей код купона можна використати лише один раз.
+        missing_product: Цей код купона не можна застосувати, бо у кошику немає всіх необхідних товарів.
+        missing_taxon: Необхідно додати товар усіх акційних категорій, щоб застосувати цей код купона.
+        no_applicable_products: Потрібно додати акційний товар, щоб застосувати код купона.
+        no_matching_taxons: Додайте товар із акційної категорії, щоб застосувати цей код купона.
+        no_user_or_email_specified: Увійдіть або введіть e-mail, щоб застосувати цей код купона.
+        no_user_specified: Увійдіть, щоб застосувати цей купон.
+        not_first_order: Цей код купона можна застосувати тільки до вашого першого замовлення.
+    email: Електронна пошта
+    empty: Порожньо
+    empty_cart: Очистити кошик
+    enable_mail_delivery: Включити доставку пошти
+    end: Кінець
+    ending_in: Закінчується
+    environment: Середовище
+    error: помилка
     errors:
       messages:
-        cannot_modify_transfer_item_closed_stock_transfer: "Позиції закритого складського переміщення не можуть бути змінені."
-        cannot_delete_finalized_stock_transfer: "Зафіксовані складські переміщення не можуть бути видалені."
-        cannot_delete_transfer_item_with_finalized_stock_transfer: "Позиції зафіксованого складського переміщення не можуть бути видалені."
-        cannot_update_expected_transfer_item_with_finalized_stock_transfer: "Кількість позицій зафіксованого складського переміщення не можу бути змінена."
-        could_not_create_taxon: "Неможливо створити таксон"
-        transfer_item_insufficient_stock: "Позиція складського переміщення немає достатньо залишку на складі"
-        no_payment_methods_available: "Для зазначеної зміни оточення відсутні методи оплати"
-        no_shipping_methods_available: "Для зазначеного складу відсутні способи доставки, будь ласка, змініть адресу та спробуйте знову."
+        cannot_delete_finalized_stock_transfer: Зафіксовані складські переміщення не можуть бути видалені.
+        cannot_delete_transfer_item_with_finalized_stock_transfer: Позиції зафіксованого складського переміщення не можуть бути видалені.
+        cannot_modify_transfer_item_closed_stock_transfer: Позиції закритого складського переміщення не можуть бути змінені.
+        cannot_update_expected_transfer_item_with_finalized_stock_transfer: Кількість позицій зафіксованого складського переміщення не можу бути
+          змінена.
+        could_not_create_taxon: Неможливо створити таксон
+        no_payment_methods_available: Для зазначеної зміни оточення відсутні методи оплати
+        no_shipping_methods_available: Для зазначеного складу відсутні способи доставки, будь ласка, змініть адресу та спробуйте знову.
+        transfer_item_insufficient_stock: Позиція складського переміщення немає достатньо залишку на складі
     errors_prohibited_this_record_from_being_saved:
       few: "%{count} помилки не дозволяють зберегти запис у базі"
       many: "%{count} помилок не дозволяють зберегти запис у базі"
       one: 1 помилка не дозволяє зберегти запис в базі
       other: "%{count} помилок не дозволяють зберегти запис у базі"
-    event: "Подія"
+    event: Подія
     events:
       spree:
         cart:
-          add: "Додати до кошика"
+          add: Додати до кошика
         checkout:
-          coupon_code_added: "Купон доданий"
+          coupon_code_added: Купон доданий
         content:
-          visited: "Відвідати статичну сторінку"
+          visited: Відвідати статичну сторінку
         order:
-          contents_changed: "Порядок змісту змінився"
-        page_view: "Статична сторінка була проглянута"
+          contents_changed: Порядок змісту змінився
+        page_view: Статична сторінка була проглянута
         user:
-          signup: "Новий користувач"
+          signup: Новий користувач
     exceptions:
-      count_on_hand_setter: "Неможливо встановити значення count_on_hand вручну, оскільки воно встановлюється автоматично за допомогою recalculate_count_on_hand callback'у. Замість цього використовуйте, будь ласка, `update_column(:count_on_hand, value)`"
-    exchange_for: "Замінити на"
-    excl: "викл."
-    existing_shipments: "Існуючі відправлення"
-    expedited_exchanges_warning: "Будь-яка вказана заміна буде відправлена покупцеві негайно після збереження. З покупця буде стягнуто повну суму за заміну, якщо оригінальна покупка не буде повернута протягом %{days_window} днів."
-    expiration: "Закінчення дії"
-    extension: "Розширення"
-    failed_payment_attempts: "Невдалих спроб проведення платежу"
-    filename: "Ім’я файлу"
-    fill_in_customer_info: "Заповніть інформацію про клієнта"
-    filter_results: "Фільтрувати"
-    finalize: "Зафіксувати"
-    finalized: "Зафіксовано"
-    find_a_taxon: "Знайти таксон"
-    first_item: "Початкова ставка"
-    first_name: "Ім’я"
-    first_name_begins_with: "Ім’я починається з"
-    flat_percent: "Фіксований відсоток"
-    flat_rate_per_order: "Фіксована ставка (за замовлення)"
-    flexible_rate: "Гнучка ставка"
-    forgot_password: "Забули пароль?"
-    free_shipping: "Безкоштовна доставка"
+      count_on_hand_setter: >-
+        Неможливо встановити значення count_on_hand вручну, оскільки воно встановлюється автоматично за допомогою recalculate_count_on_hand callback'у.
+        Замість цього використовуйте, будь ласка, `update_column(:count_on_hand, value)`
+    exchange_for: Замінити на
+    excl: викл.
+    existing_shipments: Існуючі відправлення
+    expedited_exchanges_warning: >-
+      Будь-яка вказана заміна буде відправлена покупцеві негайно після збереження. З покупця буде стягнуто повну суму за заміну, якщо оригінальна
+      покупка не буде повернута протягом %{days_window} днів.
+    expiration: Закінчення дії
+    extension: Розширення
+    failed_payment_attempts: Невдалих спроб проведення платежу
+    filename: Ім’я файлу
+    fill_in_customer_info: Заповніть інформацію про клієнта
+    filter_results: Фільтрувати
+    finalize: Зафіксувати
+    finalized: Зафіксовано
+    find_a_taxon: Знайти таксон
+    first_item: Початкова ставка
+    first_name: Ім’я
+    first_name_begins_with: Ім’я починається з
+    flat_percent: Фіксований відсоток
+    flat_rate_per_order: Фіксована ставка (за замовлення)
+    flexible_rate: Гнучка ставка
+    forgot_password: Забули пароль?
+    free_shipping: Безкоштовна доставка
     free_shipping_amount: "-"
-    front_end: "в публічному інтерфейсі"
-    gateway: "Платіжний шлюз"
-    gateway_config_unavailable: "Шлюз не доступний для даного оточення"
-    gateway_error: "Помилка платіжного шлюзу"
-    general: "Основні"
-    general_settings: "Загальні налаштування"
+    front_end: в публічному інтерфейсі
+    gateway: Платіжний шлюз
+    gateway_config_unavailable: Шлюз не доступний для даного оточення
+    gateway_error: Помилка платіжного шлюзу
+    general: Основні
+    general_settings: Загальні налаштування
     google_analytics: Google Analytics
     google_analytics_id: Google Analytics ID
-    guest_checkout: "Гостьове замовлення"
-    guest_user_account: "Оформити покупку як гість"
-    has_no_shipped_units: "Немає відправлених позицій"
-    height: "Висота"
-    hide_cents: "Сховати копійки"
-    home: "Додому"
+    guest_checkout: Гостьове замовлення
+    guest_user_account: Оформити покупку як гість
+    has_no_shipped_units: Немає відправлених позицій
+    height: Висота
+    hide_cents: Сховати копійки
+    home: Додому
     i18n:
-      available_locales: "Доступні переклади"
-      language: "Мова"
-      localization_settings: "Налаштування локалізації"
+      available_locales: Доступні переклади
+      language: Мова
+      localization_settings: Налаштування локалізації
       this_file_language: Ukrainian
-    icon: "Іконка"
-    identifier: "Ідентифікатор"
-    image: "Зображення"
-    images: "Зображення"
-    implement_eligible_for_return: "Необхідно реалізувати #eligible_for_return? у вашому EligibilityValidator."
-    implement_requires_manual_intervention: "Необхідно реалізувати #requires_manual_intervention? у вашому EligibilityValidator."
-    inactive: "Неактивний"
-    incl: "вкл."
-    included_in_price: "Включено в ціну"
-    included_price_validation: "неможливо вибрати, якщо тільки ви вказали Зону податку за замовчуванням"
-    incomplete: "Неповний"
+    icon: Іконка
+    identifier: Ідентифікатор
+    image: Зображення
+    images: Зображення
+    implement_eligible_for_return: 'Необхідно реалізувати #eligible_for_return? у вашому EligibilityValidator.'
+    implement_requires_manual_intervention: 'Необхідно реалізувати #requires_manual_intervention? у вашому EligibilityValidator.'
+    inactive: Неактивний
+    incl: вкл.
+    included_in_price: Включено в ціну
+    included_price_validation: неможливо вибрати, якщо тільки ви вказали Зону податку за замовчуванням
+    incomplete: Неповний
     info_number_of_skus_not_shown:
-      one: "та один інший"
-      other: "та %{count} інших"
-    info_product_has_multiple_skus: "Цей товар має %{count} варіантів"
-    instructions_to_reset_password: "Щоб скинути пароль, заповніть форму нижче. Новий пароль буде відправлений вам по зазначеному email"
-    insufficient_stock: "Недостатньо вільного залишку, в наявності %{on_hand}"
-    insufficient_stock_lines_present: "Деякі позиції цього замовлення мають недостатню кількість."
-    intercept_email_address: "Перехоплення листів"
-    intercept_email_instructions: "Замінити email одержувача на цю адресу."
-    internal_name: "Внутрішнє ім’я"
-    invalid_credit_card: "Невірна кредитна карта."
-    invalid_exchange_variant: "Невірний варіант на заміну"
-    invalid_payment_provider: "Невірно вказано спосіб оплати"
-    invalid_promotion_action: "Невірна промоакція"
-    invalid_promotion_rule: "Невірно вказано правило промоакції"
-    inventory: "Запаси"
-    inventory_adjustment: "Коригування запасів"
-    inventory_error_flash_for_insufficient_quantity: "Один з товарів вашої корзини став недоступним."
-    inventory_state: "Доступність"
-    is_not_available_to_shipment_address: "не може бути застосований до вказаної адреси доставки"
-    iso_name: "Ім’я згідно ISO"
-    item: "Найменування"
-    item_description: "Опис товару"
-    item_total: "Разом без знижки"
+      one: та один інший
+      other: та %{count} інших
+    info_product_has_multiple_skus: Цей товар має %{count} варіантів
+    instructions_to_reset_password: Щоб скинути пароль, заповніть форму нижче. Новий пароль буде відправлений вам по зазначеному email
+    insufficient_stock: Недостатньо вільного залишку, в наявності %{on_hand}
+    insufficient_stock_lines_present: Деякі позиції цього замовлення мають недостатню кількість.
+    intercept_email_address: Перехоплення листів
+    intercept_email_instructions: Замінити email одержувача на цю адресу.
+    internal_name: Внутрішнє ім’я
+    invalid_credit_card: Невірна кредитна карта.
+    invalid_exchange_variant: Невірний варіант на заміну
+    invalid_payment_provider: Невірно вказано спосіб оплати
+    invalid_promotion_action: Невірна промоакція
+    invalid_promotion_rule: Невірно вказано правило промоакції
+    inventory: Запаси
+    inventory_adjustment: Коригування запасів
+    inventory_error_flash_for_insufficient_quantity: Один з товарів вашої корзини став недоступним.
+    inventory_state: Доступність
+    is_not_available_to_shipment_address: не може бути застосований до вказаної адреси доставки
+    iso_name: Ім’я згідно ISO
+    item: Найменування
+    item_description: Опис товару
+    item_total: Разом без знижки
     item_total_rule:
       operators:
-        gt: "більше"
-        gte: "більше або дорівнює"
-        lt: "менше"
-        lte: "менше або дорівнює"
-    items_cannot_be_shipped: "На жаль ми не можемо доставити ваш товар на вказану адресу. Будь ласка, введіть іншу адресу."
-    items_in_rmas: "Позиції в дозволах на повернення товару"
-    items_reimbursed: "Відшкодовані позиції"
-    items_to_be_reimbursed: "Позиції на відшкодування"
+        gt: більше
+        gte: більше або дорівнює
+        lt: менше
+        lte: менше або дорівнює
+    items_cannot_be_shipped: На жаль ми не можемо доставити ваш товар на вказану адресу. Будь ласка, введіть іншу адресу.
+    items_in_rmas: Позиції в дозволах на повернення товару
+    items_reimbursed: Відшкодовані позиції
+    items_to_be_reimbursed: Позиції на відшкодування
     jirafe: Jirafe
     landing_page_rule:
-      path: "Шлях"
-    last_name: "Прізвище"
-    last_name_begins_with: "Прізвище починається з"
-    learn_more: "Дізнатися більше"
-    lifetime_stats: "Статистика"
-    line_item_adjustments: "Коригування позиції замовлення"
-    list: "Список"
-    loading: "Завантажується"
-    locale_changed: "Мова змінена"
-    location: "Склад"
+      path: Шлях
+    last_name: Прізвище
+    last_name_begins_with: Прізвище починається з
+    learn_more: Дізнатися більше
+    lifetime_stats: Статистика
+    line_item_adjustments: Коригування позиції замовлення
+    list: Список
+    loading: Завантажується
+    locale_changed: Мова змінена
+    location: Склад
     lock: Lock
-    log_entries: "Записи журналу"
-    logged_in_as: "Користувач"
-    logged_in_succesfully: "Ви увійшли в систему"
-    logged_out: "Ви вийшли з системи."
-    login: "Логін"
-    login_as_existing: "Увійти як існуючий покупець"
-    login_failed: "Вхід не виконано."
-    login_name: "Логін"
-    logout: "Вийти"
-    logs: "Журнали"
-    look_for_similar_items: "Подивіться схожі товари"
-    make_refund: "Зробити повернення грошей"
-    make_sure_the_above_reimbursement_amount_is_correct: "Переконайтесь, що сума відшкодування правильна"
-    manage_promotion_categories: "Керувати категоріями промоакцій"
-    manage_variants: "Керувати варіантами"
-    manual_intervention_required: "Потрібне людське втручання"
-    master_price: "Ціна за замовчуванням"
+    log_entries: Записи журналу
+    logged_in_as: Користувач
+    logged_in_succesfully: Ви увійшли в систему
+    logged_out: Ви вийшли з системи.
+    login: Логін
+    login_as_existing: Увійти як існуючий покупець
+    login_failed: Вхід не виконано.
+    login_name: Логін
+    logout: Вийти
+    logs: Журнали
+    look_for_similar_items: Подивіться схожі товари
+    make_refund: Зробити повернення грошей
+    make_sure_the_above_reimbursement_amount_is_correct: Переконайтесь, що сума відшкодування правильна
+    manage_promotion_categories: Керувати категоріями промоакцій
+    manage_variants: Керувати варіантами
+    manual_intervention_required: Потрібне людське втручання
+    master_price: Ціна за замовчуванням
     match_choices:
-      all: "Всі"
-      none: "Жодного"
-    max_items: "Максимальне число найменувань за початковою ставкою"
-    member_since: "Зареєстрований від"
-    memo: "Нотатка"
-    meta_description: "Метаопис"
-    meta_keywords: "Ключові слова"
+      all: Всі
+      none: Жодного
+    max_items: Максимальне число найменувань за початковою ставкою
+    member_since: Зареєстрований від
+    memo: Нотатка
+    meta_description: Метаопис
+    meta_keywords: Ключові слова
     meta_title: Meta-заголовок
-    metadata: "Метадані"
-    minimal_amount: "Мінімальна сума"
-    month: "Місяць"
-    more: "Більше"
-    move_stock_between_locations: "Перемістити залишки між складами"
-    my_account: "Мій обліковий запис"
-    my_orders: "Мої замовлення"
-    name: "Назва"
-    name_on_card: "Ім’я на карті"
-    name_or_sku: "Назва або артикул"
-    new: "Новий"
-    new_adjustment: "Нове коригування"
-    new_country: "Нова країна"
-    new_customer: "Для нових користувачів"
-    new_customer_return: "Нове повернення від покупця"
-    new_image: "Нове зображення"
-    new_option_type: "Нова характеристика"
-    new_order: "Нове замовлення"
-    new_order_completed: "Оформлення замовлення завершено"
-    new_payment: "Новий платіж"
-    new_payment_method: "Новий спосіб оплати"
-    new_product: "Новий товар"
-    new_promotion: "Нова промоакція"
-    new_promotion_category: "Нова категорія промоакцій"
-    new_property: "Нова властивість"
-    new_prototype: "Новий прототип"
-    new_refund: "Нове повернення грошей"
-    new_refund_reason: "Нова підстава повернення грошей"
-    new_return_authorization: "Новий дозвіл на повернення товару"
-    new_rma_reason: "Нова підстава дозволу на повернення товару"
-    new_shipment_at_location: "Нове відправлення на склад"
-    new_shipping_category: "Нова категорія доставки"
-    new_shipping_method: "Новий спосіб доставки"
-    new_state: "Новий регіон/область"
-    new_stock_location: "Новий склад"
-    new_stock_movement: "Новий рух залишків"
-    new_stock_transfer: "Нове переміщення залишків"
-    new_tax_category: "Нова категорія податків"
-    new_tax_rate: "Нова ставка податку"
-    new_taxon: "Новий таксон"
-    new_taxonomy: "Нова таксономія"
-    new_tracker: "Новий трекер"
-    new_user: "Новий користувач"
-    new_variant: "Новий варіант"
-    new_zone: "Нова зона"
-    next: "наст."
-    no_actions_added: "Немає дій"
-    no_payment_found: "Не знайдено платежів"
-    no_pending_payments: "Немає незавершених платежів"
-    no_products_found: "Не знайдено жодного товару"
+    metadata: Метадані
+    minimal_amount: Мінімальна сума
+    month: Місяць
+    more: Більше
+    move_stock_between_locations: Перемістити залишки між складами
+    my_account: Мій обліковий запис
+    my_orders: Мої замовлення
+    name: Назва
+    name_on_card: Ім’я на карті
+    name_or_sku: Назва або артикул
+    new: Новий
+    new_adjustment: Нове коригування
+    new_country: Нова країна
+    new_customer: Для нових користувачів
+    new_customer_return: Нове повернення від покупця
+    new_image: Нове зображення
+    new_option_type: Нова характеристика
+    new_order: Нове замовлення
+    new_order_completed: Оформлення замовлення завершено
+    new_payment: Новий платіж
+    new_payment_method: Новий спосіб оплати
+    new_product: Новий товар
+    new_promotion: Нова промоакція
+    new_promotion_category: Нова категорія промоакцій
+    new_property: Нова властивість
+    new_prototype: Новий прототип
+    new_refund: Нове повернення грошей
+    new_refund_reason: Нова підстава повернення грошей
+    new_return_authorization: Новий дозвіл на повернення товару
+    new_rma_reason: Нова підстава дозволу на повернення товару
+    new_shipment_at_location: Нове відправлення на склад
+    new_shipping_category: Нова категорія доставки
+    new_shipping_method: Новий спосіб доставки
+    new_state: Новий регіон/область
+    new_stock_location: Новий склад
+    new_stock_movement: Новий рух залишків
+    new_stock_transfer: Нове переміщення залишків
+    new_tax_category: Нова категорія податків
+    new_tax_rate: Нова ставка податку
+    new_taxon: Новий таксон
+    new_taxonomy: Нова таксономія
+    new_tracker: Новий трекер
+    new_user: Новий користувач
+    new_variant: Новий варіант
+    new_zone: Нова зона
+    next: наст.
+    no_actions_added: Немає дій
+    no_payment_found: Не знайдено платежів
+    no_pending_payments: Немає незавершених платежів
+    no_products_found: Не знайдено жодного товару
     no_resource_found: "%{resource} не знайдено"
-    no_results: "Нічого не знайдено"
-    no_returns_found: "Не знайдено жодного повернення"
-    no_rules_added: "Жодного правила не задано"
-    no_shipping_method_selected: "Не вибрано спосіб доставки."
-    no_state_changes:
-    no_tracking_present: "Відсутні деталі відстеження"
-    none: "Жодного"
-    none_selected: "Не вибрано"
-    normal_amount: "Звичайна сума"
-    not: "не"
-    not_available: "Н/д"
-    not_enough_stock: "Недостатньо залишку на складі-відправнику для завершення переміщення"
+    no_results: Нічого не знайдено
+    no_returns_found: Не знайдено жодного повернення
+    no_rules_added: Жодного правила не задано
+    no_shipping_method_selected: Не вибрано спосіб доставки.
+    no_state_changes: 
+    no_tracking_present: Відсутні деталі відстеження
+    none: Жодного
+    none_selected: Не вибрано
+    normal_amount: Звичайна сума
+    not: не
+    not_available: Н/д
+    not_enough_stock: Недостатньо залишку на складі-відправнику для завершення переміщення
     not_found: "%{resource} не знайдено"
-    note: "Нотатка"
+    note: Нотатка
     notice_messages:
-      product_cloned: "Копія товару створена"
-      product_deleted: "Товар успішно видалено"
-      product_not_cloned: "Товар не може бути клонований"
-      product_not_deleted: "Товар не може бути видалений"
-      variant_deleted: "Варіант успішно видалено"
-      variant_not_deleted: "Варіант не може бути видалений"
-    num_orders: "К-сть замовлень"
-    on_hand: "Вільний залишок"
-    open: "Відкрити"
-    open_all_adjustments: "Відкрити всі коригування"
-    option_type: "Характеристика"
-    option_type_placeholder: "Виберіть характеристики"
-    option_types: "Характеристики"
-    option_value: "Значення характеристики"
-    option_values: "Значення характеристик"
-    optional: "Опціонально"
-    options: "Опції"
-    or: "або"
-    or_over_price: "дорожче %{price}"
-    order: "Замовлення"
-    order_adjustments: "Коригування замовлення"
-    order_already_updated:
-    order_approved: "Замовлення прийняте"
-    order_canceled: "Замовлення скасоване"
-    order_details: "Докладно про замовлення"
-    order_email_resent: "Лист з описом замовлення надіслано повторно"
-    order_information: "Інформація стосовно замовлення"
+      product_cloned: Копія товару створена
+      product_deleted: Товар успішно видалено
+      product_not_cloned: Товар не може бути клонований
+      product_not_deleted: Товар не може бути видалений
+      variant_deleted: Варіант успішно видалено
+      variant_not_deleted: Варіант не може бути видалений
+    num_orders: К-сть замовлень
+    on_hand: Вільний залишок
+    open: Відкрити
+    open_all_adjustments: Відкрити всі коригування
+    option_type: Характеристика
+    option_type_placeholder: Виберіть характеристики
+    option_types: Характеристики
+    option_value: Значення характеристики
+    option_values: Значення характеристик
+    optional: Опціонально
+    options: Опції
+    or: або
+    or_over_price: дорожче %{price}
+    order: Замовлення
+    order_adjustments: Коригування замовлення
+    order_already_updated: 
+    order_approved: Замовлення прийняте
+    order_canceled: Замовлення скасоване
+    order_details: Докладно про замовлення
+    order_email_resent: Лист з описом замовлення надіслано повторно
+    order_information: Інформація стосовно замовлення
     order_mailer:
       cancel_email:
-        dear_customer: "Шановний покупцю,\\n"
-        instructions: "Ваше замовлення СКАСОВАНО. Збережіть цю інформацію в історії."
-        order_summary_canceled: "Коротко про замовлення [СКАСОВАНО]"
-        subject: "Скасування замовлення"
+        dear_customer: Шановний покупцю,\n
+        instructions: Ваше замовлення СКАСОВАНО. Збережіть цю інформацію в історії.
+        order_summary_canceled: Коротко про замовлення [СКАСОВАНО]
+        subject: Скасування замовлення
         subtotal: Проміжний підсумок
         total: Разом
       confirm_email:
-        dear_customer: "Шановний покупцю,\\n"
-        instructions: "Перегляньте інформацію про ваше замовлення."
-        order_summary: "Коротко про замовлення"
-        subject: "Підтвердження замовлення"
+        dear_customer: Шановний покупцю,\n
+        instructions: Перегляньте інформацію про ваше замовлення.
+        order_summary: Коротко про замовлення
+        subject: Підтвердження замовлення
         subtotal: Проміжний підсумок
-        thanks: "Дякуємо за замовлення."
+        thanks: Дякуємо за замовлення.
         total: Разом
-    order_not_found: "Ми не змогли знайти Ваше замовлення. Спробуйте ще раз."
-    order_number: "Замовлення %{number}"
-    order_processed_successfully: "Ваше замовлення було успішно опрацьоване"
-    order_resumed: "Замовлення продовжене"
+    order_not_found: Ми не змогли знайти Ваше замовлення. Спробуйте ще раз.
+    order_number: Замовлення %{number}
+    order_processed_successfully: Ваше замовлення було успішно опрацьоване
+    order_resumed: Замовлення продовжене
     order_state:
-      address: "адреса"
-      awaiting_return: "чекає на повернення"
-      canceled: "скасовано"
-      cart: "кошик"
-      complete: "завершення"
-      confirm: "підтвердження"
-      considered_risky: "вважається ризикованим"
-      delivery: "доставка"
-      payment: "оплата"
-      resumed: "відновлено"
-      returned: "повернено"
-    order_summary: "Коротко про замовлення"
-    order_sure_want_to: "Ви впевнені, що хочете %{event} це замовлення?"
-    order_total: "Разом"
-    order_updated: "Замовлення оновлене"
-    orders: "Замовлення"
-    other_items_in_other: "Інші позиції в замовленні"
-    out_of_stock: "Немає на залишку"
-    overview: "Огляд"
-    package_from: "Пакунок з"
+      address: адреса
+      awaiting_return: чекає на повернення
+      canceled: скасовано
+      cart: кошик
+      complete: завершення
+      confirm: підтвердження
+      considered_risky: вважається ризикованим
+      delivery: доставка
+      payment: оплата
+      resumed: відновлено
+      returned: повернено
+    order_summary: Коротко про замовлення
+    order_sure_want_to: Ви впевнені, що хочете %{event} це замовлення?
+    order_total: Разом
+    order_updated: Замовлення оновлене
+    orders: Замовлення
+    other_items_in_other: Інші позиції в замовленні
+    out_of_stock: Немає на залишку
+    overview: Огляд
+    package_from: Пакунок з
     pagination:
-      next_page: "наступна сторінка »"
+      next_page: наступна сторінка »
       previous_page: "« попередня сторінка"
       truncate: "…"
-    password: "Пароль"
-    paste: "Вставити"
-    path: "Шлях"
-    pay: "сплатити"
-    payment: "Платіж"
-    payment_could_not_be_created: "Неможливо створити платіж."
-    payment_identifier: "Ідентифікатор платежу"
-    payment_information: "Інформація про платіж"
-    payment_method: "Спосіб оплати"
-    payment_method_not_supported: "Цей спосіб оплати не підтримується"
-    payment_methods: "Способи оплати"
-    payment_processing_failed: "Неможливо здійснити платіж. Перевірте введену інформацію"
-    payment_processor_choose_banner_text: "Якщо вам потрібна допомога у виборі інструменту оплати, відвідайте"
-    payment_processor_choose_link: "нашу сторінку оплати"
-    payment_state: "Стан платежу"
+    password: Пароль
+    paste: Вставити
+    path: Шлях
+    pay: сплатити
+    payment: Платіж
+    payment_could_not_be_created: Неможливо створити платіж.
+    payment_identifier: Ідентифікатор платежу
+    payment_information: Інформація про платіж
+    payment_method: Спосіб оплати
+    payment_method_not_supported: Цей спосіб оплати не підтримується
+    payment_methods: Способи оплати
+    payment_processing_failed: Неможливо здійснити платіж. Перевірте введену інформацію
+    payment_processor_choose_banner_text: Якщо вам потрібна допомога у виборі інструменту оплати, відвідайте
+    payment_processor_choose_link: нашу сторінку оплати
+    payment_state: Стан платежу
     payment_states:
-      balance_due: "частково"
-      checkout: "оформляється"
-      completed: "завершений"
-      credit_owed: "в кредит"
-      failed: "помилка"
-      paid: "сплачений"
-      pending: "в очікуванні"
-      processing: "в обробці"
-      void: "анульовано"
-    payment_updated: "Платіж оновлено"
-    payments: "Платежі"
-    pending: "Очікується"
-    percent: "Відсоток"
-    percent_per_item: "Відсоток за одиницю"
-    permalink: "Постійне посилання"
-    phone: "Телефон"
-    place_order: "Розмістити замовлення"
-    please_define_payment_methods: "Визначіть спочатку метод оплати."
-    populate_get_error: "Щось трапилось. Спробуйте додати товар пізніше."
-    powered_by: "Працює на"
-    pre_tax_amount: "Сума без податків"
-    pre_tax_refund_amount: "Сума повернення грошей без податків"
-    pre_tax_total: "Разом без податків"
-    preferred_reimbursement_type: "Зручніший тип відшкодування"
-    presentation: "Відображати як"
-    previous: "поперед."
-    price: "Ціна"
-    price_range: "Ціновий діапазон"
-    price_sack: "Сума позицій"
-    process: "Обробити"
-    product: "Товар"
-    product_details: "Докладно про товар"
-    product_has_no_description: "У даного товару немає опису."
-    product_not_available_in_this_currency: "Даний товар недоступний в вибраній валюті."
-    product_properties: "Властивості товару"
+      balance_due: частково
+      checkout: оформляється
+      completed: завершений
+      credit_owed: в кредит
+      failed: помилка
+      paid: сплачений
+      pending: в очікуванні
+      processing: в обробці
+      void: анульовано
+    payment_updated: Платіж оновлено
+    payments: Платежі
+    pending: Очікується
+    percent: Відсоток
+    percent_per_item: Відсоток за одиницю
+    permalink: Постійне посилання
+    phone: Телефон
+    place_order: Розмістити замовлення
+    please_define_payment_methods: Визначіть спочатку метод оплати.
+    populate_get_error: Щось трапилось. Спробуйте додати товар пізніше.
+    powered_by: Працює на
+    pre_tax_amount: Сума без податків
+    pre_tax_refund_amount: Сума повернення грошей без податків
+    pre_tax_total: Разом без податків
+    preferred_reimbursement_type: Зручніший тип відшкодування
+    presentation: Відображати як
+    previous: поперед.
+    price: Ціна
+    price_range: Ціновий діапазон
+    price_sack: Сума позицій
+    process: Обробити
+    product: Товар
+    product_details: Докладно про товар
+    product_has_no_description: У даного товару немає опису.
+    product_not_available_in_this_currency: Даний товар недоступний в вибраній валюті.
+    product_properties: Властивості товару
     product_rule:
-      choose_products: "Вибрані товари"
-      label: "Замовлення має містити %{select} цих товарів"
-      match_all: "все"
-      match_any: "хоча б один"
-      match_none: "жодного"
+      choose_products: Вибрані товари
+      label: Замовлення має містити %{select} цих товарів
+      match_all: все
+      match_any: хоча б один
+      match_none: жодного
       product_source:
-        group: "Із групи товарів"
-        manual: "Обрати вручну"
-    products: "Товари"
-    promotion: "Промоакція"
-    promotion_action: "Вид промоакції"
+        group: Із групи товарів
+        manual: Обрати вручну
+    products: Товари
+    promotion: Промоакція
+    promotion_action: Вид промоакції
     promotion_action_types:
       create_adjustment:
-        description: "Створює промоакцію зі знижкою для замовлення"
-        name: "Створити коригування для замовлення"
+        description: Створює промоакцію зі знижкою для замовлення
+        name: Створити коригування для замовлення
       create_item_adjustments:
-        description: "Створює промоакцію зі знижкою для позиції замовлення"
-        name: "Створити коригування для позиції замовлення"
+        description: Створює промоакцію зі знижкою для позиції замовлення
+        name: Створити коригування для позиції замовлення
       create_quantity_adjustments:
-        description: "Створює коригування по кількості для позиції замовлення"
-        name: "Створити коригування по кількості"
+        description: Створює коригування по кількості для позиції замовлення
+        name: Створити коригування по кількості
       free_shipping:
-        description: "Робить всі доставки безкоштовними"
-        name: "Безкоштовна доставка"
-    promotion_actions: "Види промоакцій"
+        description: Робить всі доставки безкоштовними
+        name: Безкоштовна доставка
+    promotion_actions: Види промоакцій
     promotion_form:
       match_policies:
-        all: "Відповідає всім цим правилам"
-        any: "Відповідає хоча б одному правилу"
-    promotion_rule: "Правило промоакції"
+        all: Відповідає всім цим правилам
+        any: Відповідає хоча б одному правилу
+    promotion_rule: Правило промоакції
     promotion_rule_types:
       first_order:
-        description: "Повинно бути першим замовленням покупця"
-        name: "Перше замовлення"
-      item_total:
-        description: "Сума замовлення відповідає таким критеріям"
-        name: "Сума замовлення"
-      landing_page:
-        description: "Покупець повинен відвідати вказану сторінку"
-        name: "Промо-сторінка"
-      one_use_per_user:
-        description: "Тільки одне використання на користувача"
-        name: "Одне використання на користувача"
-      option_value:
-        description: "Замовлення включає вказані товари з відповідними значеннями характеристик"
-        name: "Значення характеристики"
-      product:
-        description: "Замовлення включає зазначені товари"
-        name: "Товар"
-      user:
-        description: "Доступно тільки для зазначених користувачів"
-        name: "Користувач"
-      user_logged_in:
-        description: "Тільки для користувачів, які увійшли"
-        name: "Користувач, який увійшов"
-      taxon:
-        description: "У замовленні є товари із вказаними таксонами"
-        name: "Таксон"
-      nth_order:
-        description: Застовувати акцію до кожного N-ого замовлення, яке користувач завершив.
-        name: N-е замовлення
-        form_text: "Застосувати цю акцію для N-ого замовлення користувача: "
+        description: Повинно бути першим замовленням покупця
+        name: Перше замовлення
       first_repeat_purchase_since:
         description: Доступне тільки для користувача, який не купляв останнім часом
+        form_text: 'Застосувати цю акцію до користувачів, чиє останнє замовлення було більше, ніж X днів тому: '
         name: Перша повторна купівля, починаючи з
-        form_text: "Застосувати цю акцію до користувачів, чиє останнє замовлення було більше, ніж X днів тому: "
+      item_total:
+        description: Сума замовлення відповідає таким критеріям
+        name: Сума замовлення
+      landing_page:
+        description: Покупець повинен відвідати вказану сторінку
+        name: Промо-сторінка
+      nth_order:
+        description: Застовувати акцію до кожного N-ого замовлення, яке користувач завершив.
+        form_text: 'Застосувати цю акцію для N-ого замовлення користувача: '
+        name: N-е замовлення
+      one_use_per_user:
+        description: Тільки одне використання на користувача
+        name: Одне використання на користувача
+      option_value:
+        description: Замовлення включає вказані товари з відповідними значеннями характеристик
+        name: Значення характеристики
+      product:
+        description: Замовлення включає зазначені товари
+        name: Товар
+      taxon:
+        description: У замовленні є товари із вказаними таксонами
+        name: Таксон
+      user:
+        description: Доступно тільки для зазначених користувачів
+        name: Користувач
+      user_logged_in:
+        description: Тільки для користувачів, які увійшли
+        name: Користувач, який увійшов
+    promotion_successfully_created: Промоакцію успішно створено!
+    promotion_total_changed_before_complete: >-
+      Одна або кілька промоакцій не можуть бути застосовані до вашого замовлення і будуть видалені. Будь ласка, перевірте суми в новому замовленні
+      і спробуйте знову.
+    promotion_uses: Застосування промоакцій
     promotions: Промоакції
-    promotion_successfully_created: "Промоакцію успішно створено!"
-    promotion_total_changed_before_complete: "Одна або кілька промоакцій не можуть бути застосовані до вашого замовлення і будуть видалені. Будь ласка, перевірте суми в новому замовленні і спробуйте знову."
-    promotion_uses: "Застосування промоакцій"
-    propagate_all_variants: "Застосувати до всіх варіантів"
-    properties: "Властивості"
-    property: "Властивість"
-    prototype: "Прототип"
-    prototypes: "Прототипи"
-    provider: "Постачальник"
-    provider_settings_warning: "Якщо ви змінюєте тип постачальника, ви повинні зберегти цю зміну, перш ніж ви зможете редагувати його налаштування."
-    qty: "Кількість"
-    quantity: "Кількість"
-    quantity_returned: "Кількість повернених"
-    quantity_shipped: "Кількість відправлених"
-    rate: "Ставка"
-    ready_to_ship: "Готовий до відправлення"
-    reason: "Підстава"
-    receive: "Отримати"
-    received: "Отримано"
-    receive_stock: "Отримати залишок"
-    receive_items: "Отримати позиції"
-    received_successfully: "Отримано успішно"
+    propagate_all_variants: Застосувати до всіх варіантів
+    properties: Властивості
+    property: Властивість
+    prototype: Прототип
+    prototypes: Прототипи
+    provider: Постачальник
+    provider_settings_warning: Якщо ви змінюєте тип постачальника, ви повинні зберегти цю зміну, перш ніж ви зможете редагувати його налаштування.
+    qty: Кількість
+    quantity: Кількість
+    quantity_returned: Кількість повернених
+    quantity_shipped: Кількість відправлених
+    rate: Ставка
+    ready_to_ship: Готовий до відправлення
+    reason: Підстава
+    receive: Отримати
+    receive_items: Отримати позиції
+    receive_stock: Отримати залишок
+    received: Отримано
+    received_successfully: Отримано успішно
     receiving: Отримання
-    receiving_match: "Отримання співпадінь"
-    reception_status: "Статус прийому"
-    reference: "Посилання"
-    refund: "Повернення грошей"
-    refund_amount_must_be_greater_than_zero: "Сума повернення грошей має бути більшою нуля"
-    refund_reasons: "Підстави повернення грошей"
-    refunded_amount: "Повернена сума грошей"
-    refunds: "Повернення грошей"
-    register: "Зареєструватися як новий користувач"
-    registration: "Реєстрація"
-    reimburse: "Відшкодувати"
-    reimbursed: "Відшкодовано"
-    reimbursement: "Відшкодування"
+    receiving_match: Отримання співпадінь
+    reception_status: Статус прийому
+    reference: Посилання
+    refund: Повернення грошей
+    refund_amount_must_be_greater_than_zero: Сума повернення грошей має бути більшою нуля
+    refund_reasons: Підстави повернення грошей
+    refunded_amount: Повернена сума грошей
+    refunds: Повернення грошей
+    register: Зареєструватися як новий користувач
+    registration: Реєстрація
+    reimburse: Відшкодувати
+    reimbursed: Відшкодовано
+    reimbursement: Відшкодування
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send: "Ви можете повернути для обміну будь-які товари протягом %{days} днів."
-        dear_customer: "Шановний покупцю,\\n"
-        exchange_summary: "Коротко про заміну"
-        for: "на"
-        instructions: "Ваше відшкодування було оброблене."
-        refund_summary: "Коротко про повернення грошей"
-        subject: "Повідомлення про відшкодування"
-        total_refunded: "Разом повернуто грошей: %{total}"
-    reimbursement_perform_failed: "Неможливо провести відшкодування. Помилка %{error}"
-    reimbursement_status: "Стан відшкодування"
-    reimbursement_type: "Тип відшкодування"
-    reimbursement_type_override: "Перевизначення типу відшкодування"
-    reimbursement_types: "Типи відшкодування"
-    reimbursements: "Відшкодування"
-    reject: "Відхилити"
-    rejected: "Відхилено"
-    remember_me: "Запам’ятати мене"
-    remove: "Видалити"
-    rename: "Переіменувати"
-    reports: "Звіти"
-    resend: "Відправити повторно"
-    reset_password: "Скинути мій пароль"
-    response_code: "Код відповіді"
-    resume: "відновити"
-    resumed: "Відновлено"
-    return: "повернути"
-    return_authorization: "Дозвіл на повернення товару"
+        days_to_send: Ви можете повернути для обміну будь-які товари протягом %{days} днів.
+        dear_customer: Шановний покупцю,\n
+        exchange_summary: Коротко про заміну
+        for: на
+        instructions: Ваше відшкодування було оброблене.
+        refund_summary: Коротко про повернення грошей
+        subject: Повідомлення про відшкодування
+        total_refunded: 'Разом повернуто грошей: %{total}'
+    reimbursement_perform_failed: Неможливо провести відшкодування. Помилка %{error}
+    reimbursement_status: Стан відшкодування
+    reimbursement_type: Тип відшкодування
+    reimbursement_type_override: Перевизначення типу відшкодування
+    reimbursement_types: Типи відшкодування
+    reimbursements: Відшкодування
+    reject: Відхилити
+    rejected: Відхилено
+    remember_me: Запам’ятати мене
+    remove: Видалити
+    rename: Переіменувати
+    reports: Звіти
+    resend: Відправити повторно
+    reset_password: Скинути мій пароль
+    response_code: Код відповіді
+    resume: відновити
+    resumed: Відновлено
+    return: повернути
+    return_authorization: Дозвіл на повернення товару
+    return_authorization_updated: Дозвіл на повернення товару оновлено
+    return_authorizations: Дозволи на повернення товару
+    return_item_inventory_unit_ineligible: Позиція, що повертається, має бути доставлена
+    return_item_inventory_unit_reimbursed: Позиція, що повертається, уже відшкодована
+    return_item_order_not_completed: Замовлення позиції, що повертається, має бути завершено
+    return_item_rma_ineligible: Повернення позиції вимагає дозволу продавця
+    return_item_time_period_ineligible: Термін повернення товару збіг
+    return_items: Повернені позиції
+    return_items_cannot_be_associated_with_multiple_orders: Повернені позиції не можуть належати до різних замовлень.
+    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: Не можна створити повернення для позицій, які очікують
+      на заміну.
+    return_number: Номер повернення
+    return_quantity: повернена кількість
     return_reasons: Підстави повернення
-    return_authorization_updated: "Дозвіл на повернення товару оновлено"
-    return_authorizations: "Дозволи на повернення товару"
-    return_item_inventory_unit_ineligible: "Позиція, що повертається, має бути доставлена"
-    return_item_inventory_unit_reimbursed: "Позиція, що повертається, уже відшкодована"
-    return_item_order_not_completed: "Замовлення позиції, що повертається, має бути завершено"
-    return_item_rma_ineligible: "Повернення позиції вимагає дозволу продавця"
-    return_item_time_period_ineligible: "Термін повернення товару збіг"
-    return_items: "Повернені позиції"
-    return_items_cannot_be_associated_with_multiple_orders: "Повернені позиції не можуть належати до різних замовлень."
-    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: "Не можна створити повернення для позицій, які очікують на заміну."
-    return_number: "Номер повернення"
-    return_quantity: "повернена кількість"
-    returned: "Повернуті"
-    returns: "Повернення"
-    review: "Огляд"
-    risk: "Ризик"
-    risk_analysis: "Аналіз ризиків"
-    risky: "Ризиковано"
-    rma_credit: "Кредит дозволу на повернення товару"
-    rma_number: "Номер дозволу на повернення товару"
-    rma_value: "Сума дозволу на повернення товару"
-    roles: "Ролі"
-    rules: "Правила"
-    sales_total: "Разом продажі"
-    sales_total_description: "Разом продано за всіма замовленнями"
-    sales_totals: "Разом продажі"
-    save_and_continue: "Зберегти і продовжити"
-    save_my_address: "Зберегти мою адресу"
-    say_no: "Ні"
-    say_yes: "Так"
-    scope: "Фільтр"
-    search: "Пошук"
-    search_results: "Результати пошуку за запитом '%{keywords}'"
-    searching: "Йде пошук ..."
-    secure_connection_type: "Тип захищеного з’єднання"
-    security_settings: "Налаштування безпеки"
-    select: "Обрати"
-    select_from_prototype: "Вибрати з прототипів"
+    returned: Повернуті
+    returns: Повернення
+    review: Огляд
+    risk: Ризик
+    risk_analysis: Аналіз ризиків
+    risky: Ризиковано
+    rma_credit: Кредит дозволу на повернення товару
+    rma_number: Номер дозволу на повернення товару
+    rma_value: Сума дозволу на повернення товару
+    roles: Ролі
+    rules: Правила
+    sales_total: Разом продажі
+    sales_total_description: Разом продано за всіма замовленнями
+    sales_totals: Разом продажі
+    save_and_continue: Зберегти і продовжити
+    save_my_address: Зберегти мою адресу
+    say_no: Ні
+    say_yes: Так
+    scope: Фільтр
+    search: Пошук
+    search_results: Результати пошуку за запитом '%{keywords}'
+    searching: Йде пошук ...
+    secure_connection_type: Тип захищеного з’єднання
+    security_settings: Налаштування безпеки
+    select: Обрати
     select_a_reason: Вибрати підставу
-    select_a_stock_location: "Вибрати склад"
-    select_stock: "Вибрати залишок"
-    selected_quantity_not_available: "Вибрана кількість %{item} недоступна."
-    send_copy_of_all_mails_to: "Надсилати копії всіх листів на"
-    send_mailer: "Надіслати пошту"
-    send_mails_as: "Надіслати пошту як"
-    server: "Сервер"
-    server_error: "На сервері сталася помилка"
-    settings: "Налаштування"
-    ship: "доставка"
-    ship_address: "Адреса доставки"
+    select_a_stock_location: Вибрати склад
+    select_from_prototype: Вибрати з прототипів
+    select_stock: Вибрати залишок
+    selected_quantity_not_available: Вибрана кількість %{item} недоступна.
+    send_copy_of_all_mails_to: Надсилати копії всіх листів на
+    send_mailer: Надіслати пошту
+    send_mails_as: Надіслати пошту як
+    server: Сервер
+    server_error: На сервері сталася помилка
+    settings: Налаштування
+    ship: доставка
+    ship_address: Адреса доставки
     ship_address_required: Необхідна дійсна адреса доставки
     ship_stock_transfer:
-      will_cause: Доставка переміщення запасів призведе до наступного
       no_further_changes: Відтепер Ви не зможете вносити зміни в переміщення запасів
-    ship_total: "Разом доставка"
-    shipped_at: "Відправлено в"
-    shipment: "Відправлення"
-    shipment_adjustments: "Коригування відправлення"
-    shipment_details: "З %{stock_location} способом %{shipping_method}"
+      will_cause: Доставка переміщення запасів призведе до наступного
+    ship_total: Разом доставка
+    shipment: Відправлення
+    shipment_adjustments: Коригування відправлення
+    shipment_date: Дата відправлення
+    shipment_details: З %{stock_location} способом %{shipping_method}
     shipment_mailer:
       shipped_email:
-        dear_customer: "Шановний покупцю,\\n"
-        instructions: "Ваше замовлення відправлено"
-        shipment_summary: "Коротко про відправлення"
-        subject: "Повідомлення про доставку"
-        thanks: "Дякуємо за замовлення."
-        track_information: "Інформація про відстеження: %{tracking}"
-        track_link: "Посилання на відстеження: %{url}"
-    shipment_date: Дата відправлення
+        dear_customer: Шановний покупцю,\n
+        instructions: Ваше замовлення відправлено
+        shipment_summary: Коротко про відправлення
+        subject: Повідомлення про доставку
+        thanks: Дякуємо за замовлення.
+        track_information: 'Інформація про відстеження: %{tracking}'
+        track_link: 'Посилання на відстеження: %{url}'
     shipment_number: Номер відправлення
     shipment_numbers: Номера відправлень
-    shipment_state: "Статус відправки"
+    shipment_state: Статус відправки
     shipment_states:
-      backorder: "нерозміщене"
-      canceled: "скасоване"
-      partial: "частково"
-      pending: "очікує"
-      ready: "готове"
-      shipped: "відправлене"
-    shipment_transfer_error: "Сталась помилка при переміщенні"
-    shipment_transfer_success: "Варіанти успішно переміщено"
-    shipments: "Відправлення"
-    shipped: "Відправлено"
-    shipping: "Доставка"
-    shipping_address: "Адреса доставки"
-    shipping_categories: "Категорії доставки"
-    shipping_category: "Категорія доставки"
-    shipping_flat_rate_per_item: "Фіксована ставка за позицію пакунку"
-    shipping_flat_rate_per_order: "Фіксована ставка"
-    shipping_flexible_rate: "Гнучка ставка за позицію пакунку"
-    shipping_instructions: "Іструкції щодо доставки"
-    shipping_method: "Спосіб доставки"
-    shipping_methods: "Способи доставки"
-    shipping_price_sack: "Сума відправлених позицій"
-    shipping_total: "Разом доставка"
-    shop_by_taxonomy: "Переглянути за %{taxonomy}"
-    shopping_cart: "Кошик"
-    show: "Показати"
-    show_active: "Показати активні"
-    show_deleted: "Показати видалені"
-    show_only_complete_orders: "Показувати тільки завершені замовлення"
-    show_only_considered_risky: "Показувати тільки ризиковані замовлення"
-    show_rate_in_label: "Показувати процент в назві"
-    sku: "Артикул"
-    skus: "Артикули"
-    slug: "Заголовок в URL"
-    source: "Джерело"
-    source_location: "Склад-відправник"
-    special_instructions: "Додаткові інструкції"
-    split: "Розділити"
-    spree_gateway_error_flash_for_checkout: "Виникли проблеми з Вашими реквізитами платежу. Будь ласка, перевірте їх та спробуйте ще раз."
+      backorder: нерозміщене
+      canceled: скасоване
+      partial: частково
+      pending: очікує
+      ready: готове
+      shipped: відправлене
+    shipment_transfer_error: Сталась помилка при переміщенні
+    shipment_transfer_success: Варіанти успішно переміщено
+    shipments: Відправлення
+    shipped: Відправлено
+    shipped_at: Відправлено в
+    shipping: Доставка
+    shipping_address: Адреса доставки
+    shipping_categories: Категорії доставки
+    shipping_category: Категорія доставки
+    shipping_flat_rate_per_item: Фіксована ставка за позицію пакунку
+    shipping_flat_rate_per_order: Фіксована ставка
+    shipping_flexible_rate: Гнучка ставка за позицію пакунку
+    shipping_instructions: Іструкції щодо доставки
+    shipping_method: Спосіб доставки
+    shipping_methods: Способи доставки
+    shipping_price_sack: Сума відправлених позицій
+    shipping_total: Разом доставка
+    shop_by_taxonomy: Переглянути за %{taxonomy}
+    shopping_cart: Кошик
+    show: Показати
+    show_active: Показати активні
+    show_deleted: Показати видалені
+    show_only_complete_orders: Показувати тільки завершені замовлення
+    show_only_considered_risky: Показувати тільки ризиковані замовлення
+    show_rate_in_label: Показувати процент в назві
+    sku: Артикул
+    skus: Артикули
+    slug: Заголовок в URL
+    source: Джерело
+    source_location: Склад-відправник
+    special_instructions: Додаткові інструкції
+    split: Розділити
+    spree_gateway_error_flash_for_checkout: Виникли проблеми з Вашими реквізитами платежу. Будь ласка, перевірте їх та спробуйте ще раз.
     ssl:
-      change_protocol: "Змініть протокол на HTTP (замість HTTPS) та повторіть запит."
-    start: "Початок"
-    state: "Регіон/Область"
-    state_based: "Є області"
-    states: "Регіони/Області"
-    states_required: "Регіони/Області обов’язкові"
-    status: "Статус"
-    stock: "Залишок"
-    stock_location: "Склад"
-    stock_location_info: "Інформація про склад"
-    stock_locations: "Склади"
-    stock_locations_need_a_default_country: "Перед створенням складу створіть країну за замовчуванням."
-    stock_management: "Управління запасами"
-    stock_management_requires_a_stock_location: "Будь-ласка, додайте склад для управління запасами."
-    stock_movements: "Рух залишків"
-    stock_movements_for_stock_location: "Рух залишків для %{stock_location_name}"
+      change_protocol: Змініть протокол на HTTP (замість HTTPS) та повторіть запит.
+    start: Початок
+    state: Регіон/Область
+    state_based: Є області
+    states: Регіони/Області
+    states_required: Регіони/Області обов’язкові
+    status: Статус
+    stock: Залишок
+    stock_location: Склад
+    stock_location_info: Інформація про склад
+    stock_locations: Склади
+    stock_locations_need_a_default_country: Перед створенням складу створіть країну за замовчуванням.
+    stock_management: Управління запасами
+    stock_management_requires_a_stock_location: Будь-ласка, додайте склад для управління запасами.
+    stock_movements: Рух залишків
+    stock_movements_for_stock_location: Рух залишків для %{stock_location_name}
     stock_not_below_zero: Залишок не може бути менше, ніж 0.
-    stock_successfully_transferred: "Залишок успішно переміщений між місцями зберігання."
-    stock_transfer: "Переміщення залишків"
-    stock_transfer_cannot_be_finalized: "Переміщення залишків не може бути зафіксовано"
-    stock_transfer_complete: "Переміщення залишків завершене"
-    stock_transfer_must_be_receivable: "Переміщення залишків має бути закрите та доставлене"
-    stock_transfers: "Переміщення залишків"
-    stop: "Кінець"
-    store: "До магазину"
+    stock_successfully_transferred: Залишок успішно переміщений між місцями зберігання.
+    stock_transfer: Переміщення залишків
+    stock_transfer_cannot_be_finalized: Переміщення залишків не може бути зафіксовано
+    stock_transfer_complete: Переміщення залишків завершене
+    stock_transfer_must_be_receivable: Переміщення залишків має бути закрите та доставлене
+    stock_transfers: Переміщення залишків
+    stop: Кінець
+    store: До магазину
     store_credit:
       actions:
-        invalidate: "Зробити недійсним"
-      credit_allocation_memo: "Це кредит з кредиту магазину ID %{id}"
-      currency_mismatch: "Валюта кредиту магазину не співпадає з валютою замовлення"
+        invalidate: Зробити недійсним
+      credit_allocation_memo: Це кредит з кредиту магазину ID %{id}
+      currency_mismatch: Валюта кредиту магазину не співпадає з валютою замовлення
       display_action:
         adjustment: Коригування
+        admin:
+          authorize: Авторизувати
+          eligible: Допустимість перевірено
+          void: Анульовано
         allocation: Додано
         capture: Використано
         credit: Кредит
         invalidate: Недійсне
         void: Кредит
-        admin:
-          authorize: "Авторизувати"
-          eligible: "Допустимість перевірено"
-          void: "Анульовано"
       errors:
-        unable_to_fund: "Неможливо заплатити за замовлення з кредитів магазину"
-        cannot_invalidate_uncaptured_authorization: "Неможливо зробити недійсним кредит магазину з невикористаним дозволом"
+        cannot_invalidate_uncaptured_authorization: Неможливо зробити недійсним кредит магазину з невикористаним дозволом
+        unable_to_fund: Неможливо заплатити за замовлення з кредитів магазину
       expiring: Термін дії закінчується
-      insufficient_authorized_amount: "Неможливо використати більше, ніж дозволена сума"
-      insufficient_funds: "Залишка кредиту магазину недостатньо"
+      insufficient_authorized_amount: Неможливо використати більше, ніж дозволена сума
+      insufficient_funds: Залишка кредиту магазину недостатньо
       non_expiring: Термін дії не закінчується
       select_one_store_credit: Виберіть кредит магазину для переходу до балансу"
-      store_credit: "Кредит магазину"
-      successful_action: "Успішна подія кредиту магазину — %{action}"
-      unable_to_credit: "Неможливо надати кредит за кодом: %{auth_code}"
-      unable_to_void: "Неможливо анулювати код: %{auth_code}"
-      unable_to_find: "Неможливо знайти кредит магазину"
-      unable_to_find_for_action: "Неможливо знайти кредит магазину для коду авторизації: %{auth_code} та події: %{action}"
-      user_has_no_store_credits: "У користувача немає доступних кредитів магазину"
+      store_credit: Кредит магазину
+      successful_action: Успішна подія кредиту магазину — %{action}
+      unable_to_credit: 'Неможливо надати кредит за кодом: %{auth_code}'
+      unable_to_find: Неможливо знайти кредит магазину
+      unable_to_find_for_action: 'Неможливо знайти кредит магазину для коду авторизації: %{auth_code} та події: %{action}'
+      unable_to_void: 'Неможливо анулювати код: %{auth_code}'
+      user_has_no_store_credits: У користувача немає доступних кредитів магазину
     store_credit_category:
       default: За замовчуванням
-    street_address: "Адреса"
-    street_address_2: "Адреса (рядок 2)"
-    subtotal: "Проміжний підсумок"
-    subtract: "Відрахування"
-    success: "Успішно"
+    street_address: Адреса
+    street_address_2: Адреса (рядок 2)
+    subtotal: Проміжний підсумок
+    subtract: Відрахування
+    success: Успішно
     successfully_created: "%{resource} був успішно створено!"
     successfully_refunded: "%{resource} успішно повернено!"
     successfully_removed: "%{resource} був успішно знищено!"
-    successfully_signed_up_for_analytics: "Авторизація в Spree Analytics пройшла успішно"
+    successfully_signed_up_for_analytics: Авторизація в Spree Analytics пройшла успішно
     successfully_updated: "%{resource} було успішно оновлено!"
-    tax: "Податок"
-    tax_included: "Податок (вкл.)"
-    tax_categories: "Категорії податків"
-    tax_category: "Категорія податків"
+    tax: Податок
+    tax_categories: Категорії податків
+    tax_category: Категорія податків
     tax_code: Код податку
-    tax_rate_amount_explanation: "Податкові ставки вводяться як десяткові значення (наприклад, якщо податок 5%, то введіть 0.05)"
-    tax_rates: "Податкові ставки"
-    taxon: "Таксон"
-    taxon_edit: "Редагувати таксон"
-    taxon_placeholder: "Додати таксон"
+    tax_included: Податок (вкл.)
+    tax_rate_amount_explanation: Податкові ставки вводяться як десяткові значення (наприклад, якщо податок 5%, то введіть 0.05)
+    tax_rates: Податкові ставки
+    taxon: Таксон
+    taxon_edit: Редагувати таксон
+    taxon_placeholder: Додати таксон
     taxon_rule:
-      choose_taxons: "Виберіть таксони"
-      label: "Замовлення має містити %{select} з цих таксонів"
-      match_all: "всі"
-      match_any: "щонайменше один"
-    taxonomies: "Таксономії"
-    taxonomy: "Таксономія"
-    taxonomy_edit: "Редагування таксономії"
-    taxonomy_tree_error: "Зміни не прийняті і дерево повернуто у попередній стан. Будь ласка, спробуйте знову."
+      choose_taxons: Виберіть таксони
+      label: Замовлення має містити %{select} з цих таксонів
+      match_all: всі
+      match_any: щонайменше один
+    taxonomies: Таксономії
+    taxonomy: Таксономія
+    taxonomy_edit: Редагування таксономії
+    taxonomy_tree_error: Зміни не прийняті і дерево повернуто у попередній стан. Будь ласка, спробуйте знову.
     taxonomy_tree_instruction: "* Клацніть правою кнопкою миші на дочірньому елементі дерева для додавання, видалення або сортування цього елементу."
-    taxons: "Таксони"
+    taxons: Таксони
     test: Тест
     test_mailer:
       test_email:
-        greeting: "Наші вітання!"
-        message: "Якщо ви отримали це повідомлення, тоді ваші поштові налаштування правильні."
-        subject: "Тестове повідомлення"
-    test_mode: "Тестовий режим"
-    thank_you_for_your_order: "Дякуємо за покупку!"
-    there_are_no_items_for_this_order: "В цьому замовленні немає позицій. Будь ласка, додайте товари, щоби продовжити."
-    there_were_problems_with_the_following_fields: "Виникли проблеми з наступними полями"
-    this_order_has_already_received_a_refund: "За цим замовленням уже отримано повернення грошей"
-    thumbnail: "Мініатюра"
-    tiered_flat_rate: "Багаторівнева фіксована ставка"
-    tiered_percent: "Багаторівневий відсоток"
-    tiers: "Рівні"
-    time: "Час"
-    to: "До"
-    to_add_variants_you_must_first_define: "Перед тим, як додати варіанти, ви повинні визначити"
-    total: "Разом"
-    total_per_item: "Разом позиція"
-    total_pre_tax_refund: "Разом повернення грошей без податків"
-    total_price: "Сума"
-    total_sales: "Разом продажі"
-    track_inventory: "Вести облік залишків"
-    tracking: "Відстеження"
-    tracking_number: "Номер відстеження"
-    tracking_url: "URL відстеження"
-    tracking_url_placeholder: "наприклад, http://quickship.com/package?num=:tracking"
-    transaction_id: "ID транзакції"
-    transfer_items: "Позиції переміщення"
-    transfer_from_location: "Переміщення зі складу"
-    transfer_stock: "Перемістити залишки"
-    transfer_to_location: "Переміщення на склад"
-    transfer_number: "Номер переміщення"
-    tree: "Дерево"
-    type: "Тип"
-    type_to_search: "Почніть друкувати, щоб активувати пошук"
-    unable_to_find_all_inventory_units: "Неможливо знайти всі розміщення позицій замовлення"
-    unable_to_connect_to_gateway: "Не вдалося підключитися до платіжного шлюзу."
-    unable_to_create_reimbursements: "Неможливо створити відшкодування, оскільки деякі позиції очікують людського втручання."
-    unfinalize_all_adjustments: "Розфіксувати всі коригування"
-    under_price: "Дешевше %{price}"
-    unlock: "Розблокувати"
-    unrecognized_card_type: "Невідомий тип карти"
-    unshippable_items: "Товари, що не можуть доставлятися"
-    update: "Оновити"
-    updated_successfully: "Успішно оновлено"
-    updating: "Оновлення"
-    usage_limit: "Ліміт використань"
-    use_app_default: "Використовувати значення за замовчуванням"
-    use_billing_address: "Використовувати платіжну адресу"
-    use_new_cc: "Використовувати нову карту"
-    use_s3: "Використоувати Amazon S3 для зображень"
-    user: "Користувач"
+        greeting: Наші вітання!
+        message: Якщо ви отримали це повідомлення, тоді ваші поштові налаштування правильні.
+        subject: Тестове повідомлення
+    test_mode: Тестовий режим
+    thank_you_for_your_order: Дякуємо за покупку!
+    there_are_no_items_for_this_order: В цьому замовленні немає позицій. Будь ласка, додайте товари, щоби продовжити.
+    there_were_problems_with_the_following_fields: Виникли проблеми з наступними полями
+    this_order_has_already_received_a_refund: За цим замовленням уже отримано повернення грошей
+    thumbnail: Мініатюра
+    tiered_flat_rate: Багаторівнева фіксована ставка
+    tiered_percent: Багаторівневий відсоток
+    tiers: Рівні
+    time: Час
+    to: До
+    to_add_variants_you_must_first_define: Перед тим, як додати варіанти, ви повинні визначити
+    total: Разом
+    total_per_item: Разом позиція
+    total_pre_tax_refund: Разом повернення грошей без податків
+    total_price: Сума
+    total_sales: Разом продажі
+    track_inventory: Вести облік залишків
+    tracking: Відстеження
+    tracking_number: Номер відстеження
+    tracking_url: URL відстеження
+    tracking_url_placeholder: наприклад, http://quickship.com/package?num=:tracking
+    transaction_id: ID транзакції
+    transfer_from_location: Переміщення зі складу
+    transfer_items: Позиції переміщення
+    transfer_number: Номер переміщення
+    transfer_stock: Перемістити залишки
+    transfer_to_location: Переміщення на склад
+    tree: Дерево
+    type: Тип
+    type_to_search: Почніть друкувати, щоб активувати пошук
+    unable_to_connect_to_gateway: Не вдалося підключитися до платіжного шлюзу.
+    unable_to_create_reimbursements: Неможливо створити відшкодування, оскільки деякі позиції очікують людського втручання.
+    unable_to_find_all_inventory_units: Неможливо знайти всі розміщення позицій замовлення
+    under_price: Дешевше %{price}
+    unfinalize_all_adjustments: Розфіксувати всі коригування
+    unlock: Розблокувати
+    unrecognized_card_type: Невідомий тип карти
+    unshippable_items: Товари, що не можуть доставлятися
+    update: Оновити
+    updated_successfully: Успішно оновлено
+    updating: Оновлення
+    usage_limit: Ліміт використань
+    use_app_default: Використовувати значення за замовчуванням
+    use_billing_address: Використовувати платіжну адресу
+    use_new_cc: Використовувати нову карту
+    use_s3: Використоувати Amazon S3 для зображень
+    user: Користувач
     user_rule:
-      choose_users: "Обрати користувачів"
-    users: "Користувачі"
+      choose_users: Обрати користувачів
+    users: Користувачі
     validation:
-      unpaid_amount_not_zero: "Сума неповністю відшкодована. Залишок %{amount}"
-      cannot_be_less_than_shipped_units: "не може бути менше, ніж кількість відправлених одиниць"
-      cannot_destroy_line_item_as_inventory_units_have_shipped: "Неможливо видалити позицію замовлення, оскільки деякі одиниці були відправлені."
-      exceeds_available_stock: "перевищує доступний залишок. Будь ласка, перевірте чи позиція має допустиму кількість."
-      is_too_large: "занадто багато — вільного залишку недостатньо для покриття необхідної кількість!"
-      must_be_int: "має бути цілим числом"
-      must_be_non_negative: "має бути невід’ємним числом"
-    value: "Значення"
-    variant: "Варіант"
-    variant_placeholder: "Виберіть варіант"
-    variant_properties: "Властивості варіантів"
-    variant_search: "Пошук варіантів"
-    variant_search_placeholder: "Артикул або значення характеристики"
-    variant_to_add: "Додати варіант"
-    variant_to_be_received: "Отримати варіант"
-    variants: "Варіанти"
-    version: "Версія"
-    void: "Анулювати"
-    weight: "Вага"
-    what_is_a_cvv: "Що означає CVV?"
-    what_is_this: "Що це?"
-    width: "Ширина"
-    year: "Рік"
+      cannot_be_less_than_shipped_units: не може бути менше, ніж кількість відправлених одиниць
+      cannot_destroy_line_item_as_inventory_units_have_shipped: Неможливо видалити позицію замовлення, оскільки деякі одиниці були відправлені.
+      exceeds_available_stock: перевищує доступний залишок. Будь ласка, перевірте чи позиція має допустиму кількість.
+      is_too_large: занадто багато — вільного залишку недостатньо для покриття необхідної кількість!
+      must_be_int: має бути цілим числом
+      must_be_non_negative: має бути невід’ємним числом
+      unpaid_amount_not_zero: Сума неповністю відшкодована. Залишок %{amount}
+    value: Значення
+    variant: Варіант
+    variant_placeholder: Виберіть варіант
+    variant_properties: Властивості варіантів
+    variant_search: Пошук варіантів
+    variant_search_placeholder: Артикул або значення характеристики
+    variant_to_add: Додати варіант
+    variant_to_be_received: Отримати варіант
+    variants: Варіанти
+    version: Версія
+    void: Анулювати
+    weight: Вага
+    what_is_a_cvv: Що означає CVV?
+    what_is_this: Що це?
+    width: Ширина
+    year: Рік
     yes_close: Так, закрити
     yes_finalize: Так, зафіксувати
-    you_have_no_orders_yet: "У Вас ще немає замовлень."
-    your_cart_is_empty: "Ваш кошик порожній"
-    your_order_is_empty_add_product: "Ваш кошик порожній. Будь ласка, знайдіть та додайте до кошика товар"
-    zip: "Індекс"
-    zipcode: "Поштовий індекс"
-    zone: "Торгова зона"
-    zones: "Торгові зони"
+    you_have_no_orders_yet: У Вас ще немає замовлень.
+    your_cart_is_empty: Ваш кошик порожній
+    your_order_is_empty_add_product: Ваш кошик порожній. Будь ласка, знайдіть та додайте до кошика товар
+    zip: Індекс
+    zipcode: Поштовий індекс
+    zone: Торгова зона
+    zones: Торгові зони

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,22 +1,23 @@
+---
 vi:
   activerecord:
     attributes:
       spree/address:
-        address1: "Địa chỉ"
-        address2: "Địa chỉ (tiếp)"
+        address1: Địa chỉ
+        address2: Địa chỉ (tiếp)
         city: Thành phố
         country: Quốc gia
         firstname: Tên
         lastname: Họ
-        phone: "Điện thoại"
+        phone: Điện thoại
         state: Bang
         zipcode: Mã Zip
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +25,10 @@ vi:
         name: Tên
         numcode: Mã ISO
       spree/credit_card:
-        base:
+        base: 
         cc_type: Kiểu
         month: Tháng
-        name:
+        name: 
         number: Số
         verification_value: Thông số kiểm tra
         year: Năm
@@ -42,11 +43,11 @@ vi:
       spree/order:
         checkout_complete: Thanh toán hoàn tất
         completed_at: Hoàn tất lúc
-        considered_risky:
-        coupon_code:
+        considered_risky: 
+        coupon_code: 
         created_at: Ngày đặt hàng
         email: Email của khách hàng
-        ip_address: "Địa chỉ IP"
+        ip_address: Địa chỉ IP
         item_total: Tổng sản phẩm
         number: Số
         payment_state: Trạng thái thanh toán
@@ -55,34 +56,34 @@ vi:
         state: Bang
         total: Tổng
       spree/order/bill_address:
-        address1: "Đỉa chị thanh toán - tên đường"
-        city: "Đỉa chị thanh toán - thành phố"
-        firstname: "Đỉa chị thanh toán - tên"
-        lastname: "Đỉa chị thanh toán - họ"
-        phone: "Đỉa chị thanh toán - ĐT"
-        state: "Đỉa chị thanh toán - bang"
-        zipcode: "Đỉa chị thanh toán - mã zip"
+        address1: Đỉa chị thanh toán - tên đường
+        city: Đỉa chị thanh toán - thành phố
+        firstname: Đỉa chị thanh toán - tên
+        lastname: Đỉa chị thanh toán - họ
+        phone: Đỉa chị thanh toán - ĐT
+        state: Đỉa chị thanh toán - bang
+        zipcode: Đỉa chị thanh toán - mã zip
       spree/order/ship_address:
-        address1: "Đỉa chị giao hàng - tên đường"
-        city: "Đỉa chị giao hàng - thành phố"
-        firstname: "Đỉa chị giao hàng - tên"
-        lastname: "Đỉa chị giao hàng - họ"
-        phone: "Đỉa chị giao hàng - ĐT"
-        state: "Đỉa chị giao hàng - bang"
-        zipcode: "Đỉa chị giao hàng - mã zip"
+        address1: Đỉa chị giao hàng - tên đường
+        city: Đỉa chị giao hàng - thành phố
+        firstname: Đỉa chị giao hàng - tên
+        lastname: Đỉa chị giao hàng - họ
+        phone: Đỉa chị giao hàng - ĐT
+        state: Đỉa chị giao hàng - bang
+        zipcode: Đỉa chị giao hàng - mã zip
       spree/payment:
         amount: Giá trị
       spree/payment_method:
-        name:
+        name: 
       spree/product:
         available_on: Available On
         cost_currency: Tiền giá
-        cost_price:
-        description:
-        master_price:
-        name:
-        on_hand:
-        shipping_category:
+        cost_price: 
+        description: 
+        master_price: 
+        name: 
+        on_hand: 
+        shipping_category: 
         tax_category: Mục thuế
       spree/promotion:
         advertise: Quảng cáo
@@ -91,11 +92,11 @@ vi:
         event_name: Tên sự kiện
         expires_at: Hết hạn lúc
         name: Tên
-        path: "Đường dẫn"
+        path: Đường dẫn
         starts_at: Bắt đầu lúc
         usage_limit: Giới hạn sử dụng
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
         name: Tên
         presentation: Thể hiện
@@ -109,140 +110,140 @@ vi:
         abbr: Viết tắt
         name: Tên
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
         description: Chú thích
         name: Tên
       spree/tax_rate:
         amount: Mức giá
-        included_in_price:
-        show_rate_in_label:
+        included_in_price: 
+        show_rate_in_label: 
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: 
+        permalink: 
+        position: 
       spree/taxonomy:
-        name:
+        name: 
       spree/user:
-        email:
+        email: 
         password: Mật khẩu
         password_confirmation: Xác nhận mật khẩu
       spree/variant:
         cost_currency: Tiền giá
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_price: 
+        depth: 
+        height: 
+        price: 
+        sku: 
+        weight: 
+        width: 
       spree/zone:
-        description:
-        name:
+        description: 
+        name: 
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
-      spree/address: "Địa chỉ"
+      spree/address: Địa chỉ
       spree/country: Quốc gia
       spree/credit_card: Thẻ tín dụng
-      spree/customer_return:
-      spree/inventory_unit: "Đơn vị hàng"
-      spree/line_item:
-      spree/option_type:
-      spree/option_value:
-      spree/order: "Đơn đặt hàng"
+      spree/customer_return: 
+      spree/inventory_unit: Đơn vị hàng
+      spree/line_item: 
+      spree/option_type: 
+      spree/option_value: 
+      spree/order: Đơn đặt hàng
       spree/payment: Thanh toán
-      spree/payment_method:
+      spree/payment_method: 
       spree/product: Sản phẩm
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: 
+      spree/promotion_category: 
       spree/property: Thuộc tính
       spree/prototype: Mẫu hàng
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
-      spree/return_authorization:
-      spree/return_authorization_reason:
-      spree/role:
-      spree/shipment:
-      spree/shipping_category:
-      spree/shipping_method:
-      spree/state:
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
-      spree/tax_category:
-      spree/tax_rate:
-      spree/taxon:
-      spree/taxonomy:
-      spree/tracker:
-      spree/user:
-      spree/variant:
-      spree/zone:
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
+      spree/return_authorization: 
+      spree/return_authorization_reason: 
+      spree/role: 
+      spree/shipment: 
+      spree/shipping_category: 
+      spree/shipping_method: 
+      spree/state: 
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
+      spree/tax_category: 
+      spree/tax_rate: 
+      spree/taxon: 
+      spree/taxonomy: 
+      spree/tracker: 
+      spree/user: 
+      spree/variant: 
+      spree/zone: 
   spree:
     abbreviation: Từ khóa tắt
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
     account: Tài khoản
     account_updated: Tải khoản được cập nhật!
     action: Lệnh
@@ -255,7 +256,7 @@ vi:
       list: Liệt kê
       listing: Lên danh sách
       new: Mới
-      refund:
+      refund: 
       save: Lưu
       update: Cập nhật
     activate: Kích hoạt
@@ -263,7 +264,7 @@ vi:
     add: Thêm
     add_action_of_type: Thêm hành động loại
     add_country: Thêm quốc gia
-    add_coupon_code:
+    add_coupon_code: 
     add_new_header: Tạo Header mới
     add_new_style: Tạo style mới
     add_one: Tạo một
@@ -277,54 +278,54 @@ vi:
     add_to_cart: Cho vào sọt
     add_variant: Tạo biến thể
     additional_item: Giá phải trả thêm
-    address1: "Địa chỉ"
-    address2: "Địa chỉ (tiếp)"
-    adjustable:
-    adjustment: "Điều chỉnh"
+    address1: Địa chỉ
+    address2: Địa chỉ (tiếp)
+    adjustable: 
+    adjustment: Điều chỉnh
     adjustment_amount: Giá trị
-    adjustment_successfully_closed: "Điều chỉnh đã được đóng!"
-    adjustment_successfully_opened: "Điều chỉnh đã được mở!"
+    adjustment_successfully_closed: Điều chỉnh đã được đóng!
+    adjustment_successfully_opened: Điều chỉnh đã được mở!
     adjustment_total: Tổng Điều chỉnh
-    adjustments: "Điều chỉnh"
+    adjustments: Điều chỉnh
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        promotion_categories:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: 
+        option_types: 
+        orders: 
+        overview: 
+        products: 
+        promotion_categories: 
+        promotions: 
+        properties: 
+        prototypes: 
+        reports: 
+        taxonomies: 
+        taxons: 
+        users: 
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
     administration: Quản trị
-    advertise:
-    agree_to_privacy_policy: "Đồng ý với Điều khoản riêng tư"
-    agree_to_terms_of_service: "Đồng ý với Điều khoản dịch vụ"
+    advertise: 
+    agree_to_privacy_policy: Đồng ý với Điều khoản riêng tư
+    agree_to_terms_of_service: Đồng ý với Điều khoản dịch vụ
     all: Tất cả
     all_adjustments_closed: Tất cả điều chỉnh đã được đóng!
     all_adjustments_opened: Tất cả điều chỉnh đã được mở!
     all_departments: Tất cả các mục
-    all_items_have_been_returned:
+    all_items_have_been_returned: 
     allow_ssl_in_development_and_test: Cho phép dùng SSL trong môi trường development và test
     allow_ssl_in_production: Cho phép dùng SSL trong môi trường production
     allow_ssl_in_staging: Cho phép dùng SSL trong môi trường staging
     already_signed_up_for_analytics: Bạn đã đăng kí với Spree Analytics rồi
     alt_text: Chú thích khác
-    alternative_phone: "Điện thoại khác"
+    alternative_phone: Điện thoại khác
     amount: Giá trị
     analytics_desc_header_1: Thống kê Spree
     analytics_desc_header_2: Các thông số thống kê được tích hợp vào Spree dashboard
@@ -334,74 +335,74 @@ vi:
     analytics_desc_list_4: Hoàn toàn miễn phí!
     analytics_trackers: Theo dõi thông số thống kê
     and: và
-    approve:
-    approved_at:
-    approver:
+    approve: 
+    approved_at: 
+    approver: 
     are_you_sure: Bạn có chắn chắn không?
     are_you_sure_delete: Bạn có chắc bạn muốn xóa hồ sơ này không?
-    associated_adjustment_closed: "Điều chỉnh liên đới đã bị đóng và không thể tính lại. Bạn có muốn mở nó không?"
-    at_symbol: '@'
+    associated_adjustment_closed: Điều chỉnh liên đới đã bị đóng và không thể tính lại. Bạn có muốn mở nó không?
+    at_symbol: "@"
     authorization_failure: Không được ủy quyền truy cập
-    authorized:
-    auto_capture:
+    authorized: 
+    auto_capture: 
     available_on: Có hàng vào ngày
-    average_order_value:
-    avs_response:
+    average_order_value: 
+    avs_response: 
     back: Quay lại
-    back_end:
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_end: 
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
     back_to_store: Quay lại cửa hàng
     back_to_users_list: Quay lại Liệt kê người dùng
     backorderable: Có thể đặt chỗ
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: 
+    backordered: 
+    backorders_allowed: 
     balance_due: Tiền cần thanh toán
-    base_amount:
-    base_percent:
-    bill_address: "Địa chỉ thanh toán"
+    base_amount: 
+    base_percent: 
+    bill_address: Địa chỉ thanh toán
     billing: Thanh Toán
-    billing_address: "Địa chỉ thanh toán"
+    billing_address: Địa chỉ thanh toán
     both: Both
-    calculated_reimbursements:
+    calculated_reimbursements: 
     calculator: Máy tính
     calculator_settings_warning: Nếu bạn đang thay đổi loại máy tính, bạn phải lưu trước khi thay đổi cấu hình máy tính
     cancel: Hủy
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: 
     cannot_create_returns: Không thể trả hàng vì đơn hàng chưa được gửi.
-    cannot_perform_operation:
+    cannot_perform_operation: 
     cannot_set_shipping_method_without_address: Không thể cài cách thức vận chuyển đến khi thông tin cách hàng được cung cấp.
     capture: Lấy tiền
-    capture_events:
+    capture_events: 
     card_code: Mã thẻ
     card_number: Số thẻ
-    card_type:
+    card_type: 
     card_type_is: Loại thẻ là
     cart: Sọt hàng
-    cart_subtotal:
+    cart_subtotal: 
     categories: Loại mặt hàng
     category: Loại mặt hàng
-    charged:
+    charged: 
     check_for_spree_alerts: Kiểm tra thông báo
     checkout: Thủ tục mua hàng
     choose_a_customer: Chọn một khách hàng
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: 
     choose_currency: Chọn đơn vi tiền tệ
     choose_dashboard_locale: Chọn địa hoá cho Dashboard
-    choose_location:
+    choose_location: 
     city: Thành phố
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
     clone: Nhân bản
-    close: "Đóng"
-    close_all_adjustments: "Đóng tất cả chỉnh sửa"
+    close: Đóng
+    close_all_adjustments: Đóng tất cả chỉnh sửa
     code: Mã
     company: Công ty
     complete: hoàn tất
@@ -415,7 +416,7 @@ vi:
     cost_currency: Tiền giá
     cost_price: Giá
     could_not_connect_to_jirafe: Không thể kết nối với Jirafe để đồnng bộ hoá dữ liệu. Sẽ tự động thử lại sau.
-    could_not_create_customer_return:
+    could_not_create_customer_return: 
     could_not_create_stock_movement: Có một vấn đề lưu cái di chuyển hàng này. Xin vui lòng thử lại.
     count_on_hand: Số hàng có trong tay
     countries: Quốc gia
@@ -423,12 +424,12 @@ vi:
     country_based: Dựa trên quốc gia
     country_name: Tên
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon:
-    coupon_code:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
+    coupon: 
+    coupon_code: 
     coupon_code_already_applied: Mã khuyến mại đã được dùng cho đơn hàng khác
     coupon_code_applied: The coupon code was successfully applied to your order.
     coupon_code_better_exists: Mã khuyến mại trước đó có nhiều khuyến mại hơn
@@ -436,87 +437,87 @@ vi:
     coupon_code_max_usage: Mã khuyến mại bị vượt qua số lần cho phép sử dụng
     coupon_code_not_eligible: Mã khuyến mại không cho đơn hàng này được
     coupon_code_not_found: Mã khuyến mại bạn nhập vào không tồn tại. Vui lòng thử lại.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: 
     create: Tạo
     create_a_new_account: Tạo một tài khoản mới
-    create_new_order:
-    create_reimbursement:
+    create_new_order: 
+    create_reimbursement: 
     created_at: Tạo lúc
     credit: Tín dụng
     credit_card: Thẻ tín dụng
-    credit_cards:
+    credit_cards: 
     credit_owed: Nợ tín dụng
-    credits:
-    currency:
-    currency_decimal_mark: "Điểm phân cách tiền hàng số lẻ"
-    currency_settings:
-    currency_symbol_position:
+    credits: 
+    currency: 
+    currency_decimal_mark: Điểm phân cách tiền hàng số lẻ
+    currency_settings: 
+    currency_symbol_position: 
     currency_thousands_separator: Phân cách số hàng nghìn
     current: Hiện thời
-    current_promotion_usage: "Đang dùng: %{count}"
+    current_promotion_usage: 'Đang dùng: %{count}'
     customer: Khách hàng
     customer_details: Thông tin khách hàng
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: 
+    customer_returns: 
     customer_search: Tìm kiếm khách hàng
-    cut:
-    cvv_response:
+    cut: 
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
+        app_id: 
+        app_token: 
+        currently_unavailable: 
         explanation: Các mục dưới đây có thể đã được điền nếu bạn chọn đăng kí với Jirafe từ admin dashboard.
-        header:
-        site_id:
-        token:
+        header: 
+        site_id: 
+        token: 
       jirafe_settings_updated: Cấu hình Jirafe đã được cập nhật.
     date: Ngày
-    date_completed:
+    date_completed: 
     date_picker:
-      first_day:
+      first_day: 
       format: "%d/%m/%Y"
       js_format: dd/mm/yy
     date_range: Giới hạn ngày
-    default:
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default: 
+    default_refund_amount: 
+    default_tax: 
+    default_tax_zone: 
     delete: Xóa
-    deleted_variants_present:
+    deleted_variants_present: 
     delivery: Delivery
     depth: Sâu
     description: Miêu tả
-    destination: "Đích đến"
+    destination: Đích đến
     destroy: Hủy diệt
-    details:
-    discount_amount:
-    dismiss_banner:
-    display:
-    display_currency:
-    doesnt_track_inventory:
+    details: 
+    discount_amount: 
+    dismiss_banner: 
+    display: 
+    display_currency: 
+    doesnt_track_inventory: 
     edit: Sửa đổi
-    editing_resource:
-    editing_rma_reason:
+    editing_resource: 
+    editing_rma_reason: 
     editing_user: Sửa đổi người dùng
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email:
-    empty:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
+    email: 
+    empty: 
     empty_cart: Làm rỗng sọt
     enable_mail_delivery: Cho phép vận chuyển thư
     end: Kết thúc
@@ -546,29 +547,31 @@ vi:
         user:
           signup: Người dùng đăng kí
     exceptions:
-      count_on_hand_setter: Không thể thay count_on_hand vì giá trị này được tự động thay bởi recalculate_count_on_hand callback. Xin dùng `update_column(:count_on_hand, value)`.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: >-
+        Không thể thay count_on_hand vì giá trị này được tự động thay bởi recalculate_count_on_hand callback. Xin dùng `update_column(:count_on_hand,
+        value)`.
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
     expiration: Mãn hạn
     extension: Gói mở rộng
-    failed_payment_attempts:
+    failed_payment_attempts: 
     filename: Tên tệp tin
     fill_in_customer_info: Xin điền vào thông tin khách hàng
     filter_results: Kết quả lọc
     finalize: Hoành thành
-    finalized:
-    find_a_taxon:
+    finalized: 
+    find_a_taxon: 
     first_item: Món hàng đầu tiên giá
     first_name: Tên
     first_name_begins_with: Tên bắt đầu với
-    flat_percent: "Định mức phần trăm"
+    flat_percent: Định mức phần trăm
     flat_rate_per_order: Lãi suất sàn (cho từng đơn hàng)
     flexible_rate: Lãi suất dao động
     forgot_password: Quên mật khẩu
     free_shipping: Giao hàng miễn phí
-    free_shipping_amount:
+    free_shipping_amount: 
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Không có Gateway cho môi trường này
@@ -584,38 +587,38 @@ vi:
     hide_cents: Dẫu đơn vị cent
     home: Trang chủ
     i18n:
-      available_locales:
-      language:
-      localization_settings:
+      available_locales: 
+      language: 
+      localization_settings: 
       this_file_language: tiếng Việt (VN)
     icon: Biểu tượng
-    identifier:
+    identifier: 
     image: Hình ảnh
     images: Hình ảnh
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
     included_in_price: Kèm trong giá
     included_price_validation: không thể chọn trừ khi bạn đã cài Mã vùng thuế mặc định
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password: "Điền vào mẫu phía dưới và hướng dẫn cách thay đổi mật khẩu sẽ được gửi qua email đến bạn:"
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
+    instructions_to_reset_password: 'Điền vào mẫu phía dưới và hướng dẫn cách thay đổi mật khẩu sẽ được gửi qua email đến bạn:'
     insufficient_stock: Không đủ hàng, chỉ còn lại %{on_hand}
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: 
     intercept_email_address: Can thiệp địa chỉ email
     intercept_email_instructions: Ghi đè người nhận email với địa chỉ này
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
     invalid_payment_provider: Nhà cung cấp thanh toán không đúng.
     invalid_promotion_action: Hành động khuyến mại không đúng.
     invalid_promotion_rule: Luật khuyến mại không đúng.
     inventory: Hàng
-    inventory_adjustment: "Điều chỉnh hàng tồn"
+    inventory_adjustment: Điều chỉnh hàng tồn
     inventory_error_flash_for_insufficient_quantity: Một sản phẩm trong sọt của bạn đã cháy hàng.
-    inventory_state:
+    inventory_state: 
     is_not_available_to_shipment_address: không thể chuyển đến địa chỉ chỉ định
     iso_name: Tên ISO
     item: Món
@@ -625,82 +628,82 @@ vi:
       operators:
         gt: lớn hơn
         gte: lớn hơn hoặc bằng
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
-      path: "Đường dẫn"
+      path: Đường dẫn
     last_name: Họ
     last_name_begins_with: Tên họ bắt đầu với
-    learn_more: "Đọc thêm"
-    lifetime_stats:
-    line_item_adjustments:
+    learn_more: Đọc thêm
+    lifetime_stats: 
+    line_item_adjustments: 
     list: Liệt kê
-    loading: "Đang tải"
+    loading: Đang tải
     locale_changed: Thay đổi địa hóa
-    location: "Địa điểm"
+    location: Địa điểm
     lock: Khoá
-    log_entries:
-    logged_in_as: "Đã đăng nhập với"
-    logged_in_succesfully: "Đăng nhập thành công"
+    log_entries: 
+    logged_in_as: Đã đăng nhập với
+    logged_in_succesfully: Đăng nhập thành công
     logged_out: Bạn đã đăng xuất
-    login: "Đăng nhập"
-    login_as_existing: "Đăng nhập như khách hàng cũ"
-    login_failed: "Đăng nhập không uy quyền."
-    login_name: "Đăng nhập"
-    logout: "Đăng xuất"
-    logs:
+    login: Đăng nhập
+    login_as_existing: Đăng nhập như khách hàng cũ
+    login_failed: Đăng nhập không uy quyền.
+    login_name: Đăng nhập
+    logout: Đăng xuất
+    logs: 
     look_for_similar_items: Tìm sản phẩm tương tự
     make_refund: Thối tiền
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
     master_price: Giá chủ
     match_choices:
       all: Tất cả
       none: Không có
     max_items: Số hàng tối đa
-    member_since:
-    memo:
+    member_since: 
+    memo: 
     meta_description: Meta miểu tả
     meta_keywords: Meta danh sách từ khóa
-    meta_title:
+    meta_title: 
     metadata: Metadata
     minimal_amount: Giá trị tối thiểu
     month: Tháng
     more: Hơn nữa
     move_stock_between_locations: Dời hàng giữa kho
     my_account: Tài khoản của tôi
-    my_orders: "Đơn đặt hàng của tôi"
+    my_orders: Đơn đặt hàng của tôi
     name: Tên
-    name_on_card:
+    name_on_card: 
     name_or_sku: Tên hoặc SKU
     new: Mới
     new_adjustment: Thông số điều chỉnh mới
-    new_country:
+    new_country: 
     new_customer: Khách hàng mới
-    new_customer_return:
+    new_customer_return: 
     new_image: Hình mới
     new_option_type: Kiểu tùy chọn mới
-    new_order: "Đơn đặt hàng mới"
+    new_order: Đơn đặt hàng mới
     new_order_completed: Thanh toán mới hoàn tất
     new_payment: Thanh toán mới
     new_payment_method: Phương thức thanh toán mới
     new_product: Sản phẩm mới
     new_promotion: Khuyến mại mới
-    new_promotion_category:
-    new_property: "Đặc tính mới"
+    new_promotion_category: 
+    new_property: Đặc tính mới
     new_prototype: Nguyên mẫu mới
-    new_refund:
-    new_refund_reason:
-    new_return_authorization: "Ủy quyền trả về mới"
-    new_rma_reason:
-    new_shipment_at_location:
+    new_refund: 
+    new_refund_reason: 
+    new_return_authorization: Ủy quyền trả về mới
+    new_rma_reason: 
+    new_shipment_at_location: 
     new_shipping_category: Loại hình vận chuyển mới
     new_shipping_method: Phương pháp vận chuyển mới
     new_state: Bang mới
@@ -709,7 +712,7 @@ vi:
     new_stock_transfer: Di chuyển hàng mới
     new_tax_category: Biểu thuế mới
     new_tax_rate: Lãi suất mới
-    new_taxon: "Đơn vị Phân loại mới"
+    new_taxon: Đơn vị Phân loại mới
     new_taxonomy: Phân loại mới
     new_tracker: Tracker mới
     new_user: Người dùng mới
@@ -717,37 +720,37 @@ vi:
     new_zone: Vùng mới
     next: Tiếp
     no_actions_added: Không cần làm gì
-    no_payment_found:
-    no_pending_payments:
+    no_payment_found: 
+    no_pending_payments: 
     no_products_found: Không tìm thấy sản phẩm
-    no_resource_found:
-    no_results:
-    no_returns_found:
-    no_rules_added:
-    no_shipping_method_selected:
-    no_state_changes:
+    no_resource_found: 
+    no_results: 
+    no_returns_found: 
+    no_rules_added: 
+    no_shipping_method_selected: 
+    no_state_changes: 
     no_tracking_present: Không có thông tin theo dõi được cung cấp.
     none: Rỗng
-    none_selected:
+    none_selected: 
     normal_amount: Normal Amount
     not: không
     not_available: N/A
     not_enough_stock: Không đủ hàng tại địa điểm gốc để hoàn tất thủ tục di chuyển.
-    not_found:
-    note:
+    not_found: 
+    note: 
     notice_messages:
-      product_cloned: "Đã nhân bản sản phẩm"
-      product_deleted: "Đã xóa sản phẩm"
+      product_cloned: Đã nhân bản sản phẩm
+      product_deleted: Đã xóa sản phẩm
       product_not_cloned: Không thể nhân bản sản phẩm
       product_not_deleted: Không thể xóa sản phẩm
       variant_deleted: Biến thể đã được xóa
       variant_not_deleted: Không thể xóa biến thể
-    num_orders:
+    num_orders: 
     on_hand: Có hàng
     open: Mở
     open_all_adjustments: Mở tất cả Chỉnh sửa
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: 
     option_types: Kiểu tùy chọn
     option_value: Option Value
     option_values: Giá trị tùy chọn
@@ -755,102 +758,102 @@ vi:
     options: Tùy chọn
     or: hoặc
     or_over_price: "%{price} or over"
-    order: "Đơn hàng"
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order: Đơn hàng
+    order_adjustments: 
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
     order_details: Chi tiết đơn hàng
-    order_email_resent: "Đơn hàng đã được gửi email lại"
+    order_email_resent: Đơn hàng đã được gửi email lại
     order_information: Thông tin đơn hàng
     order_mailer:
       cancel_email:
         dear_customer: Kính chào quý khách,\n
-        instructions: "Đơn đặt hàng của quý khách bị hủy. Vui lòng kiểm tra lại đơn hàng của bạn."
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        instructions: Đơn đặt hàng của quý khách bị hủy. Vui lòng kiểm tra lại đơn hàng của bạn.
+        order_summary_canceled: 
+        subject: 
+        subtotal: 
+        total: 
       confirm_email:
         dear_customer: Kính chào quý khách,\n
         instructions: Vui lòng kiểm tra đơn đặt hàng của bạn.
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
+        order_summary: 
+        subject: 
+        subtotal: 
+        thanks: 
+        total: 
     order_not_found: Không tìm thấy đơn hàng. Xin vui lòng thử hành động khác.
-    order_number:
-    order_processed_successfully: "Đơn đặt hàng của bạn đã được xử lý thành công"
-    order_resumed:
+    order_number: 
+    order_processed_successfully: Đơn đặt hàng của bạn đã được xử lý thành công
+    order_resumed: 
     order_state:
-      address:
-      awaiting_return:
-      canceled:
-      cart:
-      complete:
-      confirm:
-      considered_risky:
-      delivery:
-      payment:
-      resumed:
-      returned:
+      address: 
+      awaiting_return: 
+      canceled: 
+      cart: 
+      complete: 
+      confirm: 
+      considered_risky: 
+      delivery: 
+      payment: 
+      resumed: 
+      returned: 
     order_summary: Tóm tắt đơn đặt hàng
     order_sure_want_to: Bạn có chắc bạn muốn %{event} đơn hàng này?
     order_total: Tổng giá sau thuế
-    order_updated: "Đơn hàng được cập nhật"
-    orders: "Đơn hàng"
-    other_items_in_other:
+    order_updated: Đơn hàng được cập nhật
+    orders: Đơn hàng
+    other_items_in_other: 
     out_of_stock: Hết hàng
     overview: Tổng kết
     package_from: gói từ
     pagination:
-      next_page:
-      previous_page:
+      next_page: 
+      previous_page: 
       truncate: "…"
     password: Mật khẩu
     paste: Paste
-    path: "Đường dẫn"
+    path: Đường dẫn
     pay: thanh toán
     payment: Thanh toán
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: 
+    payment_identifier: 
     payment_information: Thông tin thanh toán
     payment_method: Phương thức thanh toán
-    payment_method_not_supported:
+    payment_method_not_supported: 
     payment_methods: Phương thức thanh toán
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
-    payment_state:
+    payment_processing_failed: 
+    payment_processor_choose_banner_text: 
+    payment_processor_choose_link: 
+    payment_state: 
     payment_states:
-      balance_due:
-      checkout:
-      completed:
-      credit_owed:
-      failed:
-      paid:
-      pending:
-      processing:
-      void:
+      balance_due: 
+      checkout: 
+      completed: 
+      credit_owed: 
+      failed: 
+      paid: 
+      pending: 
+      processing: 
+      void: 
     payment_updated: Thanh toán đã được cập nhật
     payments: Thanh toán
-    pending:
+    pending: 
     percent: Phần trăm
-    percent_per_item:
-    permalink:
-    phone: "Điện thoại"
-    place_order: "Đặt hàng"
-    please_define_payment_methods:
-    populate_get_error:
+    percent_per_item: 
+    permalink: 
+    phone: Điện thoại
+    place_order: Đặt hàng
+    please_define_payment_methods: 
+    populate_get_error: 
     powered_by: Tiếp sức bởi
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
     presentation: Trình bày
     previous: Trước
-    previous_state_missing:
+    previous_state_missing: 
     price: Giá
     price_range: Loại giá
     price_sack: Price Sack
@@ -859,167 +862,167 @@ vi:
     product_details: Chi tiết sản phẩm
     product_has_no_description: Sản phẩm không có chú thích
     product_not_available_in_this_currency: Sản phẩm này không được cung cấp ở tiền tệ được chọn.
-    product_properties: "Đặc tính sản phẩm"
+    product_properties: Đặc tính sản phẩm
     product_rule:
-      choose_products:
-      label:
-      match_all:
-      match_any:
-      match_none:
+      choose_products: 
+      label: 
+      match_all: 
+      match_any: 
+      match_none: 
       product_source:
-        group:
-        manual:
+        group: 
+        manual: 
     products: Sản phẩm
-    promotion:
-    promotion_action:
+    promotion: 
+    promotion_action: 
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: 
+        name: 
       create_item_adjustments:
-        description:
-        name:
+        description: 
+        name: 
       create_line_items:
-        description:
-        name:
+        description: 
+        name: 
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: 
+        name: 
+    promotion_actions: 
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: 
+        any: 
+    promotion_rule: 
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: 
+        name: 
       item_total:
-        description:
-        name:
+        description: 
+        name: 
       landing_page:
-        description:
-        name:
+        description: 
+        name: 
       one_use_per_user:
-        description:
-        name:
+        description: 
+        name: 
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description:
-        name:
+        description: 
+        name: 
       taxon:
-        description:
-        name:
+        description: 
+        name: 
       user:
-        description:
-        name:
+        description: 
+        name: 
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
-    promotions:
-    propagate_all_variants:
-    properties: "Đặc tính"
-    property: "Đặc tính"
+        description: 
+        name: 
+    promotion_uses: 
+    promotionable: 
+    promotions: 
+    propagate_all_variants: 
+    properties: Đặc tính
+    property: Đặc tính
     prototype: Nguyên mẫu
     prototypes: Nguyên mẫu
     provider: Nhà cung cấp
     provider_settings_warning: Nếu thay đổi nhà cung cấp, bạn phải lưu trước khi sửa đổi cấu hình nhà cung cấp
     qty: Số lượng
     quantity: Số lượng
-    quantity_returned:
+    quantity_returned: 
     quantity_shipped: Tổng hàng đã chuyển
-    quick_search:
+    quick_search: 
     rate: Lãi suất
     reason: Lí do
     receive: nhận
     receive_stock: Nhận hàng
-    received: "Đã nhận"
-    reception_status:
+    received: Đã nhận
+    reception_status: 
     reference: Tham khảo
     refund: Thối
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
-    register: "Đăng ký như một thành viên mới"
-    registration: "Đăng ký"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
+    register: Đăng ký như một thành viên mới
+    registration: Đăng ký
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
     remember_me: Nhớ tôi
     remove: Xóa
-    rename:
-    report:
+    rename: 
+    report: 
     reports: Báo cáo
     resend: Gửi lại
     reset_password: Khởi tạo lại mật khẩu
     response_code: Mã phản hồi
     resume: tiếp tục
-    resumed: "Đã tiếp tục"
+    resumed: Đã tiếp tục
     return: trở về
-    return_authorization: "Ủy Quyền Trả Về"
-    return_authorization_reasons:
-    return_authorization_updated: "Ủy Quyền Trả Về đã được cập nhật"
-    return_authorizations: "Ủy Quyền Trả Về"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_authorization: Ủy Quyền Trả Về
+    return_authorization_reasons: 
+    return_authorization_updated: Ủy Quyền Trả Về đã được cập nhật
+    return_authorizations: Ủy Quyền Trả Về
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
     return_quantity: Số lượng trả về
-    returned: "Đã trả về"
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit:
+    returned: Đã trả về
+    returns: 
+    review: 
+    risk: 
+    risk_analysis: 
+    risky: 
+    rma_credit: 
     rma_number: Số RMA
     rma_value: Giá trị RMA
     roles: Vai trò
     rules: Rules
-    safe:
+    safe: 
     sales_total: Tổng giá trị
-    sales_total_description:
+    sales_total_description: 
     sales_totals: Tổng doanh số
     save_and_continue: Lưu và tiếp tục
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: 
+    say_no: 
+    say_yes: 
     scope: Phạm vi
     search: Tìm kiếm
     search_results: Kết quả tìm kiếm cho '%{keywords}'
     searching: Searching
     secure_connection_type: Kiệu kết nối bảo mật
-    security_settings:
+    security_settings: 
     select: Lựa chọn
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
     select_from_prototype: Lựa chọn từ nguyên mẫu
     select_stock: Chọn hàng
     send_copy_of_all_mails_to: Gửi bản sao tất cả thư đến
@@ -1028,34 +1031,34 @@ vi:
     server_error: Máy chủ bị lỗi
     settings: Cấu hình
     ship: Gửi
-    ship_address: "Địa chỉ giao hàng"
+    ship_address: Địa chỉ giao hàng
     ship_total: Tổng chuyển hàng
     shipment: Vận chuyển
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
         dear_customer: Kính chào quý khách,\n
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
+        instructions: 
+        shipment_summary: 
+        subject: 
+        thanks: 
+        track_information: 
         track_link: 'Link để theo dõi: %{url}'
-    shipment_state:
+    shipment_state: 
     shipment_states:
-      backorder:
-      canceled:
-      partial:
-      pending:
-      ready:
-      shipped:
-    shipment_transfer_error:
-    shipment_transfer_success:
+      backorder: 
+      canceled: 
+      partial: 
+      pending: 
+      ready: 
+      shipped: 
+    shipment_transfer_error: 
+    shipment_transfer_success: 
     shipments: Vận chuyển
-    shipped: "Đã chuyển phát"
+    shipped: Đã chuyển phát
     shipping: Vận chuyển
-    shipping_address: "Địa chỉ giao hàng"
+    shipping_address: Địa chỉ giao hàng
     shipping_categories: Loại vận chuyển
     shipping_category: Loại vận chuyển
     shipping_flat_rate_per_item: Giá thấp nhất với từng mục gói
@@ -1065,69 +1068,69 @@ vi:
     shipping_method: Phương thức vận chuyển
     shipping_methods: Phương thức vận chuyển
     shipping_price_sack: Xô giá
-    shipping_total:
+    shipping_total: 
     shop_by_taxonomy: Mua theo %{taxonomy}
     shopping_cart: Sọt mua sắm
     show: Xem
     show_active: Liệt kê đơn còn hiệu lực
     show_deleted: Hiện đơn hàng đã xóa
     show_only_complete_orders: Chỉ hiện đơn hàng đã hoàn tất
-    show_only_considered_risky:
+    show_only_considered_risky: 
     show_rate_in_label: Hiện suất giá với nhãn mác
     sku: SKU
-    skus:
-    slug:
+    skus: 
+    slug: 
     source: Nguồn
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+    special_instructions: 
+    split: 
+    spree_gateway_error_flash_for_checkout: 
     ssl:
-      change_protocol:
+      change_protocol: 
     start: Bắt đầu
     state: Bang
     state_based: Dựa trên bang
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
     states: Bang
     states_required: Yêu cầu bang
     status: Tình trạng
-    stock:
-    stock_location: "Địa điểm hàng"
+    stock: 
+    stock_location: Địa điểm hàng
     stock_location_info: Thông tin địa điểm hàng
-    stock_locations: "Địa điểm hàng"
-    stock_locations_need_a_default_country:
+    stock_locations: Địa điểm hàng
+    stock_locations_need_a_default_country: 
     stock_management: Quản lý hàng
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: 
     stock_movements: Chuyển động của hàng
     stock_movements_for_stock_location: Chuyển động của hàng cho %{stock_location_name}
     stock_successfully_transferred: Hàng đã thành công chuyển giữa dịa điểm.
@@ -1135,82 +1138,82 @@ vi:
     stock_transfers: Chuyển hàng
     stop: Kết thúc
     store: Cửa hàng
-    street_address: "Địa chỉ"
-    street_address_2: "Địa chỉ (tiếp)"
+    street_address: Địa chỉ
+    street_address_2: Địa chỉ (tiếp)
     subtotal: Tổng giá trước thuế
     subtract: Trừ đi
-    success:
+    success: 
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} has been successfully removed!"
     successfully_signed_up_for_analytics: Thành công đăng kí cho Spree Analytics
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: 
     tax: Thuế
     tax_categories: Loại thuế
     tax_category: Biểu thuế
-    tax_code:
-    tax_included:
+    tax_code: 
+    tax_included: 
     tax_rate_amount_explanation: Mức thuế ở số thập phân để trợ giúp cách tính, (nghĩa là; nếu mức thuế là 5% thì nhập vào 0.05
     tax_rates: Lãi suất thuế
-    taxon: "Đơn vị phân loại"
+    taxon: Đơn vị phân loại
     taxon_edit: Sửa đổi đơn vị phân loại
     taxon_placeholder: Thêm vào một phân loại
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
     taxonomies: Phân loại
     taxonomy: Taxonomy
     taxonomy_edit: Sửa đổi phân loại
     taxonomy_tree_error: Thay đồi theo yêu cầu không được chấp nhận và hệ cây đã quay trở về trạng thái như trước, xin hay thử lại lần nữa.
     taxonomy_tree_instruction: "* Nhấp chuột phải vào 1 phần tử con trong hệ cây để truy cập thực đơn để thêm, xóa và sắp xếp một phần tử con."
-    taxons: "Đơn vị phân loại"
+    taxons: Đơn vị phân loại
     test: Kiểm tra
     test_mailer:
       test_email:
-        greeting:
-        message:
-        subject:
+        greeting: 
+        message: 
+        subject: 
     test_mode: Chế độ kiểm tra
     thank_you_for_your_order: Cảm ơn đã mua hàng. Xin hãy in ra một bản của trang này để tiện cho việc chứng thực nếu cần.
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields:
-    this_order_has_already_received_a_refund:
+    there_are_no_items_for_this_order: 
+    there_were_problems_with_the_following_fields: 
+    this_order_has_already_received_a_refund: 
     thumbnail: Hình nhỏ
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
     time: Thời gian
-    to_add_variants_you_must_first_define: "Để thêm biến thể, bạn phải định nghĩa trước"
+    to_add_variants_you_must_first_define: Để thêm biến thể, bạn phải định nghĩa trước
     total: Giá trị
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
     tracking: Theo dõi
     tracking_number: Số theo dõi
     tracking_url: URL theo dõi
-    tracking_url_placeholder:
-    transaction_id:
+    tracking_url_placeholder: 
+    transaction_id: 
     transfer_from_location: Chuyển từ
     transfer_stock: Chuyển hàng
     transfer_to_location: Chuyển tới
     tree: Cây
     type: Loại
-    type_to_search:
+    type_to_search: 
     unable_to_connect_to_gateway: Không thề kết nối với gateway.
-    unable_to_create_reimbursements:
-    under_price:
+    unable_to_create_reimbursements: 
+    under_price: 
     unlock: Mở khoá
     unrecognized_card_type: Không nhận ra được loại thẻ
     unshippable_items: Sản phẩm không vận chuyển được
     update: Cập nhật
-    updating: "Đang cập nhật"
+    updating: Đang cập nhật
     usage_limit: Giới hạn sử dụng
-    use_app_default:
+    use_app_default: 
     use_billing_address: Dùng địa chỉ thanh toán
     use_new_cc: Dùng thẻ mới
     use_s3: Use Amazon S3 For Images
@@ -1219,16 +1222,16 @@ vi:
       choose_users: Choose users
     users: Người dùng
     validation:
-      cannot_be_less_than_shipped_units:
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_be_less_than_shipped_units: 
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
       exceeds_available_stock: Vượt quá lượng hàng hiện có. Xin hãy chắc chắn mục dòng có một số lượng hợp lệ.
       is_too_large: quá lớn -- số hàng hiện có không đủ đáp ứng!
       must_be_int: phải là số nguyên
       must_be_non_negative: phải là số dương
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: 
     value: Giá trị
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: 
     variants: Biến thể
     version: Phiên bản
     void: Vô hiệu hóa
@@ -1239,7 +1242,7 @@ vi:
     year: Năm
     you_have_no_orders_yet: You have no orders yet.
     your_cart_is_empty: Sọt hàng rỗng
-    your_order_is_empty_add_product: "Đơn hàng của bạn rỗng, xin hay tìm và thêm vào sản phảm như trên"
+    your_order_is_empty_add_product: Đơn hàng của bạn rỗng, xin hay tìm và thêm vào sản phảm như trên
     zip: Mã bưu điện
     zipcode: Mã Zip
     zone: Vùng

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,1301 +1,1302 @@
+---
 zh-CN:
   activerecord:
     attributes:
       spree/address:
-        address1: "地址"
-        address2: "地址（继续）"
-        city: "城市"
-        country: "国家"
-        firstname: "名字"
-        lastname: "姓氏"
-        phone: "电话"
-        state: "省份"
-        zipcode: "邮政编码"
+        address1: 地址
+        address2: 地址（继续）
+        city: 城市
+        country: 国家
+        firstname: 名字
+        lastname: 姓氏
+        phone: 电话
+        state: 省份
+        zipcode: 邮政编码
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
         iso_name: ISO名称
-        name: "名称"
+        name: 名称
         numcode: ISO编号
       spree/credit_card:
-        base:
-        cc_type: "信用卡类型"
-        month: "月份"
-        name:
-        number: "卡号"
-        verification_value: "验证码"
-        year: "年份"
+        base: 
+        cc_type: 信用卡类型
+        month: 月份
+        name: 
+        number: 卡号
+        verification_value: 验证码
+        year: 年份
       spree/inventory_unit:
-        state: "状态"
+        state: 状态
       spree/line_item:
-        price: "单价"
-        quantity: "数量"
+        price: 单价
+        quantity: 数量
       spree/option_type:
-        name: "名称"
-        presentation: "描述"
+        name: 名称
+        presentation: 描述
       spree/order:
-        checkout_complete: "完成结账"
-        completed_at: "结账日期"
-        considered_risky:
-        coupon_code: "优惠券号码"
-        created_at: "下单日期"
-        email: "电子邮件"
+        checkout_complete: 完成结账
+        completed_at: 结账日期
+        considered_risky: 
+        coupon_code: 优惠券号码
+        created_at: 下单日期
+        email: 电子邮件
         ip_address: IP地址
-        item_total: "小记"
-        number: "订单号"
-        payment_state: "支付状态"
-        shipment_state: "物流状态"
-        special_instructions: "特别说明"
-        state: "状态"
-        total: "总计"
+        item_total: 小记
+        number: 订单号
+        payment_state: 支付状态
+        shipment_state: 物流状态
+        special_instructions: 特别说明
+        state: 状态
+        total: 总计
       spree/order/bill_address:
-        address1: "地址"
-        city: "城市"
-        firstname: "名字"
-        lastname: "姓氏"
-        phone: "电话"
-        state: "省份"
-        zipcode: "邮政编码"
+        address1: 地址
+        city: 城市
+        firstname: 名字
+        lastname: 姓氏
+        phone: 电话
+        state: 省份
+        zipcode: 邮政编码
       spree/order/ship_address:
-        address1: "地址"
-        city: "城市"
-        firstname: "名字"
-        lastname: "姓氏"
-        phone: "电话"
-        state: "省份"
-        zipcode: "邮政编码"
+        address1: 地址
+        city: 城市
+        firstname: 名字
+        lastname: 姓氏
+        phone: 电话
+        state: 省份
+        zipcode: 邮政编码
       spree/payment:
-        amount: "金额"
+        amount: 金额
       spree/payment_method:
-        name: "名称"
+        name: 名称
       spree/product:
-        available_on: "上架日期"
-        cost_currency: "成本币种"
-        cost_price: "成本"
-        description: "描述"
-        master_price: "默认价格"
-        name: "名称"
-        on_hand: "库存"
-        shipping_category: "物流分类"
-        tax_category: "缴税分类"
+        available_on: 上架日期
+        cost_currency: 成本币种
+        cost_price: 成本
+        description: 描述
+        master_price: 默认价格
+        name: 名称
+        on_hand: 库存
+        shipping_category: 物流分类
+        tax_category: 缴税分类
       spree/promotion:
-        advertise: "推广"
-        code: "编号"
-        description: "描述"
-        event_name: "事件名称"
-        expires_at: "过期日期"
-        name: "名称"
-        path: "路径"
-        starts_at: "开始日期"
-        usage_limit: "使用次数限制"
+        advertise: 推广
+        code: 编号
+        description: 描述
+        event_name: 事件名称
+        expires_at: 过期日期
+        name: 名称
+        path: 路径
+        starts_at: 开始日期
+        usage_limit: 使用次数限制
       spree/promotion_category:
-        name: "名称"
-        code: "编号"
+        code: 编号
+        name: 名称
       spree/property:
-        name: "名称"
-        presentation: "描述"
+        name: 名称
+        presentation: 描述
       spree/prototype:
-        name: "名称"
+        name: 名称
       spree/return_authorization:
-        amount: "金额"
+        amount: 金额
       spree/role:
         name: ming cheng
       spree/state:
-        abbr: "缩写"
-        name: "名称"
+        abbr: 缩写
+        name: 名称
       spree/state_change:
-        state_changes: "状态变更"
-        state_from:
-        state_to:
-        timestamp: "时间"
-        type: "类型"
-        updated:
-        user: "用户"
+        state_changes: 状态变更
+        state_from: 
+        state_to: 
+        timestamp: 时间
+        type: 类型
+        updated: 
+        user: 用户
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
-        description: "描述"
-        name: "名称"
+        description: 描述
+        name: 名称
       spree/tax_rate:
-        amount: "税率"
-        included_in_price: "包含在售价中"
-        show_rate_in_label: "在标签中显示比率"
+        amount: 税率
+        included_in_price: 包含在售价中
+        show_rate_in_label: 在标签中显示比率
       spree/taxon:
-        name: "名称"
-        permalink: "永久链接"
-        position: "位置"
+        name: 名称
+        permalink: 永久链接
+        position: 位置
       spree/taxonomy:
-        name: "名称"
+        name: 名称
       spree/user:
-        email: "电子邮箱"
-        password: "密码"
-        password_confirmation: "确认密码"
+        email: 电子邮箱
+        password: 密码
+        password_confirmation: 确认密码
       spree/variant:
-        cost_currency: "成本币种"
-        cost_price: "成本"
-        depth: "长度/深度"
-        height: "高度"
-        price: "单价"
-        sku: "条码"
-        weight: "重量"
-        width: "宽度"
+        cost_currency: 成本币种
+        cost_price: 成本
+        depth: 长度/深度
+        height: 高度
+        price: 单价
+        sku: 条码
+        weight: 重量
+        width: 宽度
       spree/zone:
-        description: "描述"
-        name: "名称"
+        description: 描述
+        name: 名称
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: 
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
       spree/address:
-        one: "地址"
-        other: "地址"
+        one: 地址
+        other: 地址
       spree/country:
-        one: "国家"
-        other: "国家"
+        one: 国家
+        other: 国家
       spree/credit_card:
-        one: "信用卡"
-        other: "信用卡"
-      spree/customer_return:
+        one: 信用卡
+        other: 信用卡
+      spree/customer_return: 
       spree/inventory_unit:
-        one: "库存单位"
-        other: "库存单位"
+        one: 库存单位
+        other: 库存单位
       spree/line_item:
-        one: "单项"
-        other: "单项"
+        one: 单项
+        other: 单项
       spree/option_type:
-        one: "选项类型"
-        other: "选项类型"
-      spree/option_value:
+        one: 选项类型
+        other: 选项类型
+      spree/option_value: 
       spree/order:
-        one: "订单"
-        other: "订单"
+        one: 订单
+        other: 订单
       spree/payment:
-        one: "支付"
-        other: "支付"
+        one: 支付
+        other: 支付
       spree/payment_method:
-        one: "支付方式"
-        other: "支付方式"
+        one: 支付方式
+        other: 支付方式
       spree/product:
-        one: "产品"
-        other: "产品"
-      spree/promotion: "促销"
+        one: 产品
+        other: 产品
+      spree/promotion: 促销
       spree/promotion_category:
-        one: "促销分类"
-        other: "促销分类"
+        one: 促销分类
+        other: 促销分类
       spree/property:
-        one: "属性"
-        other: "属性"
+        one: 属性
+        other: 属性
       spree/prototype:
-        one: "原型"
-        other: "原型"
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+        one: 原型
+        other: 原型
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
-        one: "返回授权"
-        other: "返回授权"
-      spree/return_authorization_reason:
+        one: 返回授权
+        other: 返回授权
+      spree/return_authorization_reason: 
       spree/role:
-        one: "角色"
-        other: "角色"
+        one: 角色
+        other: 角色
       spree/shipment:
-        one: "物流"
-        other: "物流"
+        one: 物流
+        other: 物流
       spree/shipping_category:
-        one: "物流分类"
-        other: "物流分类"
+        one: 物流分类
+        other: 物流分类
       spree/shipping_method:
-        one: "配送方式"
-        other: "配送方式"
+        one: 配送方式
+        other: 配送方式
       spree/state:
-        one: "省份"
-        other: "省份"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+        one: 省份
+        other: 省份
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
       spree/tax_category:
-        one: "缴税分类"
-        other: "缴税分类"
+        one: 缴税分类
+        other: 缴税分类
       spree/tax_rate:
-        one: "税率"
-        other: "税率"
+        one: 税率
+        other: 税率
       spree/taxon:
-        one: "分类"
-        other: "分类"
+        one: 分类
+        other: 分类
       spree/taxonomy:
-        one: "分类"
-        other: "分类"
-      spree/tracker:
+        one: 分类
+        other: 分类
+      spree/tracker: 
       spree/user:
-        one: "用户"
-        other: "用户"
+        one: 用户
+        other: 用户
       spree/variant:
-        one: "具体型号"
-        other: "具体型号"
+        one: 具体型号
+        other: 具体型号
       spree/zone:
-        one: "区域"
-        other: "区域"
+        one: 区域
+        other: 区域
   spree:
-    abbreviation: "缩写"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
-    account: "帐户"
-    account_updated: "帐户更新完成!"
-    action: "操作"
+    abbreviation: 缩写
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
+    account: 帐户
+    account_updated: 帐户更新完成!
+    action: 操作
     actions:
-      cancel: "取消"
-      continue: "继续"
-      create: "创建"
-      destroy: "删除"
-      edit: "编辑"
-      list: "列表"
-      listing: "正在列出"
-      new: "新建"
-      refund:
-      save: "保存"
-      update: "更新"
-    activate: "激活"
-    active: "激活"
-    add: "添加"
-    add_action_of_type: "添加激活方式"
-    add_country: "添加国家"
-    add_coupon_code:
-    add_new_header: "添加新的头部"
-    add_new_style: "添加新的样式"
-    add_one: "新建"
-    add_option_value: "添加选项值"
-    add_product: "添加产品"
-    add_product_properties: "添加产品属性"
-    add_rule_of_type: "添加新的类型规则"
-    add_state: "添加一个省份"
-    add_stock: "添加库存"
-    add_stock_management: "添加库存管理"
-    add_to_cart: "加入购物车"
-    add_variant: "添加具体型号"
-    additional_item: "额外项目花费"
-    address1: "地址"
-    address2: "地址（继续）"
-    adjustable:
-    adjustment: "调整"
-    adjustment_amount: "金额"
-    adjustment_successfully_closed: "价格调整已被禁用！"
-    adjustment_successfully_opened: "价格调整已被启用！"
-    adjustment_total: "调整总数"
-    adjustments: "其他调整"
+      cancel: 取消
+      continue: 继续
+      create: 创建
+      destroy: 删除
+      edit: 编辑
+      list: 列表
+      listing: 正在列出
+      new: 新建
+      refund: 
+      save: 保存
+      update: 更新
+    activate: 激活
+    active: 激活
+    add: 添加
+    add_action_of_type: 添加激活方式
+    add_country: 添加国家
+    add_coupon_code: 
+    add_new_header: 添加新的头部
+    add_new_style: 添加新的样式
+    add_one: 新建
+    add_option_value: 添加选项值
+    add_product: 添加产品
+    add_product_properties: 添加产品属性
+    add_rule_of_type: 添加新的类型规则
+    add_state: 添加一个省份
+    add_stock: 添加库存
+    add_stock_management: 添加库存管理
+    add_to_cart: 加入购物车
+    add_variant: 添加具体型号
+    additional_item: 额外项目花费
+    address1: 地址
+    address2: 地址（继续）
+    adjustable: 
+    adjustment: 调整
+    adjustment_amount: 金额
+    adjustment_successfully_closed: 价格调整已被禁用！
+    adjustment_successfully_opened: 价格调整已被启用！
+    adjustment_total: 调整总数
+    adjustments: 其他调整
     admin:
       tab:
-        configuration: "配置"
-        option_types: "选项类型"
-        orders: "订单"
-        overview: "概览"
-        products: "产品"
-        promotions: "促销"
-        promotion_categories: "促销分类"
-        properties: "属性"
-        prototypes: "原型"
-        reports: "报告"
-        taxonomies: "分类层级"
-        taxons: "分类"
-        users: "用户"
+        configuration: 配置
+        option_types: 选项类型
+        orders: 订单
+        overview: 概览
+        products: 产品
+        promotion_categories: 促销分类
+        promotions: 促销
+        properties: 属性
+        prototypes: 原型
+        reports: 报告
+        taxonomies: 分类层级
+        taxons: 分类
+        users: 用户
       user:
-        account: "账户"
-        addresses: "地址"
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders: "订单"
-        user_information:
-    administration: "管理"
-    advertise: "推广"
-    agree_to_privacy_policy: "同意隐私政策"
-    agree_to_terms_of_service: "同意服务条款"
-    all: "全部"
-    all_adjustments_closed: "所有价格调整已被成功禁用！"
-    all_adjustments_opened: "所有价格调整已被成功启用！"
-    all_departments: "所有部门"
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test: "允许在开发以及测试模式下使用SSL"
-    allow_ssl_in_production: "允许在生产模式下使用SSL"
-    allow_ssl_in_staging: "允许在演示模式下使用SSL"
-    already_signed_up_for_analytics: "您已注册Spree Analytics帐号"
-    alt_text: "其他文本"
-    alternative_phone: "其他电话"
-    amount: "金额"
+        account: 账户
+        addresses: 地址
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 订单
+        user_information: 
+    administration: 管理
+    advertise: 推广
+    agree_to_privacy_policy: 同意隐私政策
+    agree_to_terms_of_service: 同意服务条款
+    all: 全部
+    all_adjustments_closed: 所有价格调整已被成功禁用！
+    all_adjustments_opened: 所有价格调整已被成功启用！
+    all_departments: 所有部门
+    all_items_have_been_returned: 
+    allow_ssl_in_development_and_test: 允许在开发以及测试模式下使用SSL
+    allow_ssl_in_production: 允许在生产模式下使用SSL
+    allow_ssl_in_staging: 允许在演示模式下使用SSL
+    already_signed_up_for_analytics: 您已注册Spree Analytics帐号
+    alt_text: 其他文本
+    alternative_phone: 其他电话
+    amount: 金额
     analytics_desc_header_1: Spree Analytics
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2: "仅需要一个免费的Spree帐号用于激活"
-    analytics_desc_list_3:
-    analytics_desc_list_4: "完全免费"
-    analytics_trackers: "追踪分析"
-    and: "以及"
-    approve: "核准"
-    approved_at: "核准日期"
-    approver: "核准者"
-    are_you_sure: "你确定么？"
-    are_you_sure_delete: "你确定你要删除这条记录么?"
-    associated_adjustment_closed: "相关联的价格调整已被关闭，并且不会被重复计算。您需要启用它吗？"
-    at_symbol: '@'
-    authorization_failure: "认证失败"
-    authorized:
-    auto_capture:
-    available_on: "上架日期"
-    average_order_value:
-    avs_response:
-    back: "后退"
-    back_end: "后端"
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
-    back_to_store: "回到商店"
-    back_to_users_list: "回到用户列表"
-    backorderable: "可预订"
-    backorderable_default:
-    backordered: "待补"
-    backorders_allowed:
-    balance_due: "尚欠款"
-    base_amount:
-    base_percent:
-    bill_address: "账单地址"
-    billing: "账单"
-    billing_address: "账单地址"
-    both: "全部"
-    calculated_reimbursements:
-    calculator: "计算器"
-    calculator_settings_warning: "如果你正在修改计算方式，你必须在编辑计算器设置之前先保存"
-    cancel: "取消"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: "您无法在没有定义任何支付方式的情况下进行支付。"
-    cannot_create_returns: "没有配送的订单不能申请退货"
-    cannot_perform_operation: "无法执行请求的操作"
-    cannot_set_shipping_method_without_address: "缺乏客户的详细信息，无法设置配送方式。"
-    capture: "付款"
-    capture_events:
-    card_code: "卡验证码"
-    card_number: "卡号"
-    card_type:
-    card_type_is: "卡的类型是"
-    cart: "购物车"
-    cart_subtotal:
-    categories: "分类"
-    category: "分类"
-    charged:
-    check_for_spree_alerts: "查收Spree的通知"
-    checkout: "结账"
-    choose_a_customer: "选择用户"
-    choose_a_taxon_to_sort_products_for:
-    choose_currency: "选择货币"
-    choose_dashboard_locale: "选择控制面板语言"
-    choose_location:
-    city: "城市"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
-    clone: "复制"
-    close: "关闭"
-    close_all_adjustments: "禁用所有价格调整"
-    code: "编码"
-    company: "公司"
-    complete: "完成"
-    configuration: "配置"
-    configurations: "配置"
-    confirm: "确认"
-    confirm_delete: "确认删除"
-    confirm_password: "确认密码"
-    continue: "继续"
-    continue_shopping: "继续购物"
-    cost_currency: "成本币种"
-    cost_price: "进货价"
-    could_not_connect_to_jirafe: "无法连接Jirafe。稍后将会自动重新连接。"
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand: "库存数量"
-    countries: "国家"
-    country: "国家"
-    country_based: "根据国家"
-    country_name: "名称"
+    analytics_desc_header_2: 
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 仅需要一个免费的Spree帐号用于激活
+    analytics_desc_list_3: 
+    analytics_desc_list_4: 完全免费
+    analytics_trackers: 追踪分析
+    and: 以及
+    approve: 核准
+    approved_at: 核准日期
+    approver: 核准者
+    are_you_sure: 你确定么？
+    are_you_sure_delete: 你确定你要删除这条记录么?
+    associated_adjustment_closed: 相关联的价格调整已被关闭，并且不会被重复计算。您需要启用它吗？
+    at_symbol: "@"
+    authorization_failure: 认证失败
+    authorized: 
+    auto_capture: 
+    available_on: 上架日期
+    average_order_value: 
+    avs_response: 
+    back: 后退
+    back_end: 后端
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
+    back_to_store: 回到商店
+    back_to_users_list: 回到用户列表
+    backorderable: 可预订
+    backorderable_default: 
+    backordered: 待补
+    backorders_allowed: 
+    balance_due: 尚欠款
+    base_amount: 
+    base_percent: 
+    bill_address: 账单地址
+    billing: 账单
+    billing_address: 账单地址
+    both: 全部
+    calculated_reimbursements: 
+    calculator: 计算器
+    calculator_settings_warning: 如果你正在修改计算方式，你必须在编辑计算器设置之前先保存
+    cancel: 取消
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: 您无法在没有定义任何支付方式的情况下进行支付。
+    cannot_create_returns: 没有配送的订单不能申请退货
+    cannot_perform_operation: 无法执行请求的操作
+    cannot_set_shipping_method_without_address: 缺乏客户的详细信息，无法设置配送方式。
+    capture: 付款
+    capture_events: 
+    card_code: 卡验证码
+    card_number: 卡号
+    card_type: 
+    card_type_is: 卡的类型是
+    cart: 购物车
+    cart_subtotal: 
+    categories: 分类
+    category: 分类
+    charged: 
+    check_for_spree_alerts: 查收Spree的通知
+    checkout: 结账
+    choose_a_customer: 选择用户
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 选择货币
+    choose_dashboard_locale: 选择控制面板语言
+    choose_location: 
+    city: 城市
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
+    clone: 复制
+    close: 关闭
+    close_all_adjustments: 禁用所有价格调整
+    code: 编码
+    company: 公司
+    complete: 完成
+    configuration: 配置
+    configurations: 配置
+    confirm: 确认
+    confirm_delete: 确认删除
+    confirm_password: 确认密码
+    continue: 继续
+    continue_shopping: 继续购物
+    cost_currency: 成本币种
+    cost_price: 进货价
+    could_not_connect_to_jirafe: 无法连接Jirafe。稍后将会自动重新连接。
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 
+    count_on_hand: 库存数量
+    countries: 国家
+    country: 国家
+    country_based: 根据国家
+    country_name: 名称
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon: "优惠券"
-    coupon_code: "优惠券号码"
-    coupon_code_already_applied: "优惠券号码已在本订单中使用"
-    coupon_code_applied: "优惠券号码已在订单中生效。"
-    coupon_code_better_exists:
-    coupon_code_expired: "优惠券号码已过期"
-    coupon_code_max_usage: "优惠券号码使用次数超出限制"
-    coupon_code_not_eligible: "您的订单号码无法在您的订单上生效。"
-    coupon_code_not_found: "您所输入的优惠券号码不存在。请重新输入。"
-    coupon_code_unknown_error:
-    create: "创建"
-    create_a_new_account: "创建一个新帐号"
-    create_new_order:
-    create_reimbursement:
-    created_at: "创建日期"
-    credit: "欠款??"
-    credit_card: "信用卡"
-    credit_cards: "信用卡"
-    credit_owed: "应予退款"
-    credits:
-    currency: "币种"
-    currency_decimal_mark:
-    currency_settings: "当前设置"
-    currency_symbol_position: "在金额之前或者之后放置币种符号？"
-    currency_thousands_separator: "千元分割符"
-    current: "现在的"
-    current_promotion_usage: "当前已使用：%{count}"
-    customer: "顾客"
-    customer_details: "顾客详细信息"
-    customer_details_updated: "已更新客户的详细信息"
-    customer_return:
-    customer_returns:
-    customer_search: "顾客搜索"
-    cut: "剪下"
-    cvv_response:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
+    coupon: 优惠券
+    coupon_code: 优惠券号码
+    coupon_code_already_applied: 优惠券号码已在本订单中使用
+    coupon_code_applied: 优惠券号码已在订单中生效。
+    coupon_code_better_exists: 
+    coupon_code_expired: 优惠券号码已过期
+    coupon_code_max_usage: 优惠券号码使用次数超出限制
+    coupon_code_not_eligible: 您的订单号码无法在您的订单上生效。
+    coupon_code_not_found: 您所输入的优惠券号码不存在。请重新输入。
+    coupon_code_unknown_error: 
+    create: 创建
+    create_a_new_account: 创建一个新帐号
+    create_new_order: 
+    create_reimbursement: 
+    created_at: 创建日期
+    credit: 欠款??
+    credit_card: 信用卡
+    credit_cards: 信用卡
+    credit_owed: 应予退款
+    credits: 
+    currency: 币种
+    currency_decimal_mark: 
+    currency_settings: 当前设置
+    currency_symbol_position: 在金额之前或者之后放置币种符号？
+    currency_thousands_separator: 千元分割符
+    current: 现在的
+    current_promotion_usage: 当前已使用：%{count}
+    customer: 顾客
+    customer_details: 顾客详细信息
+    customer_details_updated: 已更新客户的详细信息
+    customer_return: 
+    customer_returns: 
+    customer_search: 顾客搜索
+    cut: 剪下
+    cvv_response: 
     dash:
       jirafe:
-        app_id:
-        app_token: "添加口令"
-        currently_unavailable:
-        explanation:
+        app_id: 
+        app_token: 添加口令
+        currently_unavailable: 
+        explanation: 
         header: Jirafe分析器设置
-        site_id:
-        token: "口令"
+        site_id: 
+        token: 口令
       jirafe_settings_updated: Jirafe设置已更新。
-    date: "日期"
-    date_completed: "完成日期"
+    date: 日期
+    date_completed: 完成日期
     date_picker:
-      first_day:
+      first_day: 
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
-    date_range: "时间范围"
-    default: "默认"
-    default_refund_amount:
-    default_tax: "默认缴税"
-    default_tax_zone: "默认缴税区域"
-    delete: "删除"
-    deleted_variants_present:
-    delivery: "配送"
-    depth: "长"
-    description: "描述"
-    destination: "目的地"
-    destroy: "删除"
-    details: "详情"
-    discount_amount: "折扣金额"
-    dismiss_banner: "不，谢谢！我对此不感兴趣，请不要再显示此信息。"
-    display: "显示"
-    display_currency: "显示货币符号"
-    doesnt_track_inventory:
-    edit: "编辑"
-    editing_resource:
-    editing_rma_reason:
-    editing_user: "编辑用户"
+    date_range: 时间范围
+    default: 默认
+    default_refund_amount: 
+    default_tax: 默认缴税
+    default_tax_zone: 默认缴税区域
+    delete: 删除
+    deleted_variants_present: 
+    delivery: 配送
+    depth: 长
+    description: 描述
+    destination: 目的地
+    destroy: 删除
+    details: 详情
+    discount_amount: 折扣金额
+    dismiss_banner: 不，谢谢！我对此不感兴趣，请不要再显示此信息。
+    display: 显示
+    display_currency: 显示货币符号
+    doesnt_track_inventory: 
+    edit: 编辑
+    editing_resource: 
+    editing_rma_reason: 
+    editing_user: 编辑用户
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email: "电子邮件"
-    empty: "空"
-    empty_cart: "清空购物车"
-    enable_mail_delivery: "开启邮件发送"
-    end: "结束"
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
+    email: 电子邮件
+    empty: 空
+    empty_cart: 清空购物车
+    enable_mail_delivery: 开启邮件发送
+    end: 结束
     ending_in: Ending in
-    environment: "环境"
-    error: "错误"
+    environment: 环境
+    error: 错误
     errors:
       messages:
-        could_not_create_taxon: "无法添加分类"
-        no_payment_methods_available: "当前运行环境下没有配置好支付方式"
-        no_shipping_methods_available: "选中的地址没有适合的运送方式，请修改您的地址后再次尝试"
+        could_not_create_taxon: 无法添加分类
+        no_payment_methods_available: 当前运行环境下没有配置好支付方式
+        no_shipping_methods_available: 选中的地址没有适合的运送方式，请修改您的地址后再次尝试
     errors_prohibited_this_record_from_being_saved:
       one: 1个错误导致此记录无法保存
       other: "%{count}个错误导致此记录无法保存"
-    event: "事件"
+    event: 事件
     events:
       spree:
         cart:
-          add: "添加商品到购物车"
+          add: 添加商品到购物车
         checkout:
-          coupon_code_added: "添加了优惠券号码"
+          coupon_code_added: 添加了优惠券号码
         content:
-          visited: "访问了静态页面"
+          visited: 访问了静态页面
         order:
-          contents_changed: "订单内容更新"
-        page_view: "静态页面被访问"
+          contents_changed: 订单内容更新
+        page_view: 静态页面被访问
         user:
-          signup: "用户注册"
+          signup: 用户注册
     exceptions:
-      count_on_hand_setter: "无法手动设置 count_on_hand, 将会在 recalculate_count_on_hand 中被自动设定。请使用 `update_column(:count_on_hand, value)`"
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
-    expiration: "过期"
-    extension: "扩展"
-    failed_payment_attempts:
-    filename: "文件名"
-    fill_in_customer_info: "请填写顾客信息"
-    filter: "过滤"
-    filter_results: "过滤结果"
-    finalize: "完成"
-    finalized:
-    find_a_taxon: "查找一种分类"
-    first_item: "首件产品价格??"
-    first_name: "名"
-    first_name_begins_with: "名的开始"
-    flat_percent: "固定费率"
-    flat_rate_per_order: "固定费率 (每订单)"
-    flexible_rate: "灵活费率"
-    forgot_password: "忘记密码"
-    free_shipping: "免运送费"
-    free_shipping_amount:
-    front_end: "前端"
-    gateway: "网关"
-    gateway_config_unavailable: "当前运行环境下无可用的网关"
-    gateway_error: "网关出错"
-    general: "一般"
-    general_settings: "一般设置"
+      count_on_hand_setter: 无法手动设置 count_on_hand, 将会在 recalculate_count_on_hand 中被自动设定。请使用 `update_column(:count_on_hand, value)`
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
+    expiration: 过期
+    extension: 扩展
+    failed_payment_attempts: 
+    filename: 文件名
+    fill_in_customer_info: 请填写顾客信息
+    filter: 过滤
+    filter_results: 过滤结果
+    finalize: 完成
+    finalized: 
+    find_a_taxon: 查找一种分类
+    first_item: 首件产品价格??
+    first_name: 名
+    first_name_begins_with: 名的开始
+    flat_percent: 固定费率
+    flat_rate_per_order: 固定费率 (每订单)
+    flexible_rate: 灵活费率
+    forgot_password: 忘记密码
+    free_shipping: 免运送费
+    free_shipping_amount: 
+    front_end: 前端
+    gateway: 网关
+    gateway_config_unavailable: 当前运行环境下无可用的网关
+    gateway_error: 网关出错
+    general: 一般
+    general_settings: 一般设置
     google_analytics: Google Analytics
     google_analytics_id: Analytics ID
-    guest_checkout: "匿名用户结账"
-    guest_user_account: "作为一个匿名用户结账"
-    has_no_shipped_units: "没有已配送的单元"
-    height: "高度"
-    hide_cents: "隐藏分钱"
-    home: "首页"
+    guest_checkout: 匿名用户结账
+    guest_user_account: 作为一个匿名用户结账
+    has_no_shipped_units: 没有已配送的单元
+    height: 高度
+    hide_cents: 隐藏分钱
+    home: 首页
     i18n:
-      available_locales: "可用的语言"
-      language: "语言"
-      localization_settings:
-      this_file_language: "中文(简体)"
-      translations: "翻译"
-    icon: "图标"
-    identifier:
-    image: "图片"
-    images: "图片"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price: "包含在售价中"
-    included_price_validation: "除非您设置了默认的缴税区域，否则无法选择"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password: "请填写如下表格来重置你的密码，重置后的密码会通过电子邮件发送给您"
-    insufficient_stock: "库存不足，当前还剩下%{on_hand}件库存"
-    insufficient_stock_lines_present:
-    intercept_email_address: "用于接收邮件的邮箱地址"
-    intercept_email_instructions: "使用以下邮箱地址覆盖所有收件人邮箱"
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider: "无效的支付服务提供商。"
-    invalid_promotion_action: "无效的优惠方式。"
-    invalid_promotion_rule: "无效的促销规则。"
-    inventory: "库存"
-    inventory_adjustment: "库存调整"
-    inventory_error_flash_for_insufficient_quantity: "您的购物车中的一个商品已经不可购买。"
-    inventory_state:
-    is_not_available_to_shipment_address: "无法送达要求的配送地址"
+      available_locales: 可用的语言
+      language: 语言
+      localization_settings: 
+      this_file_language: 中文(简体)
+      translations: 翻译
+    icon: 图标
+    identifier: 
+    image: 图片
+    images: 图片
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: 包含在售价中
+    included_price_validation: 除非您设置了默认的缴税区域，否则无法选择
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
+    instructions_to_reset_password: 请填写如下表格来重置你的密码，重置后的密码会通过电子邮件发送给您
+    insufficient_stock: 库存不足，当前还剩下%{on_hand}件库存
+    insufficient_stock_lines_present: 
+    intercept_email_address: 用于接收邮件的邮箱地址
+    intercept_email_instructions: 使用以下邮箱地址覆盖所有收件人邮箱
+    internal_name: 
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 无效的支付服务提供商。
+    invalid_promotion_action: 无效的优惠方式。
+    invalid_promotion_rule: 无效的促销规则。
+    inventory: 库存
+    inventory_adjustment: 库存调整
+    inventory_error_flash_for_insufficient_quantity: 您的购物车中的一个商品已经不可购买。
+    inventory_state: 
+    is_not_available_to_shipment_address: 无法送达要求的配送地址
     iso_name: ISO名称
-    item: "商品项"
-    item_description: "商品项描述"
-    item_total: "项目总计"
+    item: 商品项
+    item_description: 商品项描述
+    item_total: 项目总计
     item_total_rule:
       operators:
-        gt: "大于"
-        gte: "大于或等于"
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        gt: 大于
+        gte: 大于或等于
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Path
-    last_name: "姓"
-    last_name_begins_with: "姓的开始"
-    learn_more: "更多"
-    lifetime_stats:
-    line_item_adjustments:
-    list: "列表"
-    loading: "加载"
+    last_name: 姓
+    last_name_begins_with: 姓的开始
+    learn_more: 更多
+    lifetime_stats: 
+    line_item_adjustments: 
+    list: 列表
+    loading: 加载
     locale_changed: Locale已变更
-    location: "位置"
-    lock: "锁住/冻结"
-    log_entries:
-    logged_in_as: "已登录为"
-    logged_in_succesfully: "登录成功"
-    logged_out: "您已经登出系统"
-    login: "登录"
-    login_as_existing: "作为一个已有客户登录"
-    login_failed: "登录认证失败。"
-    login_name: "用户名"
-    logout: "退出"
-    logs:
-    look_for_similar_items: "寻找类似的产品"
-    make_refund: "进行退款??"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
-    master_price: "默认价格"
+    location: 位置
+    lock: 锁住/冻结
+    log_entries: 
+    logged_in_as: 已登录为
+    logged_in_succesfully: 登录成功
+    logged_out: 您已经登出系统
+    login: 登录
+    login_as_existing: 作为一个已有客户登录
+    login_failed: 登录认证失败。
+    login_name: 用户名
+    logout: 退出
+    logs: 
+    look_for_similar_items: 寻找类似的产品
+    make_refund: 进行退款??
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
+    master_price: 默认价格
     match_choices:
-      all: "全部"
-      none: "清空"
-    max_items: "最大商品项??"
-    member_since:
-    memo:
-    meta_description: "元描述"
-    meta_keywords: "关键字"
-    meta_title:
-    metadata: "元数据"
-    minimal_amount: "少量"
-    month: "月"
-    more: "更多"
-    move_stock_between_locations:
-    my_account: "我的帐户"
-    my_orders: "我的订单"
-    name: "名称"
-    name_on_card:
-    name_or_sku: "名称或条形码（输入产品名称中的至少4个字母）"
-    new: "新建"
-    new_adjustment: "新建调整"
-    new_country:
-    new_customer: "新建客户"
-    new_customer_return:
-    new_image: "新建图片"
-    new_option_type: "新建选项类型"
-    new_order: "新建订单"
-    new_order_completed: "新建订单完成"
-    new_payment: "新建支付"
-    new_payment_method: "新建支付方式"
-    new_product: "新建产品"
-    new_promotion: "新建促销活动"
-    new_promotion_category: "新建促销分类"
-    new_property: "新建属性"
-    new_prototype: "新建原型"
-    new_refund:
-    new_refund_reason:
-    new_return_authorization: "新建退货"
-    new_rma_reason:
-    new_shipment_at_location:
-    new_shipping_category: "新建配送分类"
-    new_shipping_method: "新建配送方式"
-    new_state: "新建省份"
-    new_stock_location: "添加仓库位置"
-    new_stock_movement:
-    new_stock_transfer:
-    new_tax_category: "新建缴税类型"
-    new_tax_rate: "新建税率"
-    new_taxon: "新建分类"
-    new_taxonomy: "新建分类层级"
+      all: 全部
+      none: 清空
+    max_items: 最大商品项??
+    member_since: 
+    memo: 
+    meta_description: 元描述
+    meta_keywords: 关键字
+    meta_title: 
+    metadata: 元数据
+    minimal_amount: 少量
+    month: 月
+    more: 更多
+    move_stock_between_locations: 
+    my_account: 我的帐户
+    my_orders: 我的订单
+    name: 名称
+    name_on_card: 
+    name_or_sku: 名称或条形码（输入产品名称中的至少4个字母）
+    new: 新建
+    new_adjustment: 新建调整
+    new_country: 
+    new_customer: 新建客户
+    new_customer_return: 
+    new_image: 新建图片
+    new_option_type: 新建选项类型
+    new_order: 新建订单
+    new_order_completed: 新建订单完成
+    new_payment: 新建支付
+    new_payment_method: 新建支付方式
+    new_product: 新建产品
+    new_promotion: 新建促销活动
+    new_promotion_category: 新建促销分类
+    new_property: 新建属性
+    new_prototype: 新建原型
+    new_refund: 
+    new_refund_reason: 
+    new_return_authorization: 新建退货
+    new_rma_reason: 
+    new_shipment_at_location: 
+    new_shipping_category: 新建配送分类
+    new_shipping_method: 新建配送方式
+    new_state: 新建省份
+    new_stock_location: 添加仓库位置
+    new_stock_movement: 
+    new_stock_transfer: 
+    new_tax_category: 新建缴税类型
+    new_tax_rate: 新建税率
+    new_taxon: 新建分类
+    new_taxonomy: 新建分类层级
     new_tracker: New Tracker
-    new_user: "新建用户"
-    new_variant: "新建具体型号"
-    new_zone: "新建区域"
-    next: "下一页"
-    no_actions_added: "未添加动作"
-    no_payment_found:
-    no_pending_payments:
-    no_products_found: "找不到产品"
-    no_resource_found: "找不到资源"
-    no_results: "无任何结果"
-    no_returns_found:
-    no_rules_added: "未添加规则"
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present: "未提供跟踪细节。"
-    none: "没有"
-    none_selected:
+    new_user: 新建用户
+    new_variant: 新建具体型号
+    new_zone: 新建区域
+    next: 下一页
+    no_actions_added: 未添加动作
+    no_payment_found: 
+    no_pending_payments: 
+    no_products_found: 找不到产品
+    no_resource_found: 找不到资源
+    no_results: 无任何结果
+    no_returns_found: 
+    no_rules_added: 未添加规则
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 未提供跟踪细节。
+    none: 没有
+    none_selected: 
     normal_amount: Normal Amount
     not: false
     not_available: N/A
-    not_enough_stock:
-    not_found: "未找到%{resource}"
-    note:
+    not_enough_stock: 
+    not_found: 未找到%{resource}
+    note: 
     notice_messages:
-      product_cloned: "产品已经被复制"
-      product_deleted: "产品已经被删除"
-      product_not_cloned: "产品无法被复制"
-      product_not_deleted: "产品无法被删除"
-      variant_deleted: "具体型号已经被删除"
-      variant_not_deleted: "具体型号不能被删除"
-    num_orders:
-    on_hand: "库存"
-    open: "打开"
-    open_all_adjustments: "启用所有价格调整"
-    option_type: "选项类型"
-    option_type_placeholder: "选项类型默认值"
-    option_types: "选项类型"
-    option_value: "选项值"
-    option_values: "选项值"
-    optional: "可选的"
-    options: "选项"
-    or: "或"
+      product_cloned: 产品已经被复制
+      product_deleted: 产品已经被删除
+      product_not_cloned: 产品无法被复制
+      product_not_deleted: 产品无法被删除
+      variant_deleted: 具体型号已经被删除
+      variant_not_deleted: 具体型号不能被删除
+    num_orders: 
+    on_hand: 库存
+    open: 打开
+    open_all_adjustments: 启用所有价格调整
+    option_type: 选项类型
+    option_type_placeholder: 选项类型默认值
+    option_types: 选项类型
+    option_value: 选项值
+    option_values: 选项值
+    optional: 可选的
+    options: 选项
+    or: 或
     or_over_price: "%{price}或以上"
-    order: "订单"
-    order_adjustments: "订单调整"
-    order_already_updated:
-    order_approved:
-    order_canceled:
-    order_details: "订单详情"
-    order_email_resent: "重新发出了订单邮件"
-    order_information: "订单信息"
+    order: 订单
+    order_adjustments: 订单调整
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
+    order_details: 订单详情
+    order_email_resent: 重新发出了订单邮件
+    order_information: 订单信息
     order_mailer:
       cancel_email:
-        dear_customer: "亲爱的顾客，"
-        instructions: "您的订单已被取消。请保留此取消信息记录。"
-        order_summary_canceled: "订单总览 [已取消]"
-        subject: "取消订单"
-        subtotal:
-        total:
+        dear_customer: 亲爱的顾客，
+        instructions: 您的订单已被取消。请保留此取消信息记录。
+        order_summary_canceled: 订单总览 [已取消]
+        subject: 取消订单
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer: "亲爱的顾客，"
-        instructions: "请仔细阅读并保留以下订单信息记录。"
-        order_summary: "订单总览"
-        subject: "订单确认"
-        subtotal:
-        thanks: "谢谢您的购买。"
-        total:
-    order_not_found: "我们无法找到您的订单。请重新尝试。"
-    order_number: "订单号 %{number}"
-    order_processed_successfully: "您的订单已经被成功处理了"
-    order_resumed:
+        dear_customer: 亲爱的顾客，
+        instructions: 请仔细阅读并保留以下订单信息记录。
+        order_summary: 订单总览
+        subject: 订单确认
+        subtotal: 
+        thanks: 谢谢您的购买。
+        total: 
+    order_not_found: 我们无法找到您的订单。请重新尝试。
+    order_number: 订单号 %{number}
+    order_processed_successfully: 您的订单已经被成功处理了
+    order_resumed: 
     order_state:
-      address: "地址"
-      awaiting_return: "等待退货"
-      canceled: "取消"
-      cart: "购物车"
-      complete: "完成"
-      confirm: "确认"
-      considered_risky:
-      delivery: "配送"
-      payment: "支付"
-      resumed: "重新开始"
-      returned: "返回"
-    order_summary: "订单概述"
-    order_sure_want_to: "您确定您想要%{event}这个订单么?"
-    order_total: "订单总计"
-    order_updated: "订单已更新"
-    orders: "订单"
-    other_items_in_other:
-    out_of_stock: "没有库存"
-    overview: "首页"
-    package_from: "包裹来自"
+      address: 地址
+      awaiting_return: 等待退货
+      canceled: 取消
+      cart: 购物车
+      complete: 完成
+      confirm: 确认
+      considered_risky: 
+      delivery: 配送
+      payment: 支付
+      resumed: 重新开始
+      returned: 返回
+    order_summary: 订单概述
+    order_sure_want_to: 您确定您想要%{event}这个订单么?
+    order_total: 订单总计
+    order_updated: 订单已更新
+    orders: 订单
+    other_items_in_other: 
+    out_of_stock: 没有库存
+    overview: 首页
+    package_from: 包裹来自
     pagination:
-      next_page: "下一页 »"
+      next_page: 下一页 »
       previous_page: "« 上一页"
       truncate: "…"
-    password: "密码"
-    paste: "粘贴"
-    path: "路径"
-    pay: "支付"
-    payment: "支付"
-    payment_could_not_be_created:
-    payment_identifier:
-    payment_information: "支付信息"
-    payment_method: "支付方式"
-    payment_method_not_supported:
-    payment_methods: "支付方式"
-    payment_processing_failed: "无法处理支付信息，请检查您所输入的详细信息"
-    payment_processor_choose_banner_text: "如果您需要关于支付处理的帮助，请访问"
-    payment_processor_choose_link: "我们的支付页面"
-    payment_state: "支付状态"
+    password: 密码
+    paste: 粘贴
+    path: 路径
+    pay: 支付
+    payment: 支付
+    payment_could_not_be_created: 
+    payment_identifier: 
+    payment_information: 支付信息
+    payment_method: 支付方式
+    payment_method_not_supported: 
+    payment_methods: 支付方式
+    payment_processing_failed: 无法处理支付信息，请检查您所输入的详细信息
+    payment_processor_choose_banner_text: 如果您需要关于支付处理的帮助，请访问
+    payment_processor_choose_link: 我们的支付页面
+    payment_state: 支付状态
     payment_states:
-      balance_due: "欠款"
-      checkout: "支付"
-      completed: "完成"
+      balance_due: 欠款
+      checkout: 支付
+      completed: 完成
       credit_owed: credit owed
-      failed: "失败"
-      paid: "已支付"
-      pending: "等待中"
-      processing: "正在处理"
-      void: "无效"
-    payment_updated: "支付已更新"
-    payments: "支付"
-    pending:
-    percent: "百分比"
-    percent_per_item: "单件百分比"
-    permalink: "永久链接"
-    phone: "电话"
-    place_order: "下单"
-    please_define_payment_methods: "请先设定支付方式。"
-    populate_get_error: "出错了，请重新添加项目。"
-    powered_by: "技术支持"
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
-    presentation: "描述"
-    previous: "上一页"
-    previous_state_missing: "状态未知"
-    price: "价格"
-    price_range: "价格范围"
-    price_sack: "袋价格"
-    process: "处理"
-    product: "产品"
-    product_details: "产品详情"
-    product_has_no_description: "该产品没有描述"
-    product_not_available_in_this_currency: "此产品在当前选中的货币下不可购买。"
-    product_properties: "产品属性"
+      failed: 失败
+      paid: 已支付
+      pending: 等待中
+      processing: 正在处理
+      void: 无效
+    payment_updated: 支付已更新
+    payments: 支付
+    pending: 
+    percent: 百分比
+    percent_per_item: 单件百分比
+    permalink: 永久链接
+    phone: 电话
+    place_order: 下单
+    please_define_payment_methods: 请先设定支付方式。
+    populate_get_error: 出错了，请重新添加项目。
+    powered_by: 技术支持
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
+    presentation: 描述
+    previous: 上一页
+    previous_state_missing: 状态未知
+    price: 价格
+    price_range: 价格范围
+    price_sack: 袋价格
+    process: 处理
+    product: 产品
+    product_details: 产品详情
+    product_has_no_description: 该产品没有描述
+    product_not_available_in_this_currency: 此产品在当前选中的货币下不可购买。
+    product_properties: 产品属性
     product_rule:
-      choose_products: "选择产品"
-      label:
-      match_all: "全部"
-      match_any: "至少一个"
-      match_none:
+      choose_products: 选择产品
+      label: 
+      match_all: 全部
+      match_any: 至少一个
+      match_none: 
       product_source:
-        group: "从产品分组"
-        manual: "手工选择"
-    products: "产品"
-    promotion: "促销"
-    promotion_action: "优惠方式"
+        group: 从产品分组
+        manual: 手工选择
+    products: 产品
+    promotion: 促销
+    promotion_action: 优惠方式
     promotion_action_types:
       create_adjustment:
-        description: "为订单添加促销用的价格调整"
-        name: "添加订单的价格调整"
+        description: 为订单添加促销用的价格调整
+        name: 添加订单的价格调整
       create_item_adjustments:
-        description: "为订单上的单项产品添加一笔促销用的价格调整"
-        name: "添加单项的价格调整"
+        description: 为订单上的单项产品添加一笔促销用的价格调整
+        name: 添加单项的价格调整
       create_line_items:
-        description: "增加特定商品到订单中"
-        name: "赠送礼品"
+        description: 增加特定商品到订单中
+        name: 赠送礼品
       free_shipping:
-        description: "整张订单免费发货"
-        name: "免运费"
-    promotion_actions: "优惠方式"
+        description: 整张订单免费发货
+        name: 免运费
+    promotion_actions: 优惠方式
     promotion_form:
       match_policies:
-        all: "匹配任意规则"
-        any: "匹配所有规则"
-    promotion_rule: "促销规则"
+        all: 匹配任意规则
+        any: 匹配所有规则
+    promotion_rule: 促销规则
     promotion_rule_types:
       first_order:
-        description: "必须是客户的第一笔订单"
-        name: "第一笔订单"
+        description: 必须是客户的第一笔订单
+        name: 第一笔订单
       item_total:
-        description: "订单总额满足这些条件"
-        name: "小记"
+        description: 订单总额满足这些条件
+        name: 小记
       landing_page:
-        description: "客户必须访问了指定的页面"
-        name: "登录页面"
+        description: 客户必须访问了指定的页面
+        name: 登录页面
       one_use_per_user:
-        description: "每人只可使用一次"
-        name: "每人一次"
+        description: 每人只可使用一次
+        name: 每人一次
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description: "订单包含指定的产品"
-        name: "产品"
+        description: 订单包含指定的产品
+        name: 产品
       taxon:
-        description: "订单中包括指定分类产品"
-        name: "分类"
+        description: 订单中包括指定分类产品
+        name: 分类
       user:
-        description: "只对指定的用户生效"
-        name: "用户"
+        description: 只对指定的用户生效
+        name: 用户
       user_logged_in:
-        description: "只对已经登录的用户有效"
-        name: "用户登录"
-    promotion_uses: "促销使用频率"
-    promotionable:
-    promotions: "促销"
-    propagate_all_variants:
-    properties: "属性"
-    property: "属性"
-    prototype: "原型"
-    prototypes: "原型"
-    provider: "提供者"
-    provider_settings_warning: "如果您正在修改提供者类型，您需要在编辑提供者设置之前先保存。"
-    qty: "数量"
-    quantity: "数量"
-    quantity_returned: "返回的数量"
-    quantity_shipped: "已发货数量"
-    quick_search: "快速搜索"
-    rate: "费率"
-    reason: "原因"
-    receive: "收到"
-    receive_stock:
-    received: "已收到"
-    reception_status:
-    reference:
-    refund: "退款"
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
-    register: "注册成为新用户"
-    registration: "注册"
-    reimburse:
-    reimbursed:
-    reimbursement:
+        description: 只对已经登录的用户有效
+        name: 用户登录
+    promotion_uses: 促销使用频率
+    promotionable: 
+    promotions: 促销
+    propagate_all_variants: 
+    properties: 属性
+    property: 属性
+    prototype: 原型
+    prototypes: 原型
+    provider: 提供者
+    provider_settings_warning: 如果您正在修改提供者类型，您需要在编辑提供者设置之前先保存。
+    qty: 数量
+    quantity: 数量
+    quantity_returned: 返回的数量
+    quantity_shipped: 已发货数量
+    quick_search: 快速搜索
+    rate: 费率
+    reason: 原因
+    receive: 收到
+    receive_stock: 
+    received: 已收到
+    reception_status: 
+    reference: 
+    refund: 退款
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
+    register: 注册成为新用户
+    registration: 注册
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
-    remember_me: "记住我"
-    remove: "移出"
-    rename: "重命名"
-    report:
-    reports: "报表"
-    resend: "重新发送"
-    reset_password: "重置密码"
-    response_code: "返回代码"
-    resume: "恢复"
-    resumed: "已恢复"
-    return: "退回"
-    return_authorization: "退货审批"
-    return_authorization_reasons:
-    return_authorization_updated: "退货审批已更新"
-    return_authorizations: "退货审批"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity: "退货数量"
-    returned: "已退回"
-    returns:
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
+    remember_me: 记住我
+    remove: 移出
+    rename: 重命名
+    report: 
+    reports: 报表
+    resend: 重新发送
+    reset_password: 重置密码
+    response_code: 返回代码
+    resume: 恢复
+    resumed: 已恢复
+    return: 退回
+    return_authorization: 退货审批
+    return_authorization_reasons: 
+    return_authorization_updated: 退货审批已更新
+    return_authorizations: 退货审批
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
+    return_quantity: 退货数量
+    returned: 已退回
+    returns: 
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA Credit
-    rma_number: "退货单号"
-    rma_value: "退货价值"
-    roles: "角色"
+    rma_number: 退货单号
+    rma_value: 退货价值
+    roles: 角色
     rules: Rules
-    safe: "安全"
-    sales_total: "销售总计"
-    sales_total_description: "所有订单总销量"
-    sales_totals: "总销量"
-    save_and_continue: "保存并继续"
-    save_my_address: "保存我的地址"
-    say_no: "不"
-    say_yes: "是的"
-    scope: "范围"
-    search: "搜索"
-    search_results: "搜索 '%{keywords}' 的结果"
-    searching: "搜索"
-    secure_connection_type: "安全连接类型"
-    security_settings: "安全设置"
-    select: "选择"
-    select_a_return_authorization_reason:
-    select_a_stock_location:
-    select_from_prototype: "从原型中选择"
-    select_stock:
-    send_copy_of_all_mails_to: "将所有邮件的副本发送至"
-    send_mails_as: "发送邮件作为"
-    server: "服务器"
-    server_error: "服务器返回了一个错误"
-    settings: "设置"
-    ship: "发货"
-    ship_address: "配送地址"
-    ship_total:
-    shipment: "配送"
-    shipment_adjustments:
-    shipment_details:
+    safe: 安全
+    sales_total: 销售总计
+    sales_total_description: 所有订单总销量
+    sales_totals: 总销量
+    save_and_continue: 保存并继续
+    save_my_address: 保存我的地址
+    say_no: 不
+    say_yes: 是的
+    scope: 范围
+    search: 搜索
+    search_results: 搜索 '%{keywords}' 的结果
+    searching: 搜索
+    secure_connection_type: 安全连接类型
+    security_settings: 安全设置
+    select: 选择
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
+    select_from_prototype: 从原型中选择
+    select_stock: 
+    send_copy_of_all_mails_to: 将所有邮件的副本发送至
+    send_mails_as: 发送邮件作为
+    server: 服务器
+    server_error: 服务器返回了一个错误
+    settings: 设置
+    ship: 发货
+    ship_address: 配送地址
+    ship_total: 
+    shipment: 配送
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer: "亲爱的顾客，"
-        instructions: "您的订单已发货"
-        shipment_summary: "发货概览"
-        subject: "发货通知"
-        thanks: "谢谢您的购买"
-        track_information: "货运单号： %{tracking}"
-        track_link:
-    shipment_state: "配送状态"
+        dear_customer: 亲爱的顾客，
+        instructions: 您的订单已发货
+        shipment_summary: 发货概览
+        subject: 发货通知
+        thanks: 谢谢您的购买
+        track_information: 货运单号： %{tracking}
+        track_link: 
+    shipment_state: 配送状态
     shipment_states:
-      backorder: "延期未交定货"
-      canceled:
-      partial: "部分"
-      pending: "等待中"
-      ready: "就绪"
-      shipped: "已经发货"
-    shipment_transfer_error:
-    shipment_transfer_success:
-    shipments: "配送"
-    shipped: "已发货"
-    shipping: "配送中"
-    shipping_address: "配送地址"
-    shipping_categories: "配送类型"
-    shipping_category: "配送分类"
-    shipping_flat_rate_per_item: "以单项计固定费率"
-    shipping_flat_rate_per_order: "固定费率"
-    shipping_flexible_rate: "以每项计弹性价格"
-    shipping_instructions: "配送指南"
-    shipping_method: "配送方式"
-    shipping_methods: "配送方式"
-    shipping_price_sack:
-    shipping_total:
-    shop_by_taxonomy: "根据%{taxonomy}购物"
-    shopping_cart: "购物车"
-    show: "显示"
-    show_active: "显示激活的"
-    show_deleted: "显示删除的"
-    show_only_complete_orders: "只显示完整的订单"
-    show_only_considered_risky:
-    show_rate_in_label:
-    sku: "条形码"
-    skus:
-    slug:
-    source: "来源"
-    special_instructions: "特别说明"
-    split: "分拆"
-    spree_gateway_error_flash_for_checkout: "您的支付信息存在错误。请检查您的信息后再次尝试。"
+      backorder: 延期未交定货
+      canceled: 
+      partial: 部分
+      pending: 等待中
+      ready: 就绪
+      shipped: 已经发货
+    shipment_transfer_error: 
+    shipment_transfer_success: 
+    shipments: 配送
+    shipped: 已发货
+    shipping: 配送中
+    shipping_address: 配送地址
+    shipping_categories: 配送类型
+    shipping_category: 配送分类
+    shipping_flat_rate_per_item: 以单项计固定费率
+    shipping_flat_rate_per_order: 固定费率
+    shipping_flexible_rate: 以每项计弹性价格
+    shipping_instructions: 配送指南
+    shipping_method: 配送方式
+    shipping_methods: 配送方式
+    shipping_price_sack: 
+    shipping_total: 
+    shop_by_taxonomy: 根据%{taxonomy}购物
+    shopping_cart: 购物车
+    show: 显示
+    show_active: 显示激活的
+    show_deleted: 显示删除的
+    show_only_complete_orders: 只显示完整的订单
+    show_only_considered_risky: 
+    show_rate_in_label: 
+    sku: 条形码
+    skus: 
+    slug: 
+    source: 来源
+    special_instructions: 特别说明
+    split: 分拆
+    spree_gateway_error_flash_for_checkout: 您的支付信息存在错误。请检查您的信息后再次尝试。
     ssl:
-      change_protocol:
-    start: "开始"
-    state: "省份"
-    state_based: "根据省份"
+      change_protocol: 
+    start: 开始
+    state: 省份
+    state_based: 根据省份
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states: "省份"
-    states_required:
-    status: "状态"
-    stock: "库存"
-    stock_location: "库存区域"
-    stock_location_info: "库存区域资讯"
-    stock_locations: "库存区域"
-    stock_locations_need_a_default_country:
-    stock_management: "库存管理"
-    stock_management_requires_a_stock_location: "请先新增库存区域，才可使用库存管理"
-    stock_movements: "库存动向"
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
+    states: 省份
+    states_required: 
+    status: 状态
+    stock: 库存
+    stock_location: 库存区域
+    stock_location_info: 库存区域资讯
+    stock_locations: 库存区域
+    stock_locations_need_a_default_country: 
+    stock_management: 库存管理
+    stock_management_requires_a_stock_location: 请先新增库存区域，才可使用库存管理
+    stock_movements: 库存动向
     stock_movements_for_stock_location: "%{stock_location_name} 的库存动向"
-    stock_successfully_transferred: "库存已成功在两区域转移"
-    stock_transfer: "库存转移"
-    stock_transfers: "库存转移"
-    stop: "结束"
-    store: "商城"
-    street_address: "地址"
-    street_address_2: "地址(继续输入)"
-    subtotal: "小计"
-    subtract: "减去"
-    success:
+    stock_successfully_transferred: 库存已成功在两区域转移
+    stock_transfer: 库存转移
+    stock_transfers: 库存转移
+    stop: 结束
+    store: 商城
+    street_address: 地址
+    street_address_2: 地址(继续输入)
+    subtotal: 小计
+    subtract: 减去
+    success: 
     successfully_created: "%{resource} 已被成功添加!"
-    successfully_refunded:
+    successfully_refunded: 
     successfully_removed: "%{resource} 已被成功删除!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: 
     successfully_updated: "%{resource} 已被成功更新!"
-    summary:
-    tax: "税"
-    tax_categories: "缴税分类"
-    tax_category: "缴税分类"
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
-    tax_rates: "税率"
-    taxon: "分类"
-    taxon_edit: "编辑分类"
-    taxon_placeholder: "添加分类"
+    summary: 
+    tax: 税
+    tax_categories: 缴税分类
+    tax_category: 缴税分类
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
+    tax_rates: 税率
+    taxon: 分类
+    taxon_edit: 编辑分类
+    taxon_placeholder: 添加分类
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
-    taxonomies: "分类层级"
-    taxonomy: "分类层级"
-    taxonomy_edit: "编辑分类层级"
-    taxonomy_tree_error: "请求的变更没有被接受，分类树会恢复到之前的状态，请重新尝试."
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
+    taxonomies: 分类层级
+    taxonomy: 分类层级
+    taxonomy_edit: 编辑分类层级
+    taxonomy_tree_error: 请求的变更没有被接受，分类树会恢复到之前的状态，请重新尝试.
     taxonomy_tree_instruction: "* 右键单击一个树的子结点以访问添加、删除或者排序字节点的菜单."
-    taxons: "分类"
-    test: "测试"
+    taxons: 分类
+    test: 测试
     test_mailer:
       test_email:
-        greeting: "恭喜!"
-        message: "如果您收到此邮件，则说明您的邮件设置是正确的"
-        subject: "测试邮件"
-    test_mode: "测试模式"
-    thank_you_for_your_order: "感谢您的订购，请打印这张订单作为购买凭证。"
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields: "以下字段存在错误"
-    this_order_has_already_received_a_refund:
-    thumbnail: "缩略图"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time: "时间"
-    to_add_variants_you_must_first_define: "要添加具体型号，您需要先定义"
-    total: "总计"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
-    tracking: "追踪"
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder: "比如，http://quickship.com/package?num=:tracking"
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
-    tree: "树"
-    type: "类型"
-    type_to_search: "搜索类型"
-    unable_to_connect_to_gateway: "无法连接支付网关."
-    unable_to_create_reimbursements:
-    under_price: "低于 %{price}"
-    unlock: "解锁"
-    unrecognized_card_type: "无法辨识的支付卡种类"
-    unshippable_items: "无法邮寄的商品"
-    update: "更新"
-    updating: "更新中"
-    usage_limit: "使用限制"
-    use_app_default:
-    use_billing_address: "使用账单地址"
-    use_new_cc: "使用一张新卡"
-    use_s3: "使用Amazon S3存储图片"
-    user: "用户"
+        greeting: 恭喜!
+        message: 如果您收到此邮件，则说明您的邮件设置是正确的
+        subject: 测试邮件
+    test_mode: 测试模式
+    thank_you_for_your_order: 感谢您的订购，请打印这张订单作为购买凭证。
+    there_are_no_items_for_this_order: 
+    there_were_problems_with_the_following_fields: 以下字段存在错误
+    this_order_has_already_received_a_refund: 
+    thumbnail: 缩略图
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: 时间
+    to_add_variants_you_must_first_define: 要添加具体型号，您需要先定义
+    total: 总计
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
+    tracking: 追踪
+    tracking_number: 
+    tracking_url: 
+    tracking_url_placeholder: 比如，http://quickship.com/package?num=:tracking
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
+    tree: 树
+    type: 类型
+    type_to_search: 搜索类型
+    unable_to_connect_to_gateway: 无法连接支付网关.
+    unable_to_create_reimbursements: 
+    under_price: 低于 %{price}
+    unlock: 解锁
+    unrecognized_card_type: 无法辨识的支付卡种类
+    unshippable_items: 无法邮寄的商品
+    update: 更新
+    updating: 更新中
+    usage_limit: 使用限制
+    use_app_default: 
+    use_billing_address: 使用账单地址
+    use_new_cc: 使用一张新卡
+    use_s3: 使用Amazon S3存储图片
+    user: 用户
     user_rule:
-      choose_users: "选择用户"
-    users: "用户详情"
+      choose_users: 选择用户
+    users: 用户详情
     validation:
-      cannot_be_less_than_shipped_units: "不能少于已配送的单位数。"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock: "超出可用的库存。请确认订单项拥有有效的数量。"
-      is_too_large: "数量太多了 -- 现有库存无法满足您需要的数量!"
-      must_be_int: "必须是整数"
-      must_be_non_negative: "不能为负数"
-      unpaid_amount_not_zero:
-    value: "价值"
-    variant: "具体型号"
-    variant_placeholder: "选择具体型号"
-    variants: "具体型号"
-    version: "版本"
-    void: "作废"
-    weight: "重量"
-    what_is_a_cvv: "信用卡验证码(CVV)是什么"
-    what_is_this: "这是什么?"
-    width: "宽度"
-    year: "年"
-    you_have_no_orders_yet: "您还没有下过订单"
-    your_cart_is_empty: "您的购物车是空的"
-    your_order_is_empty_add_product: "您的订单是空的，请搜索并且添加以上的产品"
-    zip: "邮编"
-    zipcode: "邮编"
-    zone: "区域"
-    zones: "区域"
+      cannot_be_less_than_shipped_units: 不能少于已配送的单位数。
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 超出可用的库存。请确认订单项拥有有效的数量。
+      is_too_large: 数量太多了 -- 现有库存无法满足您需要的数量!
+      must_be_int: 必须是整数
+      must_be_non_negative: 不能为负数
+      unpaid_amount_not_zero: 
+    value: 价值
+    variant: 具体型号
+    variant_placeholder: 选择具体型号
+    variants: 具体型号
+    version: 版本
+    void: 作废
+    weight: 重量
+    what_is_a_cvv: 信用卡验证码(CVV)是什么
+    what_is_this: 这是什么?
+    width: 宽度
+    year: 年
+    you_have_no_orders_yet: 您还没有下过订单
+    your_cart_is_empty: 您的购物车是空的
+    your_order_is_empty_add_product: 您的订单是空的，请搜索并且添加以上的产品
+    zip: 邮编
+    zipcode: 邮编
+    zone: 区域
+    zones: 区域

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,1249 +1,1250 @@
+---
 zh-TW:
   activerecord:
     attributes:
       spree/address:
-        address1: "地址"
-        address2: "地址 (接續.)"
-        city: "城市"
-        country: "國家"
-        firstname: "名"
-        lastname: "姓"
-        phone: "電話"
-        state: "省/州"
-        zipcode: "郵遞區號"
+        address1: 地址
+        address2: 地址 (接續.)
+        city: 城市
+        country: 國家
+        firstname: 名
+        lastname: 姓
+        phone: 電話
+        state: 省/州
+        zipcode: 郵遞區號
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: 
+        preferred_tiers: 
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: 
+        preferred_tiers: 
       spree/country:
         iso: ISO
         iso3: ISO3
         iso_name: ISO 名稱
-        name: "名稱"
+        name: 名稱
         numcode: ISO 編碼
       spree/credit_card:
-        base:
-        cc_type: "信用卡類型"
-        month: "月份"
-        name:
-        number: "卡號"
-        verification_value: "驗證碼"
-        year: "年份"
+        base: 
+        cc_type: 信用卡類型
+        month: 月份
+        name: 
+        number: 卡號
+        verification_value: 驗證碼
+        year: 年份
       spree/inventory_unit:
-        state: "狀態"
+        state: 狀態
       spree/line_item:
-        price: "價格"
-        quantity: "數量"
+        price: 價格
+        quantity: 數量
       spree/option_type:
-        name: "名稱"
-        presentation: "描述"
+        name: 名稱
+        presentation: 描述
       spree/order:
-        checkout_complete: "完成結帳"
-        completed_at: "結帳日期"
-        considered_risky:
-        coupon_code: "優惠代碼"
-        created_at: "訂單日期"
-        email: "電子信箱"
+        checkout_complete: 完成結帳
+        completed_at: 結帳日期
+        considered_risky: 
+        coupon_code: 優惠代碼
+        created_at: 訂單日期
+        email: 電子信箱
         ip_address: IP 位址
-        item_total: "項目總計"
-        number: "訂單號碼"
-        payment_state: "付款狀態"
-        shipment_state: "物流狀態"
-        special_instructions: "特別說明"
-        state: "狀態"
-        total: "總計"
+        item_total: 項目總計
+        number: 訂單號碼
+        payment_state: 付款狀態
+        shipment_state: 物流狀態
+        special_instructions: 特別說明
+        state: 狀態
+        total: 總計
       spree/order/bill_address:
-        address1: "帳單地址"
-        city: "城市"
-        firstname: "名"
-        lastname: "姓"
-        phone: "電話"
-        state: "州/省"
-        zipcode: "郵遞區號"
+        address1: 帳單地址
+        city: 城市
+        firstname: 名
+        lastname: 姓
+        phone: 電話
+        state: 州/省
+        zipcode: 郵遞區號
       spree/order/ship_address:
-        address1: "送貨地址"
-        city: "城市"
-        firstname: "名"
-        lastname: "姓"
-        phone: "電話"
-        state: "州/省"
-        zipcode: "郵遞區號"
+        address1: 送貨地址
+        city: 城市
+        firstname: 名
+        lastname: 姓
+        phone: 電話
+        state: 州/省
+        zipcode: 郵遞區號
       spree/payment:
-        amount: "金額"
+        amount: 金額
       spree/payment_method:
-        name: "名稱"
+        name: 名稱
       spree/product:
-        available_on: "上架日期"
-        cost_currency: "成本幣別"
-        cost_price: "成本"
-        description: "描述"
-        master_price: "預設價格"
-        name: "名稱"
-        on_hand: "庫存"
-        shipping_category: "運送分類"
-        tax_category: "稅金分類"
+        available_on: 上架日期
+        cost_currency: 成本幣別
+        cost_price: 成本
+        description: 描述
+        master_price: 預設價格
+        name: 名稱
+        on_hand: 庫存
+        shipping_category: 運送分類
+        tax_category: 稅金分類
       spree/promotion:
-        advertise: "廣告"
-        code: "編號"
-        description: "描述"
-        event_name: "活動名稱"
-        expires_at: "有效日期"
-        name: "名稱"
-        path: "路徑"
-        starts_at: "起始日期"
-        usage_limit: "使用次數限制"
+        advertise: 廣告
+        code: 編號
+        description: 描述
+        event_name: 活動名稱
+        expires_at: 有效日期
+        name: 名稱
+        path: 路徑
+        starts_at: 起始日期
+        usage_limit: 使用次數限制
       spree/promotion_category:
-        name:
+        name: 
       spree/property:
-        name: "名稱"
-        presentation: "描述"
+        name: 名稱
+        presentation: 描述
       spree/prototype:
-        name: "名稱"
+        name: 名稱
       spree/return_authorization:
-        amount: "金額"
+        amount: 金額
       spree/role:
-        name: "名稱"
+        name: 名稱
       spree/state:
-        abbr: "縮寫"
-        name: "名稱"
+        abbr: 縮寫
+        name: 名稱
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: 
+        state_from: 
+        state_to: 
+        timestamp: 
+        type: 
+        updated: 
+        user: 
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: 
+        meta_description: 
+        meta_keywords: 
+        name: 
+        seo_title: 
+        url: 
       spree/tax_category:
-        description: "描述"
-        name: "名稱"
+        description: 描述
+        name: 名稱
       spree/tax_rate:
-        amount: "稅率"
-        included_in_price: "包含在售價中"
-        show_rate_in_label: "顯示稅率"
+        amount: 稅率
+        included_in_price: 包含在售價中
+        show_rate_in_label: 顯示稅率
       spree/taxon:
-        name: "名稱"
-        permalink: "永久連結"
-        position: "位置"
+        name: 名稱
+        permalink: 永久連結
+        position: 位置
       spree/taxonomy:
-        name: "名稱"
+        name: 名稱
       spree/user:
         email: Email
-        password: "密碼"
-        password_confirmation: "確認密碼"
+        password: 密碼
+        password_confirmation: 確認密碼
       spree/variant:
-        cost_currency: "成本幣別"
-        cost_price: "成本價"
-        depth: "長/深"
-        height: "高度"
-        price: "單價"
-        sku: "條碼"
-        weight: "重量"
-        width: "寬"
+        cost_currency: 成本幣別
+        cost_price: 成本價
+        depth: 長/深
+        height: 高度
+        price: 單價
+        sku: 條碼
+        weight: 重量
+        width: 寬
       spree/zone:
-        description: "描述"
-        name: "名稱"
+        description: 描述
+        name: 名稱
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: 
+              values_should_be_percent: 
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: 
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: 
         spree/credit_card:
           attributes:
             base:
-              card_expired: "信用卡已失效"
-              expiry_invalid:
+              card_expired: 信用卡已失效
+              expiry_invalid: 
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: 
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: 
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: 
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: 
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: 
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: 
     models:
-      spree/address: "地址"
-      spree/country: "國家"
-      spree/credit_card: "信用卡"
-      spree/customer_return:
-      spree/inventory_unit: "庫存單位"
+      spree/address: 地址
+      spree/country: 國家
+      spree/credit_card: 信用卡
+      spree/customer_return: 
+      spree/inventory_unit: 庫存單位
       spree/line_item:
-        one: "單項"
-        other: "單項"
-      spree/option_type:
-      spree/option_value:
-      spree/order: "訂單"
-      spree/payment: "付款"
-      spree/payment_method:
-      spree/product: "產品"
-      spree/promotion: "促銷"
-      spree/promotion_category:
-      spree/property: "屬性"
-      spree/prototype: "原型"
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+        one: 單項
+        other: 單項
+      spree/option_type: 
+      spree/option_value: 
+      spree/order: 訂單
+      spree/payment: 付款
+      spree/payment_method: 
+      spree/product: 產品
+      spree/promotion: 促銷
+      spree/promotion_category: 
+      spree/property: 屬性
+      spree/prototype: 原型
+      spree/refund_reason: 
+      spree/reimbursement: 
+      spree/reimbursement_type: 
       spree/return_authorization:
-        one: "返回授權"
-        other: "返回授權"
-      spree/return_authorization_reason:
-      spree/role: "角色"
-      spree/shipment: "貨運"
-      spree/shipping_category: "貨運類別"
-      spree/shipping_method:
-      spree/state: "州/省"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
-      spree/tax_category: "稅金類別"
-      spree/tax_rate: "稅率"
-      spree/taxon: "分類"
-      spree/taxonomy: "分類"
-      spree/tracker:
-      spree/user: "使用者"
-      spree/variant: "型號"
-      spree/zone: "區域"
+        one: 返回授權
+        other: 返回授權
+      spree/return_authorization_reason: 
+      spree/role: 角色
+      spree/shipment: 貨運
+      spree/shipping_category: 貨運類別
+      spree/shipping_method: 
+      spree/state: 州/省
+      spree/state_change: 
+      spree/stock_location: 
+      spree/stock_movement: 
+      spree/stock_transfer: 
+      spree/tax_category: 稅金類別
+      spree/tax_rate: 稅率
+      spree/taxon: 分類
+      spree/taxonomy: 分類
+      spree/tracker: 
+      spree/user: 使用者
+      spree/variant: 型號
+      spree/zone: 區域
   spree:
-    abbreviation: "縮寫"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
-    account: "帳戶"
-    account_updated: "帳戶已更新"
-    action: "操作"
+    abbreviation: 縮寫
+    accept: 
+    acceptance_errors: 
+    acceptance_status: 
+    accepted: 
+    account: 帳戶
+    account_updated: 帳戶已更新
+    action: 操作
     actions:
-      cancel: "取消"
-      continue: "繼續"
-      create: "建立"
-      destroy: "刪除"
-      edit: "編輯"
-      list: "列表"
-      listing: "列出中"
-      new: "新增"
-      refund:
-      save: "儲存"
-      update: "更新"
-    activate: "啓用"
-    active: "啟動"
-    add: "增加"
-    add_action_of_type: "增加促銷優惠"
-    add_country: "增加國家"
-    add_coupon_code:
-    add_new_header: "增加新 Header"
-    add_new_style: "增加新樣式"
-    add_one: "新增"
-    add_option_value: "增加選項"
-    add_product: "增加商品"
-    add_product_properties: "增加商品屬性"
-    add_rule_of_type: "增加條件"
-    add_state: "增加 州,省,日本県,台灣縣市"
-    add_stock: "新增庫存"
-    add_stock_management: "新增庫存管理"
-    add_to_cart: "加到購物車"
-    add_variant: "新增型號"
-    additional_item: "額外商品花費"
-    address1: "地址"
-    address2: "地址 (接續)"
-    adjustable:
-    adjustment: "其他項目"
-    adjustment_amount: "金額"
-    adjustment_successfully_closed: "其他項目已成功停用!"
-    adjustment_successfully_opened: "其他項目已成功啓用!"
-    adjustment_total: "其他項目總計"
-    adjustments: "其他項目"
+      cancel: 取消
+      continue: 繼續
+      create: 建立
+      destroy: 刪除
+      edit: 編輯
+      list: 列表
+      listing: 列出中
+      new: 新增
+      refund: 
+      save: 儲存
+      update: 更新
+    activate: 啓用
+    active: 啟動
+    add: 增加
+    add_action_of_type: 增加促銷優惠
+    add_country: 增加國家
+    add_coupon_code: 
+    add_new_header: 增加新 Header
+    add_new_style: 增加新樣式
+    add_one: 新增
+    add_option_value: 增加選項
+    add_product: 增加商品
+    add_product_properties: 增加商品屬性
+    add_rule_of_type: 增加條件
+    add_state: 增加 州,省,日本県,台灣縣市
+    add_stock: 新增庫存
+    add_stock_management: 新增庫存管理
+    add_to_cart: 加到購物車
+    add_variant: 新增型號
+    additional_item: 額外商品花費
+    address1: 地址
+    address2: 地址 (接續)
+    adjustable: 
+    adjustment: 其他項目
+    adjustment_amount: 金額
+    adjustment_successfully_closed: 其他項目已成功停用!
+    adjustment_successfully_opened: 其他項目已成功啓用!
+    adjustment_total: 其他項目總計
+    adjustments: 其他項目
     admin:
       tab:
-        configuration: "設定"
-        option_types:
-        orders: "訂單"
-        overview: "總覽"
-        products: "產品"
-        promotions: "宣傳"
-        properties:
-        prototypes:
-        reports: "報表"
-        taxonomies:
-        taxons:
-        users: "使用者"
+        configuration: 設定
+        option_types: 
+        orders: 訂單
+        overview: 總覽
+        products: 產品
+        promotions: 宣傳
+        properties: 
+        prototypes: 
+        reports: 報表
+        taxonomies: 
+        taxons: 
+        users: 使用者
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
-    administration: "管理介面"
-    advertise:
-    agree_to_privacy_policy: "同意隱私條款"
-    agree_to_terms_of_service: "同意服務條款"
-    all: "全部"
-    all_adjustments_closed: "所有調整項目已成功停用!"
-    all_adjustments_opened: "所有調整項目已成功啓用!"
-    all_departments: "所有部門"
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test: "允許在 Development / Test 模式下使用SSL"
-    allow_ssl_in_production: "允許在 Production 模式下使用SSL"
-    allow_ssl_in_staging: "允許在 Staging 模式下使用SSL"
-    already_signed_up_for_analytics: "您已註冊 Spree Analytics"
-    alt_text: "說明文字"
-    alternative_phone: "額外電話"
-    amount: "金額"
+        account: 
+        addresses: 
+        items: 
+        items_purchased: 
+        order_history: 
+        order_num: 
+        orders: 
+        user_information: 
+    administration: 管理介面
+    advertise: 
+    agree_to_privacy_policy: 同意隱私條款
+    agree_to_terms_of_service: 同意服務條款
+    all: 全部
+    all_adjustments_closed: 所有調整項目已成功停用!
+    all_adjustments_opened: 所有調整項目已成功啓用!
+    all_departments: 所有部門
+    all_items_have_been_returned: 
+    allow_ssl_in_development_and_test: 允許在 Development / Test 模式下使用SSL
+    allow_ssl_in_production: 允許在 Production 模式下使用SSL
+    allow_ssl_in_staging: 允許在 Staging 模式下使用SSL
+    already_signed_up_for_analytics: 您已註冊 Spree Analytics
+    alt_text: 說明文字
+    alternative_phone: 額外電話
+    amount: 金額
     analytics_desc_header_1: Spree Analytics
-    analytics_desc_header_2: "整合線上分析至您的Spree 控制台"
-    analytics_desc_list_1:
-    analytics_desc_list_2: "只需一個免費的Spree 帳號便能啓用"
-    analytics_desc_list_3: "完全不需要插入程式碼"
-    analytics_desc_list_4: "完全免費!"
-    analytics_trackers: "分析追蹤"
-    and: "以及"
-    approve: "核准"
-    approved_at: "核准日期"
-    approver: "核准者"
-    are_you_sure: "你確定嗎?"
-    are_you_sure_delete: "你確定要刪除?"
-    associated_adjustment_closed: "這個關聯的調整項目已經停用, 而且不會被重複計算, 您要啓用它嗎?"
-    at_symbol: '@'
-    authorization_failure: "認証失敗"
-    authorized:
-    auto_capture:
-    available_on: "上架時間"
-    average_order_value:
-    avs_response:
-    back: "返回"
-    back_end: "後端"
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
-    back_to_store: "回商店"
-    back_to_users_list: "返回使用者列表"
-    backorderable: "可預購"
-    backorderable_default:
-    backordered: "待補"
-    backorders_allowed: "已允許預購"
-    balance_due: "未入帳"
-    base_amount:
-    base_percent:
-    bill_address: "帳單地址"
-    billing: "帳單"
-    billing_address: "帳單地址"
-    both: "全部"
-    calculated_reimbursements:
-    calculator: "計算規則"
-    calculator_settings_warning: "如果你更改了計算規則, 需要先儲存才能進行修改"
-    cancel: "取消"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: "你無法在未定義付費方法前產生訂單的付費資訊."
-    cannot_create_returns: "無法建立退貨資訊, 因為這筆訂單不需要配送"
-    cannot_perform_operation: "無法執行要求的運算"
-    cannot_set_shipping_method_without_address: "在消費者細節沒提供前, 無法設定運送方法"
-    capture: "入帳完成付款"
-    capture_events:
-    card_code: "信用卡驗證碼"
-    card_number: "信用卡卡號"
-    card_type:
-    card_type_is: "信用卡類型"
-    cart: "購物車"
-    cart_subtotal:
-    categories: "分類"
-    category: "分類"
-    charged:
-    check_for_spree_alerts: "檢查 Spree的警告"
-    checkout: "結帳"
-    choose_a_customer: "選擇一個消費者"
-    choose_a_taxon_to_sort_products_for:
-    choose_currency: "選擇幣別"
-    choose_dashboard_locale: "選擇控制台語系"
-    choose_location:
-    city: "城市"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
-    clone: "複製"
-    close: "關閉"
-    close_all_adjustments: "停用所有調整項目"
-    code: "編碼"
-    company: "公司"
-    complete: "完成"
-    configuration: "偏好設定"
-    configurations: "偏好設定"
-    confirm: "確認"
-    confirm_delete: "確認刪除"
-    confirm_password: "確認密碼"
-    continue: "繼續"
-    continue_shopping: "繼續購物"
-    cost_currency: "成本貨幣"
-    cost_price: "成本價格"
-    could_not_connect_to_jirafe: "無法從 Jirafe同步資料, 稍候將自動重新嘗試."
-    could_not_create_customer_return:
-    could_not_create_stock_movement: "在儲存庫存動向時發生了錯誤, 請再試一次."
-    count_on_hand: "庫存數量"
-    countries: "國家"
-    country: "國家"
-    country_based: "依據國家"
-    country_name: "名稱"
+    analytics_desc_header_2: 整合線上分析至您的Spree 控制台
+    analytics_desc_list_1: 
+    analytics_desc_list_2: 只需一個免費的Spree 帳號便能啓用
+    analytics_desc_list_3: 完全不需要插入程式碼
+    analytics_desc_list_4: 完全免費!
+    analytics_trackers: 分析追蹤
+    and: 以及
+    approve: 核准
+    approved_at: 核准日期
+    approver: 核准者
+    are_you_sure: 你確定嗎?
+    are_you_sure_delete: 你確定要刪除?
+    associated_adjustment_closed: 這個關聯的調整項目已經停用, 而且不會被重複計算, 您要啓用它嗎?
+    at_symbol: "@"
+    authorization_failure: 認証失敗
+    authorized: 
+    auto_capture: 
+    available_on: 上架時間
+    average_order_value: 
+    avs_response: 
+    back: 返回
+    back_end: 後端
+    back_to_payment: 
+    back_to_resource_list: 
+    back_to_rma_reason_list: 
+    back_to_store: 回商店
+    back_to_users_list: 返回使用者列表
+    backorderable: 可預購
+    backorderable_default: 
+    backordered: 待補
+    backorders_allowed: 已允許預購
+    balance_due: 未入帳
+    base_amount: 
+    base_percent: 
+    bill_address: 帳單地址
+    billing: 帳單
+    billing_address: 帳單地址
+    both: 全部
+    calculated_reimbursements: 
+    calculator: 計算規則
+    calculator_settings_warning: 如果你更改了計算規則, 需要先儲存才能進行修改
+    cancel: 取消
+    canceled_at: 
+    canceler: 
+    cannot_create_customer_returns: 
+    cannot_create_payment_without_payment_methods: 你無法在未定義付費方法前產生訂單的付費資訊.
+    cannot_create_returns: 無法建立退貨資訊, 因為這筆訂單不需要配送
+    cannot_perform_operation: 無法執行要求的運算
+    cannot_set_shipping_method_without_address: 在消費者細節沒提供前, 無法設定運送方法
+    capture: 入帳完成付款
+    capture_events: 
+    card_code: 信用卡驗證碼
+    card_number: 信用卡卡號
+    card_type: 
+    card_type_is: 信用卡類型
+    cart: 購物車
+    cart_subtotal: 
+    categories: 分類
+    category: 分類
+    charged: 
+    check_for_spree_alerts: 檢查 Spree的警告
+    checkout: 結帳
+    choose_a_customer: 選擇一個消費者
+    choose_a_taxon_to_sort_products_for: 
+    choose_currency: 選擇幣別
+    choose_dashboard_locale: 選擇控制台語系
+    choose_location: 
+    city: 城市
+    clear_cache: 
+    clear_cache_ok: 
+    clear_cache_warning: 
+    click_and_drag_on_the_products_to_sort_them: 
+    clone: 複製
+    close: 關閉
+    close_all_adjustments: 停用所有調整項目
+    code: 編碼
+    company: 公司
+    complete: 完成
+    configuration: 偏好設定
+    configurations: 偏好設定
+    confirm: 確認
+    confirm_delete: 確認刪除
+    confirm_password: 確認密碼
+    continue: 繼續
+    continue_shopping: 繼續購物
+    cost_currency: 成本貨幣
+    cost_price: 成本價格
+    could_not_connect_to_jirafe: 無法從 Jirafe同步資料, 稍候將自動重新嘗試.
+    could_not_create_customer_return: 
+    could_not_create_stock_movement: 在儲存庫存動向時發生了錯誤, 請再試一次.
+    count_on_hand: 庫存數量
+    countries: 國家
+    country: 國家
+    country_based: 依據國家
+    country_name: 名稱
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon: "促銷代碼"
-    coupon_code: "促銷代碼"
-    coupon_code_already_applied: "優惠代碼已經被使用在這個訂單"
-    coupon_code_applied: "優惠代碼已經成功使用在您的訂單."
-    coupon_code_better_exists: "上一組優惠代碼比較划算"
-    coupon_code_expired: "優惠代碼已過期"
-    coupon_code_max_usage: "已達優惠代碼使用上限"
-    coupon_code_not_eligible: "此優惠代碼不適用於本訂單"
-    coupon_code_not_found: "您輸入的優惠代碼不存在. 請再試一次."
-    coupon_code_unknown_error:
-    create: "建立"
-    create_a_new_account: "建立新帳號"
-    create_new_order:
-    create_reimbursement:
-    created_at: "建立於"
-    credit: "額度"
-    credit_card: "信用卡"
-    credit_cards: "信用卡"
-    credit_owed: "負債"
-    credits:
-    currency: "幣別"
-    currency_decimal_mark: "幣別小數點符號"
-    currency_settings: "幣別設定"
-    currency_symbol_position: "幣別符號在金額數字前還是後?"
-    currency_thousands_separator: "幣別千分位分隔符號"
-    current: "目前的"
-    current_promotion_usage: "目前使用量: %{count}"
-    customer: "客戶"
-    customer_details: "客戶資料"
-    customer_details_updated: "客戶資料更新完成"
-    customer_return:
-    customer_returns:
-    customer_search: "搜尋客戶"
-    cut: "剪下"
-    cvv_response:
+      CA: 
+      FRA: 
+      ITA: 
+      US: 
+    coupon: 促銷代碼
+    coupon_code: 促銷代碼
+    coupon_code_already_applied: 優惠代碼已經被使用在這個訂單
+    coupon_code_applied: 優惠代碼已經成功使用在您的訂單.
+    coupon_code_better_exists: 上一組優惠代碼比較划算
+    coupon_code_expired: 優惠代碼已過期
+    coupon_code_max_usage: 已達優惠代碼使用上限
+    coupon_code_not_eligible: 此優惠代碼不適用於本訂單
+    coupon_code_not_found: 您輸入的優惠代碼不存在. 請再試一次.
+    coupon_code_unknown_error: 
+    create: 建立
+    create_a_new_account: 建立新帳號
+    create_new_order: 
+    create_reimbursement: 
+    created_at: 建立於
+    credit: 額度
+    credit_card: 信用卡
+    credit_cards: 信用卡
+    credit_owed: 負債
+    credits: 
+    currency: 幣別
+    currency_decimal_mark: 幣別小數點符號
+    currency_settings: 幣別設定
+    currency_symbol_position: 幣別符號在金額數字前還是後?
+    currency_thousands_separator: 幣別千分位分隔符號
+    current: 目前的
+    current_promotion_usage: '目前使用量: %{count}'
+    customer: 客戶
+    customer_details: 客戶資料
+    customer_details_updated: 客戶資料更新完成
+    customer_return: 
+    customer_returns: 
+    customer_search: 搜尋客戶
+    cut: 剪下
+    cvv_response: 
     dash:
       jirafe:
         app_id: App ID
         app_token: App Token
         currently_unavailable: Jirafe 目前無法使用. Spree 將在Jirafe 恢復正常時自動連線.
-        explanation: "如果你選擇從管理界面來註冊Jirafe, 以下填寫的欄位很有可能已經存在"
+        explanation: 如果你選擇從管理界面來註冊Jirafe, 以下填寫的欄位很有可能已經存在
         header: Jirafe Analytics 設定
-        site_id: "網站 ID"
-        token: "辨識碼"
+        site_id: 網站 ID
+        token: 辨識碼
       jirafe_settings_updated: Jirafe 設定已經更新.
-    date: "日期"
-    date_completed: "完成日期"
+    date: 日期
+    date_completed: 完成日期
     date_picker:
       first_day: 0
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
-    date_range: "日期範圍"
-    default: "預設"
-    default_refund_amount:
-    default_tax: "預設稅項"
-    default_tax_zone: "預設稅區"
-    delete: "刪除"
-    deleted_variants_present:
-    delivery: "抵達"
-    depth: "深"
-    description: "描述"
-    destination: "目的地"
-    destroy: "刪除"
-    details:
-    discount_amount: "折扣金額"
-    dismiss_banner: "不。謝謝！我沒有興趣，不要再顯示此訊息。"
-    display: "顯示"
-    display_currency: "顯示貨幣"
-    doesnt_track_inventory:
-    edit: "編輯"
-    editing_resource:
-    editing_rma_reason:
-    editing_user: "編輯使用者"
+    date_range: 日期範圍
+    default: 預設
+    default_refund_amount: 
+    default_tax: 預設稅項
+    default_tax_zone: 預設稅區
+    delete: 刪除
+    deleted_variants_present: 
+    delivery: 抵達
+    depth: 深
+    description: 描述
+    destination: 目的地
+    destroy: 刪除
+    details: 
+    discount_amount: 折扣金額
+    dismiss_banner: 不。謝謝！我沒有興趣，不要再顯示此訊息。
+    display: 顯示
+    display_currency: 顯示貨幣
+    doesnt_track_inventory: 
+    edit: 編輯
+    editing_resource: 
+    editing_rma_reason: 
+    editing_user: 編輯使用者
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: 
+        item_total_less_than: 
+        item_total_less_than_or_equal: 
+        item_total_more_than: 
+        item_total_more_than_or_equal: 
+        limit_once_per_user: 
+        missing_product: 
+        missing_taxon: 
+        no_applicable_products: 
+        no_matching_taxons: 
+        no_user_or_email_specified: 
+        no_user_specified: 
+        not_first_order: 
     email: Email
-    empty: "空"
-    empty_cart: "清空購物車"
-    enable_mail_delivery: "啟用 Email 寄送功能"
-    end: "結束"
+    empty: 空
+    empty_cart: 清空購物車
+    enable_mail_delivery: 啟用 Email 寄送功能
+    end: 結束
     ending_in: Ending in
-    environment: "環境"
-    error: "錯誤"
+    environment: 環境
+    error: 錯誤
     errors:
       messages:
-        could_not_create_taxon: "無法建立類型"
+        could_not_create_taxon: 無法建立類型
         no_payment_methods_available: No payment methods are configured for this environment
-        no_shipping_methods_available: "沒有可用的出貨方式, 請修改地址後再試一次"
+        no_shipping_methods_available: 沒有可用的出貨方式, 請修改地址後再試一次
     errors_prohibited_this_record_from_being_saved:
-      one: "有 1 個錯誤發生使得這筆資料無法被儲存"
-      other: "有 %{count} 個錯誤發生使得這筆資料無法被儲存"
-    event: "觸發事件"
+      one: 有 1 個錯誤發生使得這筆資料無法被儲存
+      other: 有 %{count} 個錯誤發生使得這筆資料無法被儲存
+    event: 觸發事件
     events:
       spree:
         cart:
-          add: "加入購物車"
+          add: 加入購物車
         checkout:
-          coupon_code_added: "添加了優惠券號碼"
+          coupon_code_added: 添加了優惠券號碼
         content:
-          visited: "訪問靜態頁面"
+          visited: 訪問靜態頁面
         order:
-          contents_changed: "訂單內容已變更"
-        page_view: "被訪問靜態頁面"
+          contents_changed: 訂單內容已變更
+        page_view: 被訪問靜態頁面
         user:
-          signup: "使用者登記"
+          signup: 使用者登記
     exceptions:
-      count_on_hand_setter: "無法手動設置 count_on_hand, 將會在 recalculate_count_on_hand 中被自動設定. 請使用 `update_column(:count_on_hand, value)`"
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
-    expiration: "過期"
-    extension: "擴展"
-    failed_payment_attempts:
-    filename: "檔案名稱"
-    fill_in_customer_info: "請填寫消費者資訊"
-    filter_results: "過濾結果"
-    finalize: "完成"
-    finalized:
-    find_a_taxon:
-    first_item: "第一項商品價格"
-    first_name: "名"
-    first_name_begins_with: "名字開始"
-    flat_percent: "固定比例"
-    flat_rate_per_order: "固定金額(單一訂單)"
-    flexible_rate: "變動金額"
-    forgot_password: "忘記密碼"
-    free_shipping: "免運費"
-    free_shipping_amount:
-    front_end: "前端"
+      count_on_hand_setter: 無法手動設置 count_on_hand, 將會在 recalculate_count_on_hand 中被自動設定. 請使用 `update_column(:count_on_hand, value)`
+    exchange_for: 
+    excl: 
+    existing_shipments: 
+    expedited_exchanges_warning: 
+    expiration: 過期
+    extension: 擴展
+    failed_payment_attempts: 
+    filename: 檔案名稱
+    fill_in_customer_info: 請填寫消費者資訊
+    filter_results: 過濾結果
+    finalize: 完成
+    finalized: 
+    find_a_taxon: 
+    first_item: 第一項商品價格
+    first_name: 名
+    first_name_begins_with: 名字開始
+    flat_percent: 固定比例
+    flat_rate_per_order: 固定金額(單一訂單)
+    flexible_rate: 變動金額
+    forgot_password: 忘記密碼
+    free_shipping: 免運費
+    free_shipping_amount: 
+    front_end: 前端
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
     gateway_error: Gateway Error
-    general: "一般"
-    general_settings: "一般設定"
+    general: 一般
+    general_settings: 一般設定
     google_analytics: Google Analytics
     google_analytics_id: Analytics ID
-    guest_checkout: "訪客結帳"
-    guest_user_account: "訪客帳戶"
-    has_no_shipped_units: "不需出貨"
-    height: "高"
-    hide_cents: "隱藏小數點"
-    home: "首頁"
+    guest_checkout: 訪客結帳
+    guest_user_account: 訪客帳戶
+    has_no_shipped_units: 不需出貨
+    height: 高
+    hide_cents: 隱藏小數點
+    home: 首頁
     i18n:
-      available_locales: "可用語系"
-      language: "語言"
-      localization_settings: "在地化設定"
-      this_file_language: "中文 (繁體)"
-    icon: "圖示"
-    identifier:
-    image: "圖片"
-    images: "圖片"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price: "已包括於售價"
-    included_price_validation: "除非您設置了默認的繳稅區域，否則無法選擇"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password: "請填寫如下表格來重置你的密碼，重置後的密碼會通過電子郵件發送給您"
-    insufficient_stock: "庫存不足，當前還剩下 %{on_hand} 件庫存"
-    insufficient_stock_lines_present:
-    intercept_email_address: "攔截電郵地址"
-    intercept_email_instructions: "更改電子郵件回函收件位址為這個位址"
-    internal_name: "內部名稱"
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider: "不正確的付費供應商."
-    invalid_promotion_action: "不正確的宣傳操作."
-    invalid_promotion_rule: "不正確的宣傳規則."
-    inventory: "庫存"
-    inventory_adjustment: "庫存調整"
-    inventory_error_flash_for_insufficient_quantity: "您購物車內的商品已無法使用."
-    inventory_state:
-    is_not_available_to_shipment_address: "沒有可用的出貨地址"
+      available_locales: 可用語系
+      language: 語言
+      localization_settings: 在地化設定
+      this_file_language: 中文 (繁體)
+    icon: 圖示
+    identifier: 
+    image: 圖片
+    images: 圖片
+    implement_eligible_for_return: 
+    implement_requires_manual_intervention: 
+    inactive: 
+    incl: 
+    included_in_price: 已包括於售價
+    included_price_validation: 除非您設置了默認的繳稅區域，否則無法選擇
+    incomplete: 
+    info_number_of_skus_not_shown: 
+    info_product_has_multiple_skus: 
+    instructions_to_reset_password: 請填寫如下表格來重置你的密碼，重置後的密碼會通過電子郵件發送給您
+    insufficient_stock: 庫存不足，當前還剩下 %{on_hand} 件庫存
+    insufficient_stock_lines_present: 
+    intercept_email_address: 攔截電郵地址
+    intercept_email_instructions: 更改電子郵件回函收件位址為這個位址
+    internal_name: 內部名稱
+    invalid_credit_card: 
+    invalid_exchange_variant: 
+    invalid_payment_provider: 不正確的付費供應商.
+    invalid_promotion_action: 不正確的宣傳操作.
+    invalid_promotion_rule: 不正確的宣傳規則.
+    inventory: 庫存
+    inventory_adjustment: 庫存調整
+    inventory_error_flash_for_insufficient_quantity: 您購物車內的商品已無法使用.
+    inventory_state: 
+    is_not_available_to_shipment_address: 沒有可用的出貨地址
     iso_name: ISO 名稱
-    item: "商品"
-    item_description: "商品描述"
-    item_total: "商品總價"
+    item: 商品
+    item_description: 商品描述
+    item_total: 商品總價
     item_total_rule:
       operators:
-        gt: "大於"
-        gte: "大於等於"
-        lt:
-        lte:
-    items_cannot_be_shipped: "我們無法遞送物品至您的運送地址. 請選擇其他運送位置."
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        gt: 大於
+        gte: 大於等於
+        lt: 
+        lte: 
+    items_cannot_be_shipped: 我們無法遞送物品至您的運送地址. 請選擇其他運送位置.
+    items_in_rmas: 
+    items_reimbursed: 
+    items_to_be_reimbursed: 
     jirafe: Jirafe
     landing_page_rule:
       path: Path
-    last_name: "姓"
-    last_name_begins_with: "姓氏開頭"
+    last_name: 姓
+    last_name_begins_with: 姓氏開頭
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
-    list: "列表"
-    loading: "載入中"
-    locale_changed: "語系已變更"
-    location: "位置"
-    lock: "鎖定"
-    log_entries:
-    logged_in_as: "目前帳號"
-    logged_in_succesfully: "登入成功"
-    logged_out: "你已經完成登出"
-    login: "登入"
-    login_as_existing: "用戶登入"
-    login_failed: "登入認証失敗"
-    login_name: "使用者名稱"
-    logout: "登出"
-    logs:
-    look_for_similar_items: "瀏覽相似的商品"
-    make_refund: "退款"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
-    master_price: "主要定價"
+    lifetime_stats: 
+    line_item_adjustments: 
+    list: 列表
+    loading: 載入中
+    locale_changed: 語系已變更
+    location: 位置
+    lock: 鎖定
+    log_entries: 
+    logged_in_as: 目前帳號
+    logged_in_succesfully: 登入成功
+    logged_out: 你已經完成登出
+    login: 登入
+    login_as_existing: 用戶登入
+    login_failed: 登入認証失敗
+    login_name: 使用者名稱
+    logout: 登出
+    logs: 
+    look_for_similar_items: 瀏覽相似的商品
+    make_refund: 退款
+    make_sure_the_above_reimbursement_amount_is_correct: 
+    manage_promotion_categories: 
+    manage_variants: 
+    manual_intervention_required: 
+    master_price: 主要定價
     match_choices:
-      all: "全部"
-      none: "清空"
-    max_items:
-    member_since:
-    memo:
+      all: 全部
+      none: 清空
+    max_items: 
+    member_since: 
+    memo: 
     meta_description: Meta 描述
     meta_keywords: Meta 關鍵字
-    meta_title:
+    meta_title: 
     metadata: Metadata
-    minimal_amount: "最小個數"
-    month: "月"
+    minimal_amount: 最小個數
+    month: 月
     more: More
-    move_stock_between_locations: "移動庫存位置"
-    my_account: "我的帳戶"
-    my_orders: "我的訂單"
-    name: "名稱"
-    name_on_card:
-    name_or_sku: "商品名稱或編號"
-    new: "新增"
-    new_adjustment: "新增訂單項目"
-    new_country:
-    new_customer: "新增客戶"
-    new_customer_return:
-    new_image: "新增圖片"
-    new_option_type: "新增商品選項類型"
-    new_order: "新增訂單"
-    new_order_completed: "新增訂單完成"
-    new_payment: "新增付費紀錄"
-    new_payment_method: "新增付費方式"
-    new_product: "新增商品"
-    new_promotion: "新增優惠推廣"
-    new_promotion_category:
-    new_property: "新增商品屬性"
-    new_prototype: "新增商品原型"
-    new_refund:
-    new_refund_reason:
-    new_return_authorization: "新增退貨資料"
-    new_rma_reason:
-    new_shipment_at_location:
-    new_shipping_category: "新增出貨類型"
-    new_shipping_method: "新增出貨方式"
-    new_state: "新增省份"
-    new_stock_location: "新增庫存位置"
-    new_stock_movement: "新增庫存動向"
-    new_stock_transfer: "新增庫存轉移"
-    new_tax_category: "新增課稅分類"
-    new_tax_rate: "新增稅���"
-    new_taxon: "新增分類"
-    new_taxonomy: "新增分類"
-    new_tracker:
-    new_user: "新增使用者"
-    new_variant: "新增款式系列"
-    new_zone: "新增區域"
-    next: "下一頁"
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
-    no_products_found: "找不到商品"
-    no_resource_found:
-    no_results: "沒有結果"
-    no_returns_found:
+    move_stock_between_locations: 移動庫存位置
+    my_account: 我的帳戶
+    my_orders: 我的訂單
+    name: 名稱
+    name_on_card: 
+    name_or_sku: 商品名稱或編號
+    new: 新增
+    new_adjustment: 新增訂單項目
+    new_country: 
+    new_customer: 新增客戶
+    new_customer_return: 
+    new_image: 新增圖片
+    new_option_type: 新增商品選項類型
+    new_order: 新增訂單
+    new_order_completed: 新增訂單完成
+    new_payment: 新增付費紀錄
+    new_payment_method: 新增付費方式
+    new_product: 新增商品
+    new_promotion: 新增優惠推廣
+    new_promotion_category: 
+    new_property: 新增商品屬性
+    new_prototype: 新增商品原型
+    new_refund: 
+    new_refund_reason: 
+    new_return_authorization: 新增退貨資料
+    new_rma_reason: 
+    new_shipment_at_location: 
+    new_shipping_category: 新增出貨類型
+    new_shipping_method: 新增出貨方式
+    new_state: 新增省份
+    new_stock_location: 新增庫存位置
+    new_stock_movement: 新增庫存動向
+    new_stock_transfer: 新增庫存轉移
+    new_tax_category: 新增課稅分類
+    new_tax_rate: 新增稅���
+    new_taxon: 新增分類
+    new_taxonomy: 新增分類
+    new_tracker: 
+    new_user: 新增使用者
+    new_variant: 新增款式系列
+    new_zone: 新增區域
+    next: 下一頁
+    no_actions_added: 
+    no_payment_found: 
+    no_pending_payments: 
+    no_products_found: 找不到商品
+    no_resource_found: 
+    no_results: 沒有結果
+    no_returns_found: 
     no_rules_added: No rules added
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
-    none: "沒有"
-    none_selected:
-    normal_amount: "一般數量"
-    not: "不"
+    no_shipping_method_selected: 
+    no_state_changes: 
+    no_tracking_present: 
+    none: 沒有
+    none_selected: 
+    normal_amount: 一般數量
+    not: 不
     not_available: N/A
-    not_enough_stock: "來源地沒有足夠的庫存以完成遞送."
+    not_enough_stock: 來源地沒有足夠的庫存以完成遞送.
     not_found: "%{resource} is not found"
-    note:
+    note: 
     notice_messages:
-      product_cloned: "商品已經被覆制"
-      product_deleted: "商品已經被刪除"
-      product_not_cloned: "商品無法被複製"
-      product_not_deleted: "商品無法被刪除"
-      variant_deleted: "具體型號已經被刪除"
-      variant_not_deleted: "具體型號不能被刪除"
-    num_orders:
-    on_hand: "庫存"
-    open:
-    open_all_adjustments: "啟用所有價格調整"
-    option_type: "商品選項類型"
-    option_type_placeholder:
-    option_types: "商品選項類型"
-    option_value: "商品選項"
-    option_values: "商品選項"
-    optional:
-    options: "選項"
-    or: "或"
+      product_cloned: 商品已經被覆制
+      product_deleted: 商品已經被刪除
+      product_not_cloned: 商品無法被複製
+      product_not_deleted: 商品無法被刪除
+      variant_deleted: 具體型號已經被刪除
+      variant_not_deleted: 具體型號不能被刪除
+    num_orders: 
+    on_hand: 庫存
+    open: 
+    open_all_adjustments: 啟用所有價格調整
+    option_type: 商品選項類型
+    option_type_placeholder: 
+    option_types: 商品選項類型
+    option_value: 商品選項
+    option_values: 商品選項
+    optional: 
+    options: 選項
+    or: 或
     or_over_price: "%{price} 或以上"
-    order: "訂單"
-    order_adjustments: "訂單調整"
-    order_already_updated:
-    order_approved:
-    order_canceled:
-    order_details: "訂單資料"
-    order_email_resent: "重新發送了訂單郵件"
-    order_information: "訂單資訊"
+    order: 訂單
+    order_adjustments: 訂單調整
+    order_already_updated: 
+    order_approved: 
+    order_canceled: 
+    order_details: 訂單資料
+    order_email_resent: 重新發送了訂單郵件
+    order_information: 訂單資訊
     order_mailer:
       cancel_email:
-        dear_customer: "親愛的顧客，"
-        instructions: "您的訂單已被取消。請保留此取消信息記錄。"
-        order_summary_canceled: "訂單總覽 [已取消]"
-        subject: "註銷訂單"
-        subtotal:
-        total:
+        dear_customer: 親愛的顧客，
+        instructions: 您的訂單已被取消。請保留此取消信息記錄。
+        order_summary_canceled: 訂單總覽 [已取消]
+        subject: 註銷訂單
+        subtotal: 
+        total: 
       confirm_email:
-        dear_customer: "親愛的顧客，"
-        instructions: "請仔細閱讀並保留以下訂單信息記錄。"
-        order_summary: "訂單總覽"
-        subject: "訂單確認"
-        subtotal:
-        thanks: "謝謝你的購物和信賴。"
-        total:
-    order_not_found: "找不到您的訂單. 請再試一次."
-    order_number: "訂單編號 %{number}"
-    order_processed_successfully: "您的訂單已被接收"
-    order_resumed:
+        dear_customer: 親愛的顧客，
+        instructions: 請仔細閱讀並保留以下訂單信息記錄。
+        order_summary: 訂單總覽
+        subject: 訂單確認
+        subtotal: 
+        thanks: 謝謝你的購物和信賴。
+        total: 
+    order_not_found: 找不到您的訂單. 請再試一次.
+    order_number: 訂單編號 %{number}
+    order_processed_successfully: 您的訂單已被接收
+    order_resumed: 
     order_state:
-      address: "地址"
-      awaiting_return: "等待寄回"
-      canceled: "取消"
-      cart: "購物車"
-      complete: "完成"
-      confirm: "確認"
-      considered_risky:
-      delivery: "寄送方式"
-      payment: "付款"
-      resumed: "重新開始"
-      returned: "己寄回"
-    order_summary: "訂單總計"
-    order_sure_want_to: "您確定您想要%{event}這個訂單嗎？"
-    order_total: "總金額"
-    order_updated: "訂單已更新"
-    orders: "訂單"
-    other_items_in_other:
-    out_of_stock: "缺貨中"
-    overview: "總覽"
-    package_from: "包裝自"
+      address: 地址
+      awaiting_return: 等待寄回
+      canceled: 取消
+      cart: 購物車
+      complete: 完成
+      confirm: 確認
+      considered_risky: 
+      delivery: 寄送方式
+      payment: 付款
+      resumed: 重新開始
+      returned: 己寄回
+    order_summary: 訂單總計
+    order_sure_want_to: 您確定您想要%{event}這個訂單嗎？
+    order_total: 總金額
+    order_updated: 訂單已更新
+    orders: 訂單
+    other_items_in_other: 
+    out_of_stock: 缺貨中
+    overview: 總覽
+    package_from: 包裝自
     pagination:
-      next_page: "下一頁 »"
+      next_page: 下一頁 »
       previous_page: "« 上一頁"
       truncate: "…"
-    password: "密碼"
-    paste: "貼上"
-    path: "路徑"
-    pay: "付款"
-    payment: "付款"
-    payment_could_not_be_created:
-    payment_identifier:
-    payment_information: "付費資訊"
-    payment_method: "付費方式"
-    payment_method_not_supported:
-    payment_methods: "付費方式"
-    payment_processing_failed:
-    payment_processor_choose_banner_text: "如果您需要關於支付處理的幫助，請訪問"
-    payment_processor_choose_link: "我們的支付頁面"
-    payment_state: "付費狀態"
+    password: 密碼
+    paste: 貼上
+    path: 路徑
+    pay: 付款
+    payment: 付款
+    payment_could_not_be_created: 
+    payment_identifier: 
+    payment_information: 付費資訊
+    payment_method: 付費方式
+    payment_method_not_supported: 
+    payment_methods: 付費方式
+    payment_processing_failed: 
+    payment_processor_choose_banner_text: 如果您需要關於支付處理的幫助，請訪問
+    payment_processor_choose_link: 我們的支付頁面
+    payment_state: 付費狀態
     payment_states:
-      balance_due: "未入帳"
-      checkout: "付款"
-      completed: "已完成"
-      credit_owed:
-      failed: "失敗"
-      paid: "已付費"
-      pending: "擱置"
-      processing: "處理中"
-      void: "無效"
-    payment_updated: "付費資料已更新"
-    payments: "付費資料"
-    pending:
-    percent: "百分比"
-    percent_per_item: "單件百分比"
-    permalink: "永久連結"
-    phone: "電話"
-    place_order: "落單"
-    please_define_payment_methods: "請先設定支付方式。"
-    populate_get_error: "發生錯誤，請再添加項目。"
-    powered_by: "技術支持"
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
-    presentation: "描述"
-    previous: "上一個"
-    previous_state_missing:
-    price: "價格"
-    price_range: "價格範圍"
-    price_sack: "袋價格"
-    process: "處理"
-    product: "產品"
-    product_details: "商品資料"
-    product_has_no_description: "該產品沒有描述"
-    product_not_available_in_this_currency: "本產品無法使用您選擇的幣別付費."
-    product_properties: "商品屬性"
+      balance_due: 未入帳
+      checkout: 付款
+      completed: 已完成
+      credit_owed: 
+      failed: 失敗
+      paid: 已付費
+      pending: 擱置
+      processing: 處理中
+      void: 無效
+    payment_updated: 付費資料已更新
+    payments: 付費資料
+    pending: 
+    percent: 百分比
+    percent_per_item: 單件百分比
+    permalink: 永久連結
+    phone: 電話
+    place_order: 落單
+    please_define_payment_methods: 請先設定支付方式。
+    populate_get_error: 發生錯誤，請再添加項目。
+    powered_by: 技術支持
+    pre_tax_amount: 
+    pre_tax_refund_amount: 
+    pre_tax_total: 
+    preferred_reimbursement_type: 
+    presentation: 描述
+    previous: 上一個
+    previous_state_missing: 
+    price: 價格
+    price_range: 價格範圍
+    price_sack: 袋價格
+    process: 處理
+    product: 產品
+    product_details: 商品資料
+    product_has_no_description: 該產品沒有描述
+    product_not_available_in_this_currency: 本產品無法使用您選擇的幣別付費.
+    product_properties: 商品屬性
     product_rule:
-      choose_products: "選擇產品"
-      label:
-      match_all: "全部"
-      match_any: "最新一個"
-      match_none:
+      choose_products: 選擇產品
+      label: 
+      match_all: 全部
+      match_any: 最新一個
+      match_none: 
       product_source:
-        group: "從產品分組"
-        manual: "手動選擇"
-    products: "商品"
-    promotion: "優惠推廣"
-    promotion_action: "優惠方式"
+        group: 從產品分組
+        manual: 手動選擇
+    products: 商品
+    promotion: 優惠推廣
+    promotion_action: 優惠方式
     promotion_action_types:
       create_adjustment:
-        description: "為訂單添加促銷用的價格調整"
-        name: "添加訂單的價格調整"
+        description: 為訂單添加促銷用的價格調整
+        name: 添加訂單的價格調整
       create_item_adjustments:
-        description: "為訂單上的單項產品添加一筆促銷用的價格調整"
-        name: "添加單項的價格調整"
+        description: 為訂單上的單項產品添加一筆促銷用的價格調整
+        name: 添加單項的價格調整
       create_line_items:
-        description: "添加特定商品到訂單中"
-        name: "添加訂單商品"
+        description: 添加特定商品到訂單中
+        name: 添加訂單商品
       free_shipping:
-        description: "整張訂單免費發貨"
-        name: "免運費"
-    promotion_actions: "優惠方式"
+        description: 整張訂單免費發貨
+        name: 免運費
+    promotion_actions: 優惠方式
     promotion_form:
       match_policies:
-        all: "符合所有條件"
-        any: "符合任一條件"
-    promotion_rule: "促銷規則"
+        all: 符合所有條件
+        any: 符合任一條件
+    promotion_rule: 促銷規則
     promotion_rule_types:
       first_order:
-        description: "使用者的第 1 筆訂單"
-        name: "第 1 筆訂單"
+        description: 使用者的第 1 筆訂單
+        name: 第 1 筆訂單
       item_total:
-        description: "商品總價符合條件"
-        name: "商品總價"
+        description: 商品總價符合條件
+        name: 商品總價
       landing_page:
-        description: "客戶必須訪問了指定的頁面"
-        name: "登陸頁面"
+        description: 客戶必須訪問了指定的頁面
+        name: 登陸頁面
       one_use_per_user:
-        description: "每人只可使用一次"
-        name: "每人一次"
+        description: 每人只可使用一次
+        name: 每人一次
       option_value:
-        description:
-        name:
+        description: 
+        name: 
       product:
-        description: "訂單中包含特定商品"
-        name: "商品"
+        description: 訂單中包含特定商品
+        name: 商品
       taxon:
-        description: "訂單中包括指定分類產品"
-        name: "分類"
+        description: 訂單中包括指定分類產品
+        name: 分類
       user:
-        description: "符合特定使用者"
-        name: "使用者"
+        description: 符合特定使用者
+        name: 使用者
       user_logged_in:
-        description: "網站已註冊的使用者"
-        name: "已註冊使用者登入"
-    promotion_uses: "促銷使用頻率"
-    promotionable:
-    promotions: "優惠推廣"
-    propagate_all_variants:
-    properties: "屬性"
-    property: "屬性"
-    prototype: "原型"
-    prototypes: "原型"
-    provider: "供應商"
-    provider_settings_warning: "如果您正在修改提供者類型，您需要在編輯提供者設置之前先保存。"
-    qty: "數量"
-    quantity: "數量"
-    quantity_returned: "退貨數量"
-    quantity_shipped: "出貨數量"
-    quick_search:
-    rate: "費率"
-    reason: "理由"
-    receive: "收到"
-    receive_stock: "接收存貨"
-    received: "已收到"
-    reception_status:
-    reference: "參考"
-    refund: "退款"
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
-    register: "註冊新用戶"
-    registration: "註冊"
-    reimburse:
-    reimbursed:
-    reimbursement:
+        description: 網站已註冊的使用者
+        name: 已註冊使用者登入
+    promotion_uses: 促銷使用頻率
+    promotionable: 
+    promotions: 優惠推廣
+    propagate_all_variants: 
+    properties: 屬性
+    property: 屬性
+    prototype: 原型
+    prototypes: 原型
+    provider: 供應商
+    provider_settings_warning: 如果您正在修改提供者類型，您需要在編輯提供者設置之前先保存。
+    qty: 數量
+    quantity: 數量
+    quantity_returned: 退貨數量
+    quantity_shipped: 出貨數量
+    quick_search: 
+    rate: 費率
+    reason: 理由
+    receive: 收到
+    receive_stock: 接收存貨
+    received: 已收到
+    reception_status: 
+    reference: 參考
+    refund: 退款
+    refund_amount_must_be_greater_than_zero: 
+    refund_reasons: 
+    refunded_amount: 
+    refunds: 
+    register: 註冊新用戶
+    registration: 註冊
+    reimburse: 
+    reimbursed: 
+    reimbursement: 
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
-    remember_me: "記住我"
-    remove: "移除"
+        days_to_send: 
+        dear_customer: 
+        exchange_summary: 
+        for: 
+        instructions: 
+        refund_summary: 
+        subject: 
+        total_refunded: 
+    reimbursement_perform_failed: 
+    reimbursement_status: 
+    reimbursement_type: 
+    reimbursement_type_override: 
+    reimbursement_types: 
+    reimbursements: 
+    reject: 
+    rejected: 
+    remember_me: 記住我
+    remove: 移除
     rename: Rename
-    report:
-    reports: "報告"
-    resend: "重寄"
-    reset_password: "重設密碼"
-    response_code: "回應代碼"
-    resume: "恢復"
-    resumed: "已恢復"
-    return: "退回"
-    return_authorization: "退貨資料"
-    return_authorization_reasons:
-    return_authorization_updated: "退貨資料已更新"
-    return_authorizations: "退貨資料"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity: "退貨數量"
-    returned: "已退回"
-    returns:
+    report: 
+    reports: 報告
+    resend: 重寄
+    reset_password: 重設密碼
+    response_code: 回應代碼
+    resume: 恢復
+    resumed: 已恢復
+    return: 退回
+    return_authorization: 退貨資料
+    return_authorization_reasons: 
+    return_authorization_updated: 退貨資料已更新
+    return_authorizations: 退貨資料
+    return_item_inventory_unit_ineligible: 
+    return_item_inventory_unit_reimbursed: 
+    return_item_rma_ineligible: 
+    return_item_time_period_ineligible: 
+    return_items: 
+    return_items_cannot_be_associated_with_multiple_orders: 
+    return_number: 
+    return_quantity: 退貨數量
+    returned: 已退回
+    returns: 
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: 
+    risk_analysis: 
+    risky: 
     rma_credit: RMA 額度
     rma_number: RMA 數字
     rma_value: RMA 值
-    roles: "角色"
-    rules: "規則"
-    safe:
-    sales_total:
-    sales_total_description:
-    sales_totals:
-    save_and_continue: "儲存後繼續"
-    save_my_address:
-    say_no: "不"
-    say_yes: "是的"
-    scope: "範圍"
-    search: "搜尋"
+    roles: 角色
+    rules: 規則
+    safe: 
+    sales_total: 
+    sales_total_description: 
+    sales_totals: 
+    save_and_continue: 儲存後繼續
+    save_my_address: 
+    say_no: 不
+    say_yes: 是的
+    scope: 範圍
+    search: 搜尋
     search_results: "%{keywords} 搜尋結果"
-    searching: "搜尋中"
-    secure_connection_type: "安全連線類型"
-    security_settings: "安全設定"
-    select: "選擇"
-    select_a_return_authorization_reason:
-    select_a_stock_location:
-    select_from_prototype: "從商品原型選擇"
-    select_stock: "選擇庫存"
-    send_copy_of_all_mails_to: "將所有郵件的副本發送至"
-    send_mails_as: "發送郵件作為"
-    server: "伺服器"
-    server_error: "伺服器回傳了錯誤訊息"
-    settings: "設定"
-    ship: "出貨"
-    ship_address: "出貨地址"
-    ship_total:
-    shipment: "出貨資料"
-    shipment_adjustments:
-    shipment_details:
+    searching: 搜尋中
+    secure_connection_type: 安全連線類型
+    security_settings: 安全設定
+    select: 選擇
+    select_a_return_authorization_reason: 
+    select_a_stock_location: 
+    select_from_prototype: 從商品原型選擇
+    select_stock: 選擇庫存
+    send_copy_of_all_mails_to: 將所有郵件的副本發送至
+    send_mails_as: 發送郵件作為
+    server: 伺服器
+    server_error: 伺服器回傳了錯誤訊息
+    settings: 設定
+    ship: 出貨
+    ship_address: 出貨地址
+    ship_total: 
+    shipment: 出貨資料
+    shipment_adjustments: 
+    shipment_details: 
     shipment_mailer:
       shipped_email:
-        dear_customer: "親愛的顧客，"
-        instructions: "您的訂單已發貨"
-        shipment_summary: "發貨概覽"
-        subject: "出貨通知"
-        thanks: "謝謝你的購物和信賴。"
-        track_information: "貨運單號： %{tracking}"
-        track_link: "追蹤連結: %{url}"
-    shipment_state: "出貨狀態"
+        dear_customer: 親愛的顧客，
+        instructions: 您的訂單已發貨
+        shipment_summary: 發貨概覽
+        subject: 出貨通知
+        thanks: 謝謝你的購物和信賴。
+        track_information: 貨運單號： %{tracking}
+        track_link: '追蹤連結: %{url}'
+    shipment_state: 出貨狀態
     shipment_states:
-      backorder: "預購"
-      canceled:
-      partial: "部份出貨"
-      pending: "擱置"
-      ready: "準備出貨"
-      shipped: "已出貨"
-    shipment_transfer_error:
-    shipment_transfer_success:
-    shipments: "出貨資料"
-    shipped: "已寄出"
-    shipping: "運費"
-    shipping_address: "出貨地址"
-    shipping_categories: "出貨分類"
-    shipping_category: "出貨分類"
-    shipping_flat_rate_per_item: "以單項計固定費率"
-    shipping_flat_rate_per_order: "固定費率"
-    shipping_flexible_rate: "以每項計彈性價格"
-    shipping_instructions: "配送嚮導"
-    shipping_method: "出貨方式"
-    shipping_methods: "出貨方式"
-    shipping_price_sack:
-    shipping_total:
-    shop_by_taxonomy: "依照%{taxonomy}排序"
-    shopping_cart: "購物車"
-    show: "顯示"
-    show_active: "顯示使用中的資料"
-    show_deleted: "顯示被刪除的資料"
-    show_only_complete_orders: "顯示已完成的訂單"
-    show_only_considered_risky:
-    show_rate_in_label:
-    sku: "商品編號"
-    skus:
-    slug:
-    source: "來源"
-    special_instructions: "特殊說明"
-    split: "分拆"
-    spree_gateway_error_flash_for_checkout: "你的付費資訊有問題. 請檢查後再試一次."
+      backorder: 預購
+      canceled: 
+      partial: 部份出貨
+      pending: 擱置
+      ready: 準備出貨
+      shipped: 已出貨
+    shipment_transfer_error: 
+    shipment_transfer_success: 
+    shipments: 出貨資料
+    shipped: 已寄出
+    shipping: 運費
+    shipping_address: 出貨地址
+    shipping_categories: 出貨分類
+    shipping_category: 出貨分類
+    shipping_flat_rate_per_item: 以單項計固定費率
+    shipping_flat_rate_per_order: 固定費率
+    shipping_flexible_rate: 以每項計彈性價格
+    shipping_instructions: 配送嚮導
+    shipping_method: 出貨方式
+    shipping_methods: 出貨方式
+    shipping_price_sack: 
+    shipping_total: 
+    shop_by_taxonomy: 依照%{taxonomy}排序
+    shopping_cart: 購物車
+    show: 顯示
+    show_active: 顯示使用中的資料
+    show_deleted: 顯示被刪除的資料
+    show_only_complete_orders: 顯示已完成的訂單
+    show_only_considered_risky: 
+    show_rate_in_label: 
+    sku: 商品編號
+    skus: 
+    slug: 
+    source: 來源
+    special_instructions: 特殊說明
+    split: 分拆
+    spree_gateway_error_flash_for_checkout: 你的付費資訊有問題. 請檢查後再試一次.
     ssl:
-      change_protocol:
-    start: "開始"
-    state: "省份"
-    state_based: "依據省份"
+      change_protocol: 
+    start: 開始
+    state: 省份
+    state_based: 依據省份
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states: "省份"
-    states_required: "需要州別"
-    status: "狀態"
-    stock:
-    stock_location: "庫存區域"
-    stock_location_info: "庫存區域資訊"
-    stock_locations: "庫存區域"
-    stock_locations_need_a_default_country:
-    stock_management: "庫存管理"
-    stock_management_requires_a_stock_location: "請先新增庫存區域，才可使用庫存管理"
-    stock_movements: "庫存動向"
+      accepted: 
+      address: 
+      authorized: 
+      awaiting: 
+      awaiting_return: 
+      backordered: 
+      canceled: 
+      cart: 
+      checkout: 
+      closed: 
+      complete: 
+      completed: 
+      confirm: 
+      delivery: 
+      errored: 
+      failed: 
+      given_to_customer: 
+      invalid: 
+      manual_intervention_required: 
+      on_hand: 
+      open: 
+      order: 
+      payment: 
+      pending: 
+      processing: 
+      ready: 
+      reimbursed: 
+      resumed: 
+      returned: 
+      shipped: 
+      void: 
+    states: 省份
+    states_required: 需要州別
+    status: 狀態
+    stock: 
+    stock_location: 庫存區域
+    stock_location_info: 庫存區域資訊
+    stock_locations: 庫存區域
+    stock_locations_need_a_default_country: 
+    stock_management: 庫存管理
+    stock_management_requires_a_stock_location: 請先新增庫存區域，才可使用庫存管理
+    stock_movements: 庫存動向
     stock_movements_for_stock_location: "%{stock_location_name} 的庫存動向"
-    stock_successfully_transferred: "庫存已成功在兩區域轉移"
-    stock_transfer: "庫存轉移"
-    stock_transfers: "庫存轉移"
-    stop: "停止"
-    store: "商店"
-    street_address: "地址"
-    street_address_2: "地址(繼續)"
-    subtotal: "小計"
-    subtract: "減去"
-    success:
-    successfully_created: "建立%{resource}成功！"
-    successfully_refunded:
-    successfully_removed: "刪除%{resource}成功！"
-    successfully_signed_up_for_analytics:
-    successfully_updated: "更新%{resource}成功！"
-    summary:
-    tax: "稅"
-    tax_categories: "課稅類別"
-    tax_category: "課稅類別"
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
-    tax_rates: "稅率"
-    taxon: "分類"
-    taxon_edit: "編輯分類"
-    taxon_placeholder:
+    stock_successfully_transferred: 庫存已成功在兩區域轉移
+    stock_transfer: 庫存轉移
+    stock_transfers: 庫存轉移
+    stop: 停止
+    store: 商店
+    street_address: 地址
+    street_address_2: 地址(繼續)
+    subtotal: 小計
+    subtract: 減去
+    success: 
+    successfully_created: 建立%{resource}成功！
+    successfully_refunded: 
+    successfully_removed: 刪除%{resource}成功！
+    successfully_signed_up_for_analytics: 
+    successfully_updated: 更新%{resource}成功！
+    summary: 
+    tax: 稅
+    tax_categories: 課稅類別
+    tax_category: 課稅類別
+    tax_code: 
+    tax_included: 
+    tax_rate_amount_explanation: 
+    tax_rates: 稅率
+    taxon: 分類
+    taxon_edit: 編輯分類
+    taxon_placeholder: 
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
-    taxonomies: "分類"
+      choose_taxons: 
+      label: 
+      match_all: 
+      match_any: 
+    taxonomies: 分類
     taxonomy: Taxonomy
-    taxonomy_edit: "編輯分類"
-    taxonomy_tree_error: "請求的變更沒有被接受，樹會恢復到之前的狀態，請重新嘗試。"
+    taxonomy_edit: 編輯分類
+    taxonomy_tree_error: 請求的變更沒有被接受，樹會恢復到之前的狀態，請重新嘗試。
     taxonomy_tree_instruction: "* 右鍵單擊一個樹的子結點以訪問添加、刪除或排序字節點的菜單。"
-    taxons: "分類"
-    test: "測試"
+    taxons: 分類
+    test: 測試
     test_mailer:
       test_email:
         greeting: Congratulations!
         message: If you have received this email, then your email settings are correct.
         subject: Testmail
-    test_mode: "測試模式"
-    thank_you_for_your_order:
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields:
-    this_order_has_already_received_a_refund:
-    thumbnail: "縮圖"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time: "時間"
-    to_add_variants_you_must_first_define:
-    total: "總金額"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
-    tracking: "物流追蹤碼"
-    tracking_number: "追蹤號碼"
-    tracking_url: "追蹤網址"
-    tracking_url_placeholder: "例如: http://quickship.com/package?num=:tracking"
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
-    tree: "樹"
-    type: "類型"
-    type_to_search: "輸入搜尋關鍵字"
-    unable_to_connect_to_gateway: "無法連上 gateway"
-    unable_to_create_reimbursements:
+    test_mode: 測試模式
+    thank_you_for_your_order: 
+    there_are_no_items_for_this_order: 
+    there_were_problems_with_the_following_fields: 
+    this_order_has_already_received_a_refund: 
+    thumbnail: 縮圖
+    tiered_flat_rate: 
+    tiered_percent: 
+    tiers: 
+    time: 時間
+    to_add_variants_you_must_first_define: 
+    total: 總金額
+    total_per_item: 
+    total_pre_tax_refund: 
+    total_price: 
+    total_sales: 
+    track_inventory: 
+    tracking: 物流追蹤碼
+    tracking_number: 追蹤號碼
+    tracking_url: 追蹤網址
+    tracking_url_placeholder: '例如: http://quickship.com/package?num=:tracking'
+    transaction_id: 
+    transfer_from_location: 
+    transfer_stock: 
+    transfer_to_location: 
+    tree: 樹
+    type: 類型
+    type_to_search: 輸入搜尋關鍵字
+    unable_to_connect_to_gateway: 無法連上 gateway
+    unable_to_create_reimbursements: 
     under_price: Under %{price}
-    unlock: "解鎖"
-    unrecognized_card_type: "無法辨識的信用卡類別"
-    unshippable_items:
-    update: "更新"
-    updating: "更新中"
-    usage_limit: "使用次數限制"
-    use_app_default:
-    use_billing_address: "使用帳單地址"
-    use_new_cc: "使用新卡"
+    unlock: 解鎖
+    unrecognized_card_type: 無法辨識的信用卡類別
+    unshippable_items: 
+    update: 更新
+    updating: 更新中
+    usage_limit: 使用次數限制
+    use_app_default: 
+    use_billing_address: 使用帳單地址
+    use_new_cc: 使用新卡
     use_s3: Use Amazon S3 For Images
-    user: "使用者"
+    user: 使用者
     user_rule:
-      choose_users: "選擇使用者"
-    users: "使用者"
+      choose_users: 選擇使用者
+    users: 使用者
     validation:
-      cannot_be_less_than_shipped_units: "不能少於已配送的單位數。"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock: "超出可用的庫存。請確認訂單項的有效的數量。"
-      is_too_large: "數量太多了，現有庫存無法滿足您需要的數量！"
-      must_be_int: "必須是整數"
-      must_be_non_negative: "必須為非負數"
-      unpaid_amount_not_zero:
-    value: "值"
-    variant: "具體型號"
-    variant_placeholder: "選擇具体型号"
-    variants: "款式系列"
-    version: "版本"
-    void: "無效"
-    weight: "重"
-    what_is_a_cvv: "什麼是 (CVV) 信用卡代碼?"
-    what_is_this: "這是什麼？"
-    width: "寬"
-    year: "年"
-    you_have_no_orders_yet: "您還沒有任何訂單"
-    your_cart_is_empty: "購物車是空的"
-    your_order_is_empty_add_product: "你的訂單是空的, 請搜尋並加入產品"
-    zip: "郵遞區號"
-    zipcode: "區域代碼"
-    zone: "區域"
-    zones: "區域"
+      cannot_be_less_than_shipped_units: 不能少於已配送的單位數。
+      cannot_destroy_line_item_as_inventory_units_have_shipped: 
+      exceeds_available_stock: 超出可用的庫存。請確認訂單項的有效的數量。
+      is_too_large: 數量太多了，現有庫存無法滿足您需要的數量！
+      must_be_int: 必須是整數
+      must_be_non_negative: 必須為非負數
+      unpaid_amount_not_zero: 
+    value: 值
+    variant: 具體型號
+    variant_placeholder: 選擇具体型号
+    variants: 款式系列
+    version: 版本
+    void: 無效
+    weight: 重
+    what_is_a_cvv: 什麼是 (CVV) 信用卡代碼?
+    what_is_this: 這是什麼？
+    width: 寬
+    year: 年
+    you_have_no_orders_yet: 您還沒有任何訂單
+    your_cart_is_empty: 購物車是空的
+    your_order_is_empty_add_product: 你的訂單是空的, 請搜尋並加入產品
+    zip: 郵遞區號
+    zipcode: 區域代碼
+    zone: 區域
+    zones: 區域

--- a/solidus_i18n.gemspec
+++ b/solidus_i18n.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'solidus_core', ['>= 1.1', '< 3']
 
+  spec.add_development_dependency 'i18n-tasks', '~> 0.9.29'
   spec.add_development_dependency 'pry-rails', '~> 0.3.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'rubocop', '~> 0.67.2'


### PR DESCRIPTION
Hi everyone,
follow up from https://github.com/solidusio/solidus_i18n/pull/146.
I'd like to check for the translation files to be normalized using the `i18n-tasks check-normalized` task.
I added it to the Travis configuration and I simply ran `i18n-tasks normalize` on all translation files.
No manual work has been made in this PR, all changes to the files have been done by the normalize task. I add this information to simplify the code review because the changes are many.
One note: the `normalize` task adds an empty space on keys without a value ([see here](https://github.com/solidusio/solidus_i18n/compare/master...normalize_translations#diff-c457e175aa3dd4d9749b57f51813f4d3R16)). 
I am asking myself why do we have keys without value? is there a reasoning behind that or can we simply remove them? In case we want to keep them we would have to live with the empty space.
This check seems the most interesting at the moment because this gem is not covered (of course) by a lot of tests. Some improvements on this side will come in a separate PR.