### PR TITLE
Remove Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,3 @@ before_install:
   - gem install bundler
 rvm:
   - 2.5
-env:
-  matrix:
-    - SOLIDUS_BRANCH=v2.4 DB=postgres
-    - SOLIDUS_BRANCH=v2.5 DB=postgres
-    - SOLIDUS_BRANCH=v2.6 DB=postgres
-    - SOLIDUS_BRANCH=v2.7 DB=postgres
-    - SOLIDUS_BRANCH=v2.8 DB=postgres
-    - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.4 DB=mysql
-    - SOLIDUS_BRANCH=v2.5 DB=mysql
-    - SOLIDUS_BRANCH=v2.6 DB=mysql
-    - SOLIDUS_BRANCH=v2.7 DB=mysql
-    - SOLIDUS_BRANCH=v2.8 DB=mysql
-    - SOLIDUS_BRANCH=master DB=mysql


### PR DESCRIPTION
Why do we use a matrix? The tests that we run are two and check things on the yml files that are not dependent on the solidus version. Can we simply remove it and speed up the CI or am I missing something?