### PR TITLE
Allow Solidus 3

### DIFF
--- a/solidus_i18n.gemspec
+++ b/solidus_i18n.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
     s.metadata["source_code_uri"] = s.homepage if s.homepage
   end
 
-  s.add_runtime_dependency 'solidus_core', ['>= 1.1', '< 3']
+  s.add_runtime_dependency 'solidus_core', ['>= 1.1', '< 4']
   s.add_runtime_dependency 'solidus_support', '~> 0.4'
 
   s.add_development_dependency 'solidus_dev_support'


### PR DESCRIPTION
I expect this to fail since solidus_dev_support depends on this gem and this gem depends on the failing solidus_dev_support.