### PR TITLE
Add missing punctuation for `are_you_sure` strings

### DIFF
--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -383,7 +383,7 @@ en-GB:
     approve:
     approved_at:
     approver:
-    are_you_sure: Are you sure
+    are_you_sure: Are you sure?
     are_you_sure_delete: Are you sure you want to delete this record?
     associated_adjustment_closed: The associated adjustment is closed, and will not be recalculated. Do you want to open it?
     at_symbol: '@'

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -381,7 +381,7 @@ en-IN:
     approve:
     approved_at:
     approver:
-    are_you_sure: Are you sure
+    are_you_sure: Are you sure?
     are_you_sure_delete: Are you sure you want to delete this record?
     associated_adjustment_closed: The associated adjustment is closed, and will not be recalculated. Do you want to open it?
     at_symbol: '@'

--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -381,7 +381,7 @@ en-NZ:
     approve:
     approved_at:
     approver:
-    are_you_sure: Are you sure
+    are_you_sure: Are you sure?
     are_you_sure_delete: Are you sure you want to delete this record?
     associated_adjustment_closed:
     at_symbol: '@'


### PR DESCRIPTION
The `are_you_sure` alert confirmation message should end in a question mark in all English locales. If you look at other alert confirmation strings, you can see that they already end in question marks.