### PR TITLE
make gem work with solidus_support >0.5

### DIFF
--- a/solidus_i18n.gemspec
+++ b/solidus_i18n.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_runtime_dependency 'solidus_core', ['>= 1.1', '< 3']
-  s.add_runtime_dependency 'solidus_support', '~> 0.4.0'
+  s.add_runtime_dependency 'solidus_support', '~> 0.4'
 
   s.add_development_dependency 'solidus_dev_support'
 end


### PR DESCRIPTION
This extension does no longer work together with newer versions of other gems like solidus_print_invoice or solidus_static_content, which rely on solidus_support (~> 0.5)

```
Bundler could not find compatible versions for gem "solidus_support":
  In Gemfile:
    solidus_i18n was resolved to 2.0.0, which depends on
      solidus_support (~> 0.4.0)

    solidus_print_invoice was resolved to 1.0.2, which depends on
      solidus_support (~> 0.5)

```