### PR TITLE
Add missing FR `spree.admin_login` translation

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -941,6 +941,7 @@ fr:
           pricing: Prix
           pricing_hint: Ces valeurs sont remplies grâce à la page produit et peuvent être modifiées ci-dessous
     administration: Administration
+    admin_login: Connexion administrateur
     advertise: Publiciser
     agree_to_privacy_policy: Accepter l'Engagement de Confidentialité
     agree_to_terms_of_service: Accepter les termes du contrat.


### PR DESCRIPTION
`spree.admin_login` is only provided in four languages. I was a bit confused when the string started displaying in Spanish.

I'm happy to add other languages to this PR if that'd be preferred. But I don't speak any other languages.