### PR TITLE
add missing german translations necessary for backend

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -558,6 +558,7 @@ de:
     add_action_of_type: Aktion hinzufügen
     add_country: Land hinzufügen
     add_coupon_code: Gutscheincode hinzufügen
+    add_line_item: Bestellposten hinzufügen
     add_new_header: Header hinzufügen
     add_new_style: Stil hinzufügen
     add_one: Hinzufügen
@@ -708,6 +709,7 @@ de:
         taxonomies: Klassifikationen
         taxons: Klassifikation
         users: Benutzer
+        RMA: RMA
       taxons:
         display_order: Darstellungsreihenfolge
       user:
@@ -1191,6 +1193,7 @@ de:
     meta_title: Meta-Titel
     metadata: Metadaten
     minimal_amount: Mindestanzahl
+    minimize_menu: Menü minimieren
     modify_stock_count: Modifizieren (+/-)
     missing_return_authorization: Fehlende Rückerstattungserlaubnis %{item_name}.
     month: Monat
@@ -1204,6 +1207,7 @@ de:
     name_or_sku: Name oder Artikelnummer
     new: Neu
     new_adjustment: Neue Anpassung
+    new_adjustment_reason: Neuer Anpassungsgrund
     new_country: Neues Land
     new_customer: Neuer Kunde
     new_customer_return: Neue Kundenrücksendung
@@ -1588,6 +1592,7 @@ de:
     shipment: Sendung
     shipment_adjustments: Sendung anpassen
     shipment_details: "%{shipping_method}"
+    shipment_number: Sendungsnummer
     shipment_mailer:
       shipped_email:
         dear_customer: Sehr geehrte Kundin, geehrter Kunde,
@@ -1830,3 +1835,7 @@ de:
     zipcode: Postleitzahl
     zone: Gebiet
     zones: Gebiete
+  time:
+    formats:
+      solidus:
+        long: "%d.%m.%Y %H:%M"


### PR DESCRIPTION
Contains necessary translations when using the backend in german. Otherwise the following errors occur on a fresh install:

```
app/views/spree/admin/orders/index.html.erb:153
translation missing: de.date.formats.default
```

```
app/views/spree/admin/shared/_js_locale_data.html.erb:9
undefined method `reject' for "translation missing: de.date.month_names":String
```

```
backend/vendor/assets/javascripts/solidus_admin/flatpickr/flatpickr.js:2167
TypeError: weekdays.join is not a function
(needs de.date.abbr_day_names)
```

```
/app/views/spree/admin/shared/_order_summary.html.erb:52
translation missing: de.time.formats.solidus.long
```