### PR TITLE
Remove empty country names from es-MX.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ gem 'solidus_globalize', github: 'solidusio-contrib/solidus_globalize', branch: 
 
 ## Localizing country names
 
-Feel free to define `spree.country_names` in your own locale files if you need custom localization of country names. The value expected is a hash. For example, to have countries in Spanish do:
+You can translate country names by defining `spree.country_names` in your own locale files. For example, to have countries in Spanish do:
 
 ```yml
 es:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ You can translate country names by defining `spree.country_names` in your own lo
 es:
   spree:
     country_names:
-      # ISO: Country name
       US: Estados Unidos de América
       UK: Reino Unido
       CA: Canadá

--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ Please update your `Gemfile` if you still need the model translations.
 gem 'solidus_globalize', github: 'solidusio-contrib/solidus_globalize', branch: 'master'
 ```
 
+## Localizing country names
+
+Feel free to define `spree.country_names` in your own locale files if you need custom localization of country names. The value expected is a hash. For example, to have countries in Spanish do:
+
+```yml
+es:
+  spree:
+    country_names:
+      # ISO: Country name
+      US: Estados Unidos de América
+      UK: Reino Unido
+      CA: Canadá
+      # ...
+```
+
+Some supported languages already define localized country names. Take a look at this repo's `.yml` files for your locale to confirm if we already provide translations.
+
 Contributing
 ------------
 

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -471,11 +471,6 @@ es-MX:
     country: País
     country_based: País base
     country_name: Nombre
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Cupón
     coupon_code: Código de cupón
     coupon_code_already_applied: El código del cupón ya ha sido aplicado en esta orden


### PR DESCRIPTION
There's no need for empty country names in this locale file. Removing.

Also, these lines cause `country.name` to be `nil` when calling `Spree::BaseHelper#available_countries` if the app's locale is `es-MX`.