### PR TITLE
Remove empty country_names translations

### DIFF
--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -460,11 +460,6 @@ bg:
     country: "Страна"
     country_based:
     country_name: "Име"
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: "Ваучер"
     coupon_code: "Код на ваучер"
     coupon_code_already_applied: "Този код вече е използван за тази доставка."

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -466,11 +466,6 @@ ca:
     country: País
     country_based: País basi
     country_name: Nom
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Cupó
     coupon_code: Codi de cupó
     coupon_code_already_applied:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -532,11 +532,6 @@ da:
     country: Land
     country_based: Landbaseret
     country_name: Navn
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Rabat
     coupon_code: Rabatkode
     coupon_code_already_applied: Rabatkoden er allerede anvendt på denne ordre

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -422,11 +422,6 @@ de-CH:
     country: Land
     country_based: Länderbasiert
     country_name:
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon:
     coupon_code:
     coupon_code_already_applied:

--- a/config/locales/en-AU.yml
+++ b/config/locales/en-AU.yml
@@ -466,11 +466,6 @@ en-AU:
     country: Country
     country_based: Country Based
     country_name:
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Coupon
     coupon_code: Coupon code
     coupon_code_already_applied:

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -468,11 +468,6 @@ en-GB:
     country: Country
     country_based: Country Based
     country_name: Name
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Coupon
     coupon_code: Coupon code
     coupon_code_already_applied: The coupon code has already been applied to this order

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -466,11 +466,6 @@ en-IN:
     country: Country
     country_based: Country Based
     country_name: Name
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Coupon
     coupon_code: Coupon code
     coupon_code_already_applied: The coupon code has already been applied to this order

--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -466,11 +466,6 @@ en-NZ:
     country: Country
     country_based: Country Based
     country_name:
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Coupon
     coupon_code: Coupon code
     coupon_code_already_applied:

--- a/config/locales/es-EC.yml
+++ b/config/locales/es-EC.yml
@@ -468,11 +468,6 @@ es-EC:
     country: País
     country_based: País base
     country_name: Nombre
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Cupón
     coupon_code: Código Cupón
     coupon_code_already_applied: El código del cupón ya ha sido aplicado a este pedido

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -448,11 +448,6 @@ et:
     country: Riik
     country_based: Riigipõhine
     country_name: Nimi
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon:
     coupon_code:
     coupon_code_already_applied:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -478,11 +478,6 @@ fi:
     country: Maa
     country_based: Sijaintimaa
     country_name: Nimi
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Kuponki
     coupon_code: Tarjouskoodi
     coupon_code_already_applied: Kampanjakoodi on jo käytössä tällä tilauksella

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -465,11 +465,6 @@ id:
     country: Negara
     country_based: Berdasarkan negara
     country_name: Nama Negara
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Kupon
     coupon_code: Kode kupon
     coupon_code_already_applied: Kode kupon suda diaplikasikan ke pemesanan ini sebelumnya.

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -422,11 +422,6 @@ ko:
     country: "국가"
     country_based: "국가 기반"
     country_name:
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: "쿠폰"
     coupon_code: "쿠폰 코드"
     coupon_code_already_applied:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -460,11 +460,6 @@ lv:
     country: Valsts
     country_based: Valsts
     country_name:
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Kupons
     coupon_code: Kupona kods
     coupon_code_already_applied:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -466,11 +466,6 @@ nb:
     country: Land
     country_based: Landsbasert
     country_name: Landnavn
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Rabattkupong
     coupon_code: Rabattkode
     coupon_code_already_applied: Rabattkupong er allerede brukt

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -468,11 +468,6 @@ nl:
     country: Land
     country_based: Gebaseerd op land
     country_name: Naam
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Kortingscode
     coupon_code: Kortingscode
     coupon_code_already_applied: Deze kortingscode is al toegepast op deze bestelling

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -422,11 +422,6 @@ pt:
     country: País
     country_based: Baseado em País
     country_name:
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Cupão
     coupon_code: Código do cupão de desconto
     coupon_code_already_applied:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -466,11 +466,6 @@ ro:
     country: "Țara"
     country_based: Bazat pe țară
     country_name: Nume
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Cupon
     coupon_code: Cod cupon
     coupon_code_already_applied: Codul voucher a fost deja aplicat acestei comenzi

--- a/config/locales/sl-SI.yml
+++ b/config/locales/sl-SI.yml
@@ -422,11 +422,6 @@ sl-SI:
     country: Država
     country_based: Glede na Države
     country_name:
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Kupon
     coupon_code: Koda kupona
     coupon_code_already_applied:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -462,11 +462,6 @@ th:
     country: "ประเทศ"
     country_based: "ยีดประเทศเป็นหลัก"
     country_name: "ชื่อ"
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: "คูปอง"
     coupon_code: "หมายเลขคูปอง"
     coupon_code_already_applied: "คูปองใบนี้ได้ถูกใช้ในรายการสั่งซื้อนี้แล้ว"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -422,11 +422,6 @@ tr:
     country: "Ülke"
     country_based: "Ülke Tabanlı"
     country_name: Ad
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: Kupon
     coupon_code: Kupon kodu
     coupon_code_already_applied: Girdiğiniz kupon kodu bu siparişe önceden uygulandı

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -422,11 +422,6 @@ vi:
     country: Quốc gia
     country_based: Dựa trên quốc gia
     country_name: Tên
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon:
     coupon_code:
     coupon_code_already_applied: Mã khuyến mại đã được dùng cho đơn hàng khác

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -475,11 +475,6 @@ zh-CN:
     country: "国家"
     country_based: "根据国家"
     country_name: "名称"
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: "优惠券"
     coupon_code: "优惠券号码"
     coupon_code_already_applied: "优惠券号码已在本订单中使用"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -425,11 +425,6 @@ zh-TW:
     country: "國家"
     country_based: "依據國家"
     country_name: "名稱"
-    country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
     coupon: "促銷代碼"
     coupon_code: "促銷代碼"
     coupon_code_already_applied: "優惠代碼已經被使用在這個訂單"


### PR DESCRIPTION
The way this is used, these empty translations will break portions of the admin, because the root `country_names` key is accessed and used as a hash. This breaks the admin in certain places if you use one of these locales, because it will use nil as the name for the countries and then try to call string methods on it.
